### PR TITLE
Throw exceptions instead of redirection when record not found

### DIFF
--- a/Controller/Crud/Action/EditCrudAction.php
+++ b/Controller/Crud/Action/EditCrudAction.php
@@ -65,6 +65,7 @@ class EditCrudAction extends CrudAction {
  *
  * @param string $id
  * @return void
+ * @throws NotFoundException If record not found
  */
 	protected function _handle($id = null) {
 		if (empty($id)) {
@@ -95,8 +96,7 @@ class EditCrudAction extends CrudAction {
 			$this->_request->data = $this->_model->find($subject->findMethod, $query);
 			if (empty($this->_request->data)) {
 				$subject = $this->_crud->trigger('recordNotFound', compact('id'));
-				$this->setFlash('find.error');
-				return $this->_redirect($subject, array('action' => 'index'));
+				throw new NotFoundException('find.error');
 			}
 
 			$this->_crud->trigger('afterFind', compact('id'));

--- a/Controller/Crud/Action/ViewCrudAction.php
+++ b/Controller/Crud/Action/ViewCrudAction.php
@@ -60,6 +60,7 @@ class ViewCrudAction extends CrudAction {
  *
  * @param string $id
  * @return void
+ * @throws NotFoundException If record not found
  */
 	protected function _handle($id = null) {
 		if (empty($id)) {
@@ -81,8 +82,7 @@ class ViewCrudAction extends CrudAction {
 
 		if (empty($item)) {
 			$subject = $this->_crud->trigger('recordNotFound', compact('id'));
-			$this->setFlash('find.error');
-			return $this->_redirect($subject, array('action' => 'index'));
+			throw new NotFoundException('find.error');
 		}
 
 		$subject = $this->_crud->trigger('afterFind', compact('id', 'item'));

--- a/Controller/Crud/CrudAction.php
+++ b/Controller/Crud/CrudAction.php
@@ -345,7 +345,7 @@ abstract class CrudAction implements CakeEventListener {
  */
 	protected function _getResourceName() {
 		if (empty($this->_settings['name'])) {
-			$this->_settings['name']	= Inflector::humanize($this->_modelClass);
+			$this->_settings['name'] = Inflector::humanize($this->_modelClass);
 		}
 
 		return $this->_settings['name'];
@@ -361,6 +361,7 @@ abstract class CrudAction implements CakeEventListener {
  *
  * @param mixed $id
  * @return boolean
+ * @throws BadRequestException If id is invalid
  */
 	protected function _validateId($id) {
 		$type = $this->config('validateId');
@@ -382,9 +383,7 @@ abstract class CrudAction implements CakeEventListener {
 		}
 
 		$subject = $this->_crud->trigger('invalidId', compact('id'));
-		$this->setFlash('invalid_id.error');
-		$this->_redirect($subject, $this->_controller->referer());
-		return false;
+		throw new BadRequestException('invalid_id.error');
 	}
 
 /**

--- a/Test/Case/Controller/Component/CrudComponentTest.php
+++ b/Test/Case/Controller/Component/CrudComponentTest.php
@@ -476,7 +476,12 @@ class CrudComponentTest extends ControllerTestCase {
 
 		$this->Crud->settings['validateId'] = 'notUuid';
 		$id = 42;
-		$this->Crud->executeAction('delete', array($id));
+
+		try {
+			$this->Crud->executeAction('delete', array($id));
+		} catch (Exception $e) {
+			$this->assertTrue($e instanceof NotFoundException);
+		}
 
 		$count = $this->model->find('count');
 		$this->assertSame(3, $count);
@@ -555,7 +560,11 @@ class CrudComponentTest extends ControllerTestCase {
 		$this->Crud->settings['validateId'] = 'integer';
 		$id = 1;
 
-		$this->Crud->executeAction('delete', array($id));
+		try {
+			$this->Crud->executeAction('delete', array($id));
+		} catch (Exception $e) {
+			$this->assertTrue($e instanceof BadRequestException);
+		}
 
 		$count = $this->model->find('count', array('conditions' => array('id' => $id)));
 		$this->assertSame(1, $count);
@@ -566,9 +575,6 @@ class CrudComponentTest extends ControllerTestCase {
 
 		$index = array_search('Crud.afterDelete', $events);
 		$this->assertSame(false, $index, "There was a Crud.beforeDelete event triggered");
-
-		$index = array_search('Crud.setFlash', $events);
-		$this->assertNotSame(false, $index, "There was no Crud.afterDelete event triggered");
 	}
 
 /**
@@ -905,7 +911,12 @@ class CrudComponentTest extends ControllerTestCase {
 		$this->model->bindModel(array('belongsTo' => array('Author'), 'hasAndBelongsToMany' => array('Tag')));
 		$this->Crud->action('delete')->config('relatedModels', array('Tag'));
 
-		$this->Crud->executeAction('delete', array('1'));
+		try {
+			$this->Crud->executeAction('delete', array('1'));
+		} catch (Exception $e) {
+			$this->assertTrue($e instanceof BadRequestException);
+		}
+
 		$vars = $this->controller->viewVars;
 		$this->assertFalse(isset($vars['tags']));
 		$this->assertFalse(isset($vars['authors']));
@@ -983,7 +994,7 @@ class CrudComponentTest extends ControllerTestCase {
 		$this->Crud->action('edit')->config('relatedModels', false);
 		$this->assertEquals(array(), $this->Crud->listener('relatedModels')->models('edit'));
 
-		$this->Crud->executeAction('edit');
+		$this->Crud->executeAction('edit', array(1));
 		$vars = $this->controller->viewVars;
 		$this->assertTrue(empty($vars['tags']));
 		$this->assertTrue(empty($vars['authors']));
@@ -1218,11 +1229,14 @@ class CrudComponentTest extends ControllerTestCase {
  * @return void
  */
 	public function testCustomFindEditUnpublished() {
-		$this->controller->expects($this->once())->method('redirect');
-
 		$this->Crud->settings['validateId'] = 'integer';
 		$this->Crud->findMethod('edit', 'firstUnpublished');
-		$this->Crud->executeAction('edit', array(2));
+
+		try {
+			$this->Crud->executeAction('edit', array(2));
+		} catch (Exception $e) {
+			$this->assertTrue($e instanceof NotFoundException);
+		}
 
 		$this->assertTrue(empty($this->request->data));
 
@@ -1276,7 +1290,12 @@ class CrudComponentTest extends ControllerTestCase {
 
 		$this->Crud->settings['validateId'] = 'integer';
 		$this->Crud->findMethod('delete', 'firstUnpublished');
-		$this->Crud->executeAction('delete', array(2));
+
+		try {
+			$this->Crud->executeAction('delete', array(2));
+		} catch (Exception $e) {
+			$this->assertTrue($e instanceof NotFoundException);
+		}
 
 		$events = CakeEventManager::instance()->getLog();
 
@@ -1323,10 +1342,14 @@ class CrudComponentTest extends ControllerTestCase {
 	public function testCustomFindViewUnpublished() {
 		$this->Crud->settings['validateId'] = 'integer';
 		$this->Crud->findMethod('view', 'firstUnpublished');
-		$this->Crud->executeAction('view', array(2));
+
+		try {
+			$this->Crud->executeAction('view', array(2));
+		} catch (Exception $e) {
+			$this->assertTrue($e instanceof NotFoundException);
+		}
 
 		$events = CakeEventManager::instance()->getLog();
-
 		$index = array_search('Crud.recordNotFound', $events);
 		$this->assertNotSame(false, $index, "There was no Crud.recordNotFound event triggered");
 	}

--- a/Test/Case/Controller/Crud/Action/EditCrudActionTest.php
+++ b/Test/Case/Controller/Crud/Action/EditCrudActionTest.php
@@ -515,17 +515,11 @@ class EditCrudActionTest extends CakeTestCase {
 			->will($this->returnValue(true));
 		$Action
 			->expects($this->once())
-			->method('setFlash')
-			->with('find.error');
-		$Action
-			->expects($this->once())
-			->method('_redirect')
-			->with($CrudSubject, array('action' => 'index'));
-		$Action
-			->expects($this->once())
 			->method('_getFindMethod')
 			->with('first')
 			->will($this->returnValue('first'));
+
+		$this->setExpectedException('NotFoundException');
 
 		$Action->handle($CrudSubject);
 	}

--- a/Test/Case/Controller/Crud/Action/ViewCrudActionTest.php
+++ b/Test/Case/Controller/Crud/Action/ViewCrudActionTest.php
@@ -313,14 +313,8 @@ class ViewCrudActionTest extends CakeTestCase {
 			->method('_validateId')
 			->with(1)
 			->will($this->returnValue(true));
-		$Action
-			->expects($this->once())
-			->method('setFlash')
-			->with('find.error');
-		$Action
-			->expects($this->once())
-			->method('_redirect')
-			->with(new CrudSubject(array('item' => $data)), array('action' => 'index'));
+
+		$this->setExpectedException('NotFoundException');
 
 		$Action->handle($CrudSubject);
 	}


### PR DESCRIPTION
Refs #18 

Once @AD7six does the messages related changes the strings 'invalid.id' & 'find.error' can be wrapped in appropriate function to get the translated strings :smile: 
