### PR TITLE
Automatically mapResources() for all controllers

### DIFF
--- a/Controller/Crud/Listener/ApiListener.php
+++ b/Controller/Crud/Listener/ApiListener.php
@@ -278,17 +278,15 @@ class ApiListener extends CrudListener {
  * @return void
  */
 	public static function mapResources($plugin = null){
-
-		if (empty($plugin)){
-			$key = 'Controller';
-		}else{
+		$key = 'Controller';
+		if ($plugin) {
 			$key = $plugin . '.Controller';
 		}
 
 		$controllers = array();
 		foreach (App::objects($key) as $controller) {
 			if ($controller !== $plugin . 'AppController') {
-				if (isset($plugin)){
+				if ($plugin) {
 					$controller = $plugin . '.' . $controller;
 				}
 				array_push($controllers, str_replace('Controller', '', $controller));


### PR DESCRIPTION
I think it would be nice if the Crud API provided a method to easily enable REST resource routes for all controllers in the application. This way the dev could make all /controller/view/123.json resources available as /controller/123.json with little to no effort.

Jippi suggested to make this dev-optional so I added this to my /app/Config/routes.php:

```
App::uses('ApiListener', 'Crud.Controller/Crud/Listener');

ApiListener::mapResources();
Router::setExtensions(array('json', 'xml'));
Router::parseExtensions();
```

Please note that:
- this is my first PR ever
- I am not sure this is even the right approach
- I honestly have no idea how to unit test this

So... please regard this as a HTH and feel free to provide me with any pointers to get this to pass.
