### PR TITLE
Implement a Crud.startup event

### DIFF
--- a/Controller/Component/CrudComponent.php
+++ b/Controller/Component/CrudComponent.php
@@ -157,16 +157,25 @@ class CrudComponent extends Component {
 	}
 
 /**
+ * Called after the Controller::beforeFilter() and before the controller action
+ *
+ * @param Controller $controller Controller with components to startup
+ * @return void
+ */
+	public function startup(Controller $controller) {
+		$this->_loadListeners();
+		$this->trigger('startup');
+	}
+
+/**
  * Initialize action
  *
  * @param string $controllerAction Override the controller action to execute as
  */
 	public function initAction($controllerAction = null) {
 		$this->_action = $controllerAction ?: $this->_action;
-
-		$this->_setModelProperties();
 		$this->_loadListeners();
-		$this->trigger('init');
+		$this->trigger('initialize');
 	}
 
 /**

--- a/Controller/Crud/Action/AddCrudAction.php
+++ b/Controller/Crud/Action/AddCrudAction.php
@@ -54,7 +54,7 @@ class AddCrudAction extends CrudAction {
  * Generic add action
  *
  * Triggers the following callbacks
- *	- Crud.init
+ *	- Crud.initialize
  *	- Crud.beforeSave
  *	- Crud.afterSave
  *	- Crud.beforeRender

--- a/Controller/Crud/Action/EditCrudAction.php
+++ b/Controller/Crud/Action/EditCrudAction.php
@@ -63,7 +63,7 @@ class EditCrudAction extends CrudAction {
  * Generic edit action
  *
  * Triggers the following callbacks
- *	- Crud.init
+ *	- Crud.initialize
  *	- Crud.beforeSave
  *	- Crud.afterSave
  *	- Crud.beforeFind

--- a/Controller/Crud/Action/IndexCrudAction.php
+++ b/Controller/Crud/Action/IndexCrudAction.php
@@ -79,7 +79,7 @@ class IndexCrudAction extends CrudAction {
  * Generic index action
  *
  * Triggers the following callbacks
- *	- Crud.init
+ *	- Crud.initialize
  *	- Crud.beforePaginate
  *	- Crud.afterPaginate
  *	- Crud.beforeRender

--- a/Controller/Crud/Action/ViewCrudAction.php
+++ b/Controller/Crud/Action/ViewCrudAction.php
@@ -52,7 +52,7 @@ class ViewCrudAction extends CrudAction {
  * Generic view action
  *
  * Triggers the following callbacks
- *	- Crud.init
+ *	- Crud.initialize
  *	- Crud.beforeFind
  *	- Crud.recordNotFound
  *	- Crud.afterFind

--- a/Controller/Crud/CrudAction.php
+++ b/Controller/Crud/CrudAction.php
@@ -1,7 +1,6 @@
 <?php
 
 App::uses('CrudBaseObject', 'Crud.Controller/Crud');
-App::uses('CakeEventListener', 'Event');
 App::uses('Validation', 'Utility');
 
 /**
@@ -12,13 +11,15 @@ App::uses('Validation', 'Utility');
  *
  * @copyright Christian Winther, 2013
  */
-abstract class CrudAction extends CrudBaseObject implements CakeEventListener {
+abstract class CrudAction extends CrudBaseObject {
 
 /**
- * Constructor
+ * Startup method
+ *
+ * Called when the action is loaded
  *
  * @param CrudSubject $subject
- * @param array $defaults Default settings
+ * @param array $defaults
  * @return void
  */
 	public function __construct(CrudSubject $subject, $defaults = array()) {

--- a/Controller/Crud/CrudBaseObject.php
+++ b/Controller/Crud/CrudBaseObject.php
@@ -1,4 +1,8 @@
 <?php
+
+App::uses('CakeEventListener', 'Event');
+App::uses('Hash', 'Utility');
+
 /**
  * Crud Base Class
  *
@@ -9,7 +13,7 @@
  *
  * @copyright Christian Winther, 2013
  */
-abstract class CrudBaseObject extends Object {
+abstract class CrudBaseObject extends Object implements CakeEventListener {
 
 /**
  * Container with reference to all objects
@@ -39,6 +43,16 @@ abstract class CrudBaseObject extends Object {
 		if (!empty($defaults)) {
 			$this->config($defaults);
 		}
+	}
+
+/**
+ * initialize callback
+ *
+ * @param CakeEvent $event
+ * @return void
+ */
+	public function initialize(CakeEvent $event) {
+		$this->_container = $event->subject;
 	}
 
 /**
@@ -84,6 +98,18 @@ abstract class CrudBaseObject extends Object {
 
 		$this->_settings = Hash::insert($this->_settings, $key, $value);
 		return $this;
+	}
+
+/**
+ * Returns a list of all events that will fire during the objects lifecycle.
+ * You can override this function to add you own listener callbacks
+ *
+ * @return array
+ */
+	public function implementedEvents() {
+		return array(
+			'Crud.initialize' => 'initialize'
+		);
 	}
 
 /**

--- a/Controller/Crud/CrudListener.php
+++ b/Controller/Crud/CrudListener.php
@@ -1,45 +1,36 @@
 <?php
 
 App::uses('CrudBaseObject', 'Crud.Controller/Crud');
-App::uses('CakeEventListener', 'Event');
-App::uses('Hash', 'Utility');
 
 /**
  * The Base Crud Listener
- *
- * All callbacks are defined here for good measure
- *
  *
  * Licensed under The MIT License
  * Redistributions of files must retain the above copyright notice.
  *
  * @copyright Christian Winther, 2013
  */
-abstract class CrudListener extends CrudBaseObject implements CakeEventListener {
+abstract class CrudListener extends CrudBaseObject {
 
 /**
  * Returns a list of all events that will fire in the controller during it's life cycle.
  * You can override this function to add you own listener callbacks
  *
- * - init : Called before any other method in the decorator.
- *     Just set the arguments as instance properties for easier access later
+ * - initialize : Called before Controller::beforeFilter
+ * - startup: Called after the Controller::beforeFilter() and before the Crud action is invoked
  * - recordNotFound : Called if a find() did not return any records
  * - beforePaginate : Called right before any paginate() method
  * - afterPaginate : Called right after any paginate() method
  * - invalidId : Called if the ID format validation failed
  * - setFlash : Called before any CakeSession::setFlash
- *     Subject contains the following keys you can modify:
- * 	     - message
- * 	     - element = 'default',
- * 	     - params = array()
- * 	     - key = 'flash'
  *
  * @codeCoverageIgnore
  * @return array
  */
 	public function implementedEvents() {
 		$eventMap = array(
-			'Crud.init'	=> 'init',
+			'Crud.initialize' => 'initialize',
+			'Crud.startup' => 'startup',
 
 			'Crud.beforePaginate' => 'beforePaginate',
 			'Crud.afterPaginate' => 'afterPaginate',
@@ -64,7 +55,7 @@ abstract class CrudListener extends CrudBaseObject implements CakeEventListener 
 		$events = array();
 		foreach ($eventMap as $event => $method) {
 			if (method_exists($this, $method)) {
-				$event[$event] = $method;
+				$events[$event] = $method;
 			}
 		}
 

--- a/Controller/Crud/Listener/ApiListener.php
+++ b/Controller/Crud/Listener/ApiListener.php
@@ -24,7 +24,8 @@ class ApiListener extends CrudListener {
  */
 	public function implementedEvents() {
 		return array(
-			'Crud.init' => array('callable' => 'init', 'priority' => 10),
+			'Crud.startup' => array('callable' => 'startup', 'priority' => 5),
+			'Crud.initialize' => array('callable' => 'initialize', 'priority' => 10),
 			'Crud.beforeRender' => array('callable' => 'beforeRender', 'priority' => 100),
 			'Crud.afterSave' => array('callable' => 'afterSave', 'priority' => 100),
 			'Crud.afterDelete' => array('callable' => 'afterDelete', 'priority' => 100),
@@ -33,18 +34,27 @@ class ApiListener extends CrudListener {
 	}
 
 /**
- * Init
- *
- * Called when the listener is started
+ * Called when all listeners has been loaded,
+ * and before the crud action is actually executed
  *
  * @param CakeEvent $event
  * @return void
  */
-	public function init(CakeEvent $event) {
-		// Configure a few useful CakeRequest detectors
+	public function startup(CakeEvent $event) {
 		$this->_setupDetectors();
+	}
 
-		// Don't do anything if we aren't in an API request
+/**
+ * initialize
+ *
+ * Called before the crud action is executed
+ *
+ * @param CakeEvent $event
+ * @return void
+ */
+	public function initialize(CakeEvent $event) {
+		parent::initialize($event);
+
 		if (!$this->_request()->is('api')) {
 			return;
 		}

--- a/Controller/Crud/Listener/DebugKitListener.php
+++ b/Controller/Crud/Listener/DebugKitListener.php
@@ -21,7 +21,7 @@ class DebugKitListener extends CrudListener {
  */
 	public function implementedEvents() {
 		return array(
-			'Crud.init' => array('callable' => 'init', 'priority' => 1),
+			'Crud.initialize' => array('callable' => 'initialize', 'priority' => 1),
 			'Crud.beforeRender' => array('callable' => 'beforeRender', 'priority' => 5000),
 
 			'Crud.beforePaginate' => array('callable' => 'beforePaginate', 'priority' => 1),
@@ -44,8 +44,10 @@ class DebugKitListener extends CrudListener {
  * @param CakeEvent $event
  * @return void
  */
-	public function init(CakeEvent $event) {
-		DebugTimer::start('Event: Crud.init');
+	public function initialize(CakeEvent $event) {
+		parent::initialize($event);
+
+		DebugTimer::start('Event: Crud.initialize');
 	}
 
 /**
@@ -55,7 +57,7 @@ class DebugKitListener extends CrudListener {
  * @return void
  */
 	public function beforeRender(CakeEvent $event) {
-		DebugTimer::stop('Event: Crud.init');
+		DebugTimer::stop('Event: Crud.initialize');
 	}
 
 /**
@@ -69,7 +71,7 @@ class DebugKitListener extends CrudListener {
 	}
 
 /**
- * Stop timer for Crud.init
+ * Stop timer for Crud.Paginate
  *
  * @param CakeEvent $event
  * @return void

--- a/Controller/Crud/Listener/RelatedModelsListener.php
+++ b/Controller/Crud/Listener/RelatedModelsListener.php
@@ -43,15 +43,6 @@ class RelatedModelsListener extends CrudListener {
 	}
 
 /**
- * List of events implemented by this class
- *
- * @return array
- */
-	public function implementedEvents() {
-		return array('Crud.beforeRender' => 'beforeRender');
-	}
-
-/**
  * Fetches related models' list and sets them to a variable for the view
  *
  * @param CakeEvent

--- a/Test/Case/Controller/Crud/Listener/ApiListenerTest.php
+++ b/Test/Case/Controller/Crud/Listener/ApiListenerTest.php
@@ -34,9 +34,12 @@ class ApiListenerTest extends CakeTestCase {
 		$subject->request = $this->getMock('CakeRequest', array('accepts'));
 		$subject->response = $this->getMock('CakeResponse');
 		$apiListener = new ApiListener($subject);
-		$event = new CakeEvent('Crud.init', $subject);
 
-		$apiListener->init($event);
+		$event = new CakeEvent('Crud.startup', $subject);
+		$apiListener->startup($event);
+
+		$event = new CakeEvent('Crud.init', $subject);
+		$apiListener->initialize($event);
 
 		//Testing detectors
 		$subject->request->expects($this->at(0))
@@ -118,7 +121,7 @@ class ApiListenerTest extends CakeTestCase {
 			->method('is')
 			->with($method)
 			->will($this->returnValue(true));
-		$apiListener->init($event);
+		$apiListener->initialize($event);
 		$this->assertEquals('Crud.CrudExceptionRenderer', Configure::read('Exception.renderer'));
 		$this->assertTrue(class_exists('CrudExceptionRenderer'));
 	}
@@ -148,7 +151,7 @@ class ApiListenerTest extends CakeTestCase {
 			->method('is')
 			->with($method)
 			->will($this->returnValue(false));
-		$apiListener->init($event);
+		$apiListener->initialize($event);
 	}
 
 /**
@@ -500,7 +503,8 @@ class ApiListenerTest extends CakeTestCase {
 		$subject = $this->getMock('CrudSubject');
 		$apiListener = new ApiListener($subject);
 		$expected = array(
-			'Crud.init' => array('callable' => 'init', 'priority' => 10),
+			'Crud.initialize' => array('callable' => 'initialize', 'priority' => 10),
+			'Crud.startup' => array('callable' => 'startup', 'priority' => 5),
 			'Crud.beforeRender' => array('callable' => 'beforeRender', 'priority' => 100),
 			'Crud.afterSave' => array('callable' => 'afterSave', 'priority' => 100),
 			'Crud.afterDelete' => array('callable' => 'afterDelete', 'priority' => 100),


### PR DESCRIPTION
It maps directly to Component::startup()

Renamed `Crud.init` to `Crud.initialize` to be more aligned with the terms used
in Components

The flow of events is now:
- __constructor (called in CrudComponent::_loadListener)
- startup (called in CrudComponent::initialize)
- initialize (called in CrudComponent::initAction)
- \- the normal flow as we know it -

Obviously due to the flow of events, it's possible that properties changes between startup() and initialize()
and thus the `_container` property will be replaced in `Crud.initialize` so `_model` and other properties that
may have changed between startup() and initialize() is reflected internally
