### PR TITLE
Correcting mapResources() usage instruction in docblock

### DIFF
--- a/Controller/Crud/Listener/ApiListener.php
+++ b/Controller/Crud/Listener/ApiListener.php
@@ -266,7 +266,7 @@ class ApiListener extends CrudListener {
  * If called with a valid plugin name all controllers in that plugin will be mapped.
  * If combined both controllers from the application and the plugin(s) will be mapped.
  *
- * This function needs to be called from your application's /Config/bootstrap.php:
+ * This function needs to be called from your application's /Config/routes.php:
  *     App::uses('ApiListener', 'Crud.Controller/Crud/Listener');
  *
  *     ApiListener::mapResources();


### PR DESCRIPTION
Just noticed this incorrect instruction.
