### PR TITLE
Implementing useModel() to easily set the model class to use for the action

### DIFF
--- a/Controller/Component/CrudComponent.php
+++ b/Controller/Component/CrudComponent.php
@@ -593,8 +593,8 @@ class CrudComponent extends Component {
  */
 	public function useModel($modelName) {
 		$this->_controller->loadModel($modelName);
-		list(, $modelName) = pluginSplit($modelClass);
-		$this->_model = $this->_controller->{$modelClass};
+		list(, $modelName) = pluginSplit($modelName);
+		$this->_model = $this->_controller->{$modelName};
 		$this->_modelName = $this->_model->name;
 	}
 

--- a/Test/Case/Controller/Component/CrudComponentTest.php
+++ b/Test/Case/Controller/Component/CrudComponentTest.php
@@ -1111,11 +1111,11 @@ class CrudComponentTest extends ControllerTestCase {
 	public function testUseModel() {
 		$controller = new Controller(new CakeRequest());
 		$this->Crud = new CrudComponent($this->Collection, array('actions' => array('index')));
-		$class = $this->getMockClass('Model');
 		$this->Crud->initialize($controller);
-		$this->Crud->useModel($class);
 		$this->controller->Crud = $this->Crud;
-		$this->Crud->initAction('index');
+		$class = $this->getMockClass('Model');
+		$this->Crud->useModel($class);
+		$this->Crud->action('index');
 		$subject = $this->Crud->trigger('sample');
 
 		$this->assertInstanceOf($class, $subject->model);


### PR DESCRIPTION
This allows to select another model for executing the action.
Removes undocumented modelMap that was a legacy feature from the old version of this plugin
