### PR TITLE
Update scope and filterArg retrieval

### DIFF
--- a/Controller/Crud/Listener/SearchListener.php
+++ b/Controller/Crud/Listener/SearchListener.php
@@ -74,10 +74,19 @@ class SearchListener extends CrudListener {
 		$query = $request->query;
 		if (!empty($request->query['_scope'])) {
 			$config = $this->config('scope.' . $request->query['_scope']);
-			$query = $config['query'];
+			if (empty($config)) {
+				$config = $this->_action()->config('scope.' . $request->query['_scope']);
+			}
+
+			$query = Hash::get((array)$config, 'query');
 
 			if (!empty($config['filter'])) {
 				$this->_setFilterArgs($model, $config['filter']);
+			}
+		} else {
+			$filterArgs = $this->_action()->config('scope');
+			if (!empty($filterArgs)) {
+				$this->_setFilterArgs($model, (array)$filterArgs);
 			}
 		}
 

--- a/Test/Case/Controller/Crud/Listener/SearchListenerTest.php
+++ b/Test/Case/Controller/Crud/Listener/SearchListenerTest.php
@@ -94,11 +94,19 @@ class SearchListenerTest extends CakeTestCase {
  * @return void
  */
 	public function testBeforePaginate() {
+    $Action = $this->getMock('stdClass', array('config'));
+    $Crud = $this->getMock('stdClass', array('action'));
+    $Crud
+      ->expects($this->once())
+      ->method('action')
+      ->will($this->returnValue($Action));
+
 		$Model = new Model();
 		$Request = new CakeRequest();
 		$Controller = new Controller();
 		$CrudSubject = new CrudSubject(array(
 			'request' => $Request,
+			'crud' => $Crud,
 			'controller' => $Controller,
 			'model' => $Model
 		));
@@ -149,12 +157,20 @@ class SearchListenerTest extends CakeTestCase {
  * @return void
  */
 	public function testBeforePaginateWithModelFilterArgs() {
+    $Action = $this->getMock('stdClass', array('config'));
+    $Crud = $this->getMock('stdClass', array('action'));
+    $Crud
+      ->expects($this->once())
+      ->method('action')
+      ->will($this->returnValue($Action));
+
 		$Model = new Model();
 		$Model->filterArgs = array('sample' => 'test');
 		$Request = new CakeRequest();
 		$Controller = new Controller();
 		$CrudSubject = new CrudSubject(array(
 			'request' => $Request,
+			'crud' => $Crud,
 			'controller' => $Controller,
 			'model' => $Model
 		));
@@ -205,6 +221,13 @@ class SearchListenerTest extends CakeTestCase {
  * @return void
  */
 	public function testBeforePaginateWithUndefinedQueryScope() {
+    $Action = $this->getMock('stdClass', array('config'));
+    $Crud = $this->getMock('stdClass', array('action'));
+    $Crud
+      ->expects($this->once())
+      ->method('action')
+      ->will($this->returnValue($Action));
+
 		$Model = new Model();
 		$Model->filterArgs = array('sample' => 'test');
 		$Request = new CakeRequest();
@@ -212,6 +235,7 @@ class SearchListenerTest extends CakeTestCase {
 		$Controller = new Controller();
 		$CrudSubject = new CrudSubject(array(
 			'request' => $Request,
+			'crud' => $Crud,
 			'controller' => $Controller,
 			'model' => $Model
 		));
@@ -376,12 +400,20 @@ class SearchListenerTest extends CakeTestCase {
  * @return void
  */
 	public function testCheckRequiredPlugins() {
+    $Action = $this->getMock('stdClass', array('config'));
+    $Crud = $this->getMock('stdClass', array('action'));
+    $Crud
+      ->expects($this->once())
+      ->method('action')
+      ->will($this->returnValue($Action));
+
 		$Model = new Model();
 		$Model->filterArgs = array('sample' => 'test');
 		$Request = new CakeRequest();
 		$Controller = new Controller();
 		$CrudSubject = new CrudSubject(array(
 			'request' => $Request,
+			'crud' => $Crud,
 			'controller' => $Controller,
 			'model' => $Model
 		));


### PR DESCRIPTION
- Added fallback to action-level scopes when controller level is unavailable
- Use Hash::get() to retrieve `query` index, which may not always be available
- If no `_scope` is set, fallback to action-level `scope` for `$filterArgs`
