### PR TITLE
remove embeded edit === put and add === post assumption

### DIFF
--- a/Controller/Crud/Action/AddCrudAction.php
+++ b/Controller/Crud/Action/AddCrudAction.php
@@ -68,7 +68,7 @@ class AddCrudAction extends CrudAction {
 		$request = $this->_request();
 		$model = $this->_model();
 
-		if (!$request->is('post')) {
+		if ($request->is('get')) {
 			$model->create();
 			$request->data = $model->data;
 			$this->_trigger('beforeRender', array('success' => false));

--- a/Controller/Crud/Action/EditCrudAction.php
+++ b/Controller/Crud/Action/EditCrudAction.php
@@ -86,17 +86,7 @@ class EditCrudAction extends CrudAction {
 		$request = $this->_request();
 		$model = $this->_model();
 
-		if ($request->is('put')) {
-			$this->_trigger('beforeSave', compact('id'));
-			if ($model->saveAll($request->data, $this->saveOptions())) {
-				$this->setFlash('success');
-				$subject = $this->_trigger('afterSave', array('id' => $id, 'success' => true, 'created' => false));
-				return $this->_redirect($subject, array('action' => 'index'));
-			} else {
-				$this->setFlash('error');
-				$this->_trigger('afterSave', array('id' => $id, 'success' => false, 'created' => false));
-			}
-		} else {
+		if ($request->is('get')) {
 			$query = array();
 			$query['conditions'] = array($model->escapeField() => $id);
 			$findMethod = $this->_getFindMethod('first');
@@ -115,6 +105,16 @@ class EditCrudAction extends CrudAction {
 			$item = $request->data;
 			$subject = $this->_trigger('afterFind', compact('id', 'item'));
 			$request->data = Hash::merge($request->data, $model->data, $subject->item);
+		} else {
+			$this->_trigger('beforeSave', compact('id'));
+			if ($model->saveAll($request->data, $this->saveOptions())) {
+				$this->setFlash('success');
+				$subject = $this->_trigger('afterSave', array('id' => $id, 'success' => true, 'created' => false));
+				return $this->_redirect($subject, array('action' => 'index'));
+			} else {
+				$this->setFlash('error');
+				$this->_trigger('afterSave', array('id' => $id, 'success' => false, 'created' => false));
+			}
 		}
 
 		$this->_trigger('beforeRender');

--- a/Test/Case/Controller/Crud/Action/AddCrudActionTest.php
+++ b/Test/Case/Controller/Crud/Action/AddCrudActionTest.php
@@ -24,8 +24,8 @@ class AddCrudActionTest extends CrudTestCase {
 		$Request
 			->expects($this->once())
 			->method('is')
-			->with('post')
-			->will($this->returnValue(false));
+			->with('get')
+			->will($this->returnValue(true));
 
 		$Model = $this->getMock('Model', array('create'));
 		$Model
@@ -69,8 +69,8 @@ class AddCrudActionTest extends CrudTestCase {
 		$Request
 			->expects($this->once())
 			->method('is')
-			->with('post')
-			->will($this->returnValue(true));
+			->with('get')
+			->will($this->returnValue(false));
 
 		$Model = $this->getMock('Model', array('saveAll'));
 		$Model
@@ -134,8 +134,8 @@ class AddCrudActionTest extends CrudTestCase {
 		$Request
 			->expects($this->once())
 			->method('is')
-			->with('post')
-			->will($this->returnValue(true));
+			->with('get')
+			->will($this->returnValue(false));
 
 		$Model = $this->getMock('Model', array('saveAll'));
 		$Model->data = array('model' => true);

--- a/Test/Case/Controller/Crud/Action/EditCrudActionTest.php
+++ b/Test/Case/Controller/Crud/Action/EditCrudActionTest.php
@@ -28,8 +28,8 @@ class EditCrudActionTest extends CrudTestCase {
     $Request
       ->expects($this->once())
       ->method('is')
-      ->with('put')
-      ->will($this->returnValue(false));
+      ->with('get')
+      ->will($this->returnValue(true));
 
     $Model = $this
       ->getMock('Model', array('create', 'find', 'escapeField'));
@@ -135,8 +135,8 @@ class EditCrudActionTest extends CrudTestCase {
     $Request
       ->expects($this->once())
       ->method('is')
-      ->with('put')
-      ->will($this->returnValue(true));
+      ->with('get')
+      ->will($this->returnValue(false));
     $Action
       ->expects($this->at($i++))
       ->method('_trigger')
@@ -220,8 +220,8 @@ class EditCrudActionTest extends CrudTestCase {
     $Request
       ->expects($this->once())
       ->method('is')
-      ->with('put')
-      ->will($this->returnValue(true));
+      ->with('get')
+      ->will($this->returnValue(false));
     $Action
       ->expects($this->at($i++))
       ->method('_trigger')
@@ -308,8 +308,8 @@ class EditCrudActionTest extends CrudTestCase {
     $Request
       ->expects($this->once())
       ->method('is')
-      ->with('put')
-      ->will($this->returnValue(false));
+      ->with('get')
+      ->will($this->returnValue(true));
     $Model
       ->expects($this->once())
       ->method('escapeField')
@@ -388,8 +388,8 @@ class EditCrudActionTest extends CrudTestCase {
     $Request
       ->expects($this->once())
       ->method('is')
-      ->with('put')
-      ->will($this->returnValue(false));
+      ->with('get')
+      ->will($this->returnValue(true));
     $Model
       ->expects($this->once())
       ->method('escapeField')


### PR DESCRIPTION
All actions have request methods defined in their config - the config is
modifyable, but it's not possible to change the "main" requeset method as the action classes themselves check if they are by POST/PUT.

Two common cases where the requestMethods would need to be modified, and conflict with the Crud plugin's definition:

PUT Add - When createing records with predefined ids
POST Edit - File uploads via PUT are more difficult, and API requests via PUT require "custom" handling to populate `$request->data` also.
