### PR TITLE
Make ScaffoldListener list all associations.

### DIFF
--- a/Controller/Crud/Listener/ScaffoldListener.php
+++ b/Controller/Crud/Listener/ScaffoldListener.php
@@ -126,11 +126,12 @@ class ScaffoldListener extends CrudListener {
  */
 	protected function _associations(Model $model) {
 		$associations = array();
-		$keys = array('belongsTo', 'hasOne', 'hasMany', 'hasAndBelongsToMany');
 
 		$associated = $model->getAssociated();
 		foreach ($associated as $assocKey => $type) {
-			$associations[$type] = array();
+			if (!isset($associations[$type])) {
+				$associations[$type] = array();
+			}
 
 			$assocDataAll = $model->$type;
 

--- a/Test/Case/Controller/Crud/Listener/ScaffoldListenerTest.php
+++ b/Test/Case/Controller/Crud/Listener/ScaffoldListenerTest.php
@@ -230,6 +230,13 @@ class ScaffoldListenerTest extends CakeTestCase {
 							'foreignKey' => 'user_id',
 							'plugin' => null,
 							'controller' => 'users'
+						),
+						'Article' => array(
+							'primaryKey' => 'id',
+							'displayField' => 'title',
+							'foreignKey' => 'article_id',
+							'plugin' => null,
+							'controller' => 'articles'
 						)
 					),
 					'hasOne' => array(


### PR DESCRIPTION
Reinitialization of an array in ScaffoldListener::_associations causes only one Association of each type to be returned: $type can assume the same value several times.

This commit fixes the bug and one associated Unittest. Note that Comment (core.comment)
has two belongsTo associations: User and Article.
