### PR TITLE
Rename Crud.initialize to Crud.beforeHandle and fix search listener HTTP POST

### DIFF
--- a/Console/Command/TranslationsShell.php
+++ b/Console/Command/TranslationsShell.php
@@ -239,7 +239,8 @@ class TranslationsShell extends AppShell {
  */
 	protected function _processAction($actionName, $Controller) {
 		try {
-			$Controller->Crud->initAction($actionName);
+			$Controller->Crud->action($actionName);
+			$Controller->Crud->trigger('beforeHandle');
 		} catch(Exception $e) {
 			return;
 		}

--- a/Controller/Component/CrudComponent.php
+++ b/Controller/Component/CrudComponent.php
@@ -176,17 +176,6 @@ class CrudComponent extends Component {
 	}
 
 /**
- * Initialize action
- *
- * @param string $controllerAction Override the controller action to execute as
- */
-	public function initAction($controllerAction = null) {
-		$this->_action = $controllerAction ?: $this->_action;
-		$this->_loadListeners();
-		$this->trigger('initialize');
-	}
-
-/**
  * Execute a Crud action
  *
  * @param string $controllerAction Override the controller action to execute as
@@ -195,14 +184,19 @@ class CrudComponent extends Component {
  * @throws CakeException If an action is not mapped
  */
 	public function executeAction($controllerAction = null, $args = array()) {
-		$this->initAction($controllerAction);
+		$this->_loadListeners();
+
+		$this->_action = $controllerAction ?: $this->_action;
+
 		$view = $action = $this->_action;
 		if (empty($args)) {
 			$args = $this->_request->params['pass'];
 		}
 
 		try {
-			$response = $this->action($action)->handle($this->getSubject(compact('args')));
+			$subject = $this->trigger('beforeHandle', compact('args', 'action'));
+
+			$response = $this->action($subject->action)->handle($subject);
 			if ($response instanceof CakeResponse) {
 				return $response;
 			}

--- a/Controller/Crud/CrudAction.php
+++ b/Controller/Crud/CrudAction.php
@@ -37,7 +37,6 @@ abstract class CrudAction extends CrudBaseObject {
  */
 	public function __construct(CrudSubject $subject, $defaults = array()) {
 		parent::__construct($subject, $defaults);
-
 		$this->_settings['action'] = $subject->action;
 	}
 

--- a/Controller/Crud/CrudBaseObject.php
+++ b/Controller/Crud/CrudBaseObject.php
@@ -49,7 +49,7 @@ abstract class CrudBaseObject extends Object implements CakeEventListener {
  * @param CakeEvent $event
  * @return void
  */
-	public function initialize(CakeEvent $event) {
+	public function beforeHandle(CakeEvent $event) {
 		$this->_container = $event->subject;
 	}
 

--- a/Controller/Crud/CrudListener.php
+++ b/Controller/Crud/CrudListener.php
@@ -14,7 +14,7 @@ abstract class CrudListener extends CrudBaseObject {
  * Returns a list of all events that will fire in the controller during it's life cycle.
  * You can override this function to add you own listener callbacks
  *
- * - initialize : Called before Controller::beforeFilter
+ * - beforeHandle : Called before CrudAction is executed
  * - startup: Called after the Controller::beforeFilter() and before the Crud action is invoked
  * - recordNotFound : Called if a find() did not return any records
  * - beforePaginate : Called right before any paginate() method
@@ -27,7 +27,7 @@ abstract class CrudListener extends CrudBaseObject {
  */
 	public function implementedEvents() {
 		$eventMap = array(
-			'Crud.initialize' => 'initialize',
+			'Crud.beforeHandle' => 'beforeHandle',
 			'Crud.startup' => 'startup',
 
 			'Crud.beforePaginate' => 'beforePaginate',

--- a/Controller/Crud/Listener/ApiListener.php
+++ b/Controller/Crud/Listener/ApiListener.php
@@ -39,7 +39,7 @@ class ApiListener extends CrudListener {
 	public function implementedEvents() {
 		return array(
 			'Crud.startup' => array('callable' => 'startup', 'priority' => 5),
-			'Crud.initialize' => array('callable' => 'initialize', 'priority' => 10),
+			'Crud.beforeHandle' => array('callable' => 'beforeHandle', 'priority' => 10),
 			'Crud.beforeRender' => array('callable' => 'beforeRender', 'priority' => 100),
 			'Crud.afterSave' => array('callable' => 'afterSave', 'priority' => 100),
 			'Crud.afterDelete' => array('callable' => 'afterDelete', 'priority' => 100),
@@ -59,15 +59,15 @@ class ApiListener extends CrudListener {
 	}
 
 /**
- * initialize
+ * beforeHandle
  *
  * Called before the crud action is executed
  *
  * @param CakeEvent $event
  * @return void
  */
-	public function initialize(CakeEvent $event) {
-		parent::initialize($event);
+	public function beforeHandle(CakeEvent $event) {
+		parent::beforeHandle($event);
 
 		if (!$this->_request()->is('api')) {
 			return;

--- a/Controller/Crud/Listener/DebugKitListener.php
+++ b/Controller/Crud/Listener/DebugKitListener.php
@@ -20,8 +20,7 @@ class DebugKitListener extends CrudListener {
 	public function implementedEvents() {
 		return array(
 			'Crud.startup' => array('callable' => 'startup'),
-
-			'Crud.initialize' => array('callable' => 'initialize', 'priority' => 1),
+			'Crud.beforeHandle' => array('callable' => 'beforeHandle', 'priority' => 1),
 			'Crud.beforeRender' => array('callable' => 'beforeRender', 'priority' => 5000),
 
 			'Crud.beforePaginate' => array('callable' => 'beforePaginate', 'priority' => 1),
@@ -39,7 +38,7 @@ class DebugKitListener extends CrudListener {
 	}
 
 /**
- * Start timer for Crud.init
+ * Start timer for Crud.beforeHandle
  *
  * And enable event logging. The Crud.startup event will not itself have been logged
  *
@@ -59,10 +58,10 @@ class DebugKitListener extends CrudListener {
  * @param CakeEvent $event
  * @return void
  */
-	public function initialize(CakeEvent $event) {
-		parent::initialize($event);
+	public function beforeHandle(CakeEvent $event) {
+		parent::beforeHandle($event);
 
-		DebugTimer::start('Event: Crud.initialize');
+		DebugTimer::start('Event: Crud.beforeHandle');
 	}
 
 /**
@@ -72,7 +71,7 @@ class DebugKitListener extends CrudListener {
  * @return void
  */
 	public function beforeRender(CakeEvent $event) {
-		DebugTimer::stop('Event: Crud.initialize');
+		DebugTimer::stop('Event: Crud.beforeHandle');
 	}
 
 /**

--- a/Controller/Crud/Listener/SearchListener.php
+++ b/Controller/Crud/Listener/SearchListener.php
@@ -37,8 +37,28 @@ class SearchListener extends CrudListener {
  */
 	public function implementedEvents() {
 		return array(
+			'Crud.beforeHandle' => array('callable' => 'beforeHandle', 'priority' => 50),
 			'Crud.beforePaginate' => array('callable' => 'beforePaginate', 'priority' => 50)
 		);
+	}
+
+	public function beforeHandle(CakeEvent $event) {
+		$request = $this->_request();
+		$model = $this->_model();
+
+		if (!array_key_exists($model->alias, $request->data)) {
+			return;
+		}
+
+		if (!array_key_exists('_search', $request->data($model->alias))) {
+			return;
+		}
+
+		$controller = $this->_controller();
+
+		$this->_ensureComponent($controller);
+		$this->_ensureBehavior($model);
+		$this->_commonProcess($controller, $model->name);
 	}
 
 /**

--- a/Test/Case/Controller/Component/CrudComponentTest.php
+++ b/Test/Case/Controller/Component/CrudComponentTest.php
@@ -1051,7 +1051,7 @@ class CrudComponentTest extends ControllerTestCase {
 		$this->Crud = new CrudComponent($this->Collection, array('actions' => array('index')));
 		$this->Crud->initialize($controller);
 		$this->controller->Crud = $this->Crud;
-		$this->Crud->initAction('index');
+		$this->Crud->action('index');
 		$subject = $this->Crud->trigger('sample');
 
 		$this->assertNull($subject->model);

--- a/Test/Case/Controller/Crud/Listener/ApiListenerTest.php
+++ b/Test/Case/Controller/Crud/Listener/ApiListenerTest.php
@@ -39,8 +39,8 @@ class ApiListenerTest extends CakeTestCase {
 		$event = new CakeEvent('Crud.startup', $subject);
 		$apiListener->startup($event);
 
-		$event = new CakeEvent('Crud.init', $subject);
-		$apiListener->initialize($event);
+		$event = new CakeEvent('Crud.beforeHandle', $subject);
+		$apiListener->beforeHandle($event);
 
 		//Testing detectors
 		$subject->request->expects($this->at(0))
@@ -81,10 +81,10 @@ class ApiListenerTest extends CakeTestCase {
 /**
  * Tests initialization in API request
  *
- * @covers ApiListener::initialize
+ * @covers ApiListener::beforeHandle
  * @return void
  */
-	public function testInitialize() {
+	public function testBeforeHandle() {
 		$request = $this->getMock('CakeRequest', array('is'));
 		$request->expects($this->once())->method('is')->with('api')->will($this->returnValue(true));
 
@@ -92,16 +92,16 @@ class ApiListenerTest extends CakeTestCase {
 		$listener = $this->getMock('ApiListener', $mockMethods, array(new CrudSubject()));
 		$listener->expects($this->once())->method('_request')->with()->will($this->returnValue($request));
 		$listener->expects($this->once())->method('registerExceptionHandler')->with();
-		$listener->initialize(new CakeEvent('Crud.init'));
+		$listener->beforeHandle(new CakeEvent('Crud.beforeHandle'));
 	}
 
 /**
  * Tests initialization in non-API request
  *
- * @covers ApiListener::initialize
+ * @covers ApiListener::beforeHandle
  * @return void
  */
-	public function testInitializeNotRequest() {
+	public function testBeforeHandleNotRequest() {
 		$request = $this->getMock('CakeRequest', array('is'));
 		$request->expects($this->once())->method('is')->with('api')->will($this->returnValue(false));
 
@@ -109,7 +109,7 @@ class ApiListenerTest extends CakeTestCase {
 		$listener = $this->getMock('ApiListener', $mockMethods, array(new CrudSubject()));
 		$listener->expects($this->once())->method('_request')->with()->will($this->returnValue($request));
 		$listener->expects($this->never())->method('registerExceptionHandler');
-		$listener->initialize(new CakeEvent('Crud.init'));
+		$listener->beforeHandle(new CakeEvent('Crud.init'));
 	}
 
 /**
@@ -473,7 +473,7 @@ class ApiListenerTest extends CakeTestCase {
 		$subject = $this->getMock('CrudSubject');
 		$apiListener = new ApiListener($subject);
 		$expected = array(
-			'Crud.initialize' => array('callable' => 'initialize', 'priority' => 10),
+			'Crud.beforeHandle' => array('callable' => 'beforeHandle', 'priority' => 10),
 			'Crud.startup' => array('callable' => 'startup', 'priority' => 5),
 			'Crud.beforeRender' => array('callable' => 'beforeRender', 'priority' => 100),
 			'Crud.afterSave' => array('callable' => 'afterSave', 'priority' => 100),

--- a/Test/Case/Controller/Crud/Listener/SearchListenerTest.php
+++ b/Test/Case/Controller/Crud/Listener/SearchListenerTest.php
@@ -39,7 +39,10 @@ class SearchListenerTest extends CakeTestCase {
 	public function testImplementedEvents() {
 		$Instance = new SearchListener(new CrudSubject());
 		$result = $Instance->implementedEvents();
-		$expected = array('Crud.beforePaginate' => array('callable' => 'beforePaginate', 'priority' => 50));
+		$expected = array(
+			'Crud.beforeHandle' => array('callable' => 'beforeHandle', 'priority' => 50),
+			'Crud.beforePaginate' => array('callable' => 'beforePaginate', 'priority' => 50)
+		);
 		$this->assertEqual($result, $expected);
 	}
 


### PR DESCRIPTION
Search forms expects to have a '_search' key present for the automatic redirect to work
