### PR TITLE
validateId can be false

### DIFF
--- a/Controller/Crud/CrudAction.php
+++ b/Controller/Crud/CrudAction.php
@@ -328,7 +328,7 @@ abstract class CrudAction extends CrudBaseObject {
 	protected function _validateId($id) {
 		$type = $this->config('validateId');
 
-		if (empty($type)) {
+		if (is_null($type)) {
 			$type = $this->detectPrimaryKeyFieldType();
 		}
 

--- a/Test/Case/Controller/Crud/CrudActionTest.php
+++ b/Test/Case/Controller/Crud/CrudActionTest.php
@@ -877,4 +877,33 @@ class CrudActionTest extends CrudTestCase {
 		$Action->handle(new CrudSubject(array('args' => array())));
 	}
 
+/**
+ * testValidateIdFalse
+ *
+ * If validateId is false - don't do squat
+ *
+ * @return void
+ */
+	public function testValidateIdFalse() {
+		$Action = $this
+			->getMockBuilder('CrudAction')
+			->disableOriginalConstructor()
+			->setMethods(array('config', 'detectPrimaryKeyFieldType'))
+			->getMock();
+
+		$Action
+			->expects($this->once())
+			->method('config')
+			->with('validateId')
+			->will($this->returnValue(false));
+		$Action
+			->expects($this->never())
+			->method('detectPrimaryKeyFieldType');
+
+		$this->setReflectionClassInstance($Action);
+		$return = $this->callProtectedMethod('_validateId', array('some id'), $Action);
+
+		$this->assertTrue($return, 'If validateId is false the check should be skipped');
+	}
+
 }


### PR DESCRIPTION
And if set to false, there should be no guess-the-type performed, only
aborting the check
