### PR TITLE
allow passing priority to registered events

### DIFF
--- a/Controller/Component/CrudComponent.php
+++ b/Controller/Component/CrudComponent.php
@@ -356,9 +356,10 @@ class CrudComponent extends Component {
  *
  * @param string|array $events Name of the Crud Event you want to attach to controller
  * @param callback $callback callable method or closure to be executed on event
+ * @param array $options used to set the `priority` and `passParams` flags to the listener.
  * @return void
  */
-	public function on($events, $callback) {
+	public function on($events, $callback, $options = array()) {
 		if (!is_array($events)) {
 			$events = array($events);
 		}
@@ -368,7 +369,7 @@ class CrudComponent extends Component {
 				$event = $this->settings['eventPrefix'] . '.' . $event;
 			}
 
-			$this->_eventManager->attach($callback, $event);
+			$this->_eventManager->attach($callback, $event, $options);
 		}
 	}
 

--- a/Test/Case/Controller/Component/CrudComponentTest.php
+++ b/Test/Case/Controller/Component/CrudComponentTest.php
@@ -715,6 +715,52 @@ class CrudComponentTest extends ControllerTestCase {
 	}
 
 /**
+ * Tests on method registers an event
+ *
+ */
+	public function testOn() {
+		$this->Crud->on('event', 'fakeCallback');
+
+		$return = $this->controller->getEventManager()->listeners('Crud.event');
+
+		$expected = array(
+			array(
+				'callable' => 'fakeCallback',
+				'passParams' => false
+			)
+		);
+		$this->assertSame($expected, $return);
+	}
+
+/**
+ * tests on method registers an event with extra params
+ *
+ */
+	public function testOnWithPriPriorityy() {
+		$this->Crud->on('event', 'fakeCallback');
+		$this->Crud->on('event', 'fakeHighPriority', array('priority' => 1));
+		$this->Crud->on('event', 'fakeLowPriority', array('priority' => 99999));
+
+		$return = $this->controller->getEventManager()->listeners('Crud.event');
+
+		$expected = array(
+			array(
+				'callable' => 'fakeHighPriority',
+				'passParams' => false
+			),
+			array(
+				'callable' => 'fakeCallback',
+				'passParams' => false
+			),
+			array(
+				'callable' => 'fakeLowPriority',
+				'passParams' => false
+			)
+		);
+		$this->assertSame($expected, $return);
+	}
+
+/**
  * Tests on method for beforePaginateEvent
  *
  * @expectedException CakeException


### PR DESCRIPTION
make it possible to define the priority when registering an event callback
