### PR TITLE
if requesting a find count - perform a find count

### DIFF
--- a/Controller/Crud/Action/EditCrudAction.php
+++ b/Controller/Crud/Action/EditCrudAction.php
@@ -152,16 +152,18 @@ class EditCrudAction extends CrudAction {
  * Find a record from the ID
  *
  * @param string $id
- * @param $findMethod
+ * @param string $findMethod
  * @return array
  */
-	protected function _findRecord($id, $findMethod = 'first') {
+	protected function _findRecord($id, $findMethod = null) {
 		$model = $this->_model();
 
 		$query = array();
 		$query['conditions'] = array($model->escapeField() => $id);
 
-		$findMethod = $this->_getFindMethod($findMethod);
+		if (!$findMethod) {
+			$findMethod = $this->_getFindMethod($findMethod);
+		}
 		$subject = $this->_trigger('beforeFind', compact('query', 'findMethod'));
 
 		return $model->find($subject->findMethod, $subject->query);

--- a/Test/Case/Controller/Crud/Action/EditCrudActionTest.php
+++ b/Test/Case/Controller/Crud/Action/EditCrudActionTest.php
@@ -63,7 +63,6 @@ class EditCrudActionTest extends CrudTestCase {
 		$Action
 			->expects($this->at($i++))
 			->method('_getFindMethod')
-			->with('first')
 			->will($this->returnValue('first'));
 		$Action
 			->expects($this->at($i++))
@@ -144,8 +143,7 @@ class EditCrudActionTest extends CrudTestCase {
 			->disableOriginalConstructor()
 			->setMethods(array(
 				'_validateId', '_request', '_model', '_trigger',
-				'_controller', '_redirect', 'setFlash', 'saveOptions',
-				'_getFindMethod'
+				'_controller', '_redirect', 'setFlash', 'saveOptions'
 			))
 			->getMock();
 		$Action
@@ -170,11 +168,6 @@ class EditCrudActionTest extends CrudTestCase {
 			->method('escapeField')
 			->with()
 			->will($this->returnValue('Model.id'));
-		$Action
-			->expects($this->at($i++))
-			->method('_getFindMethod')
-			->with('count')
-			->will($this->returnValue('count'));
 		$Action
 			->expects($this->at($i++))
 			->method('_trigger')
@@ -695,7 +688,6 @@ class EditCrudActionTest extends CrudTestCase {
 		$Action
 			->expects($this->at($i++))
 			->method('_getFindMethod')
-			->with('first')
 			->will($this->returnValue('first'));
 		$Action
 			->expects($this->at($i++))
@@ -800,6 +792,93 @@ class EditCrudActionTest extends CrudTestCase {
 
 		$this->setReflectionClassInstance($Action);
 		$this->callProtectedMethod('_put', array(1), $Action);
+	}
+
+/**
+ * test_findRecordDefault
+ *
+ * @return void
+ */
+	public function test_findRecordDefault() {
+		$query = array('conditions' => array('Model.id' => 1));
+		$findParams = array('findMethod' => 'special', 'query' => $query);
+
+		$i = 0;
+		$Model = $this->getMock('Model', array('escapeField', 'find'));
+		$Model
+			->expects($this->at($i++))
+			->method('escapeField')
+			->will($this->returnValue('Model.id'));
+		$Model
+			->expects($this->at($i++))
+			->method('find')
+			->with('special', $query);
+
+		$i = 0;
+		$Action = $this
+			->getMockBuilder('EditCrudAction')
+			->disableOriginalConstructor()
+			->setMethods(array('_model', '_getFindMethod', '_trigger'))
+			->getMock();
+		$Action
+			->expects($this->at($i++))
+			->method('_model')
+			->will($this->returnValue($Model));
+		$Action
+			->expects($this->at($i++))
+			->method('_getFindMethod')
+			->will($this->returnValue('special'));
+		$Action
+			->expects($this->at($i++))
+			->method('_trigger')
+			->with('beforeFind', $findParams)
+			->will($this->returnValue(new CrudSubject($findParams)));
+
+		$this->setReflectionClassInstance($Action);
+		$this->callProtectedMethod('_findRecord', array(1), $Action);
+	}
+
+/**
+ * test_findRecordOverride
+ *
+ * @return void
+ */
+	public function test_findRecordOverride() {
+		$query = array('conditions' => array('Model.id' => 1));
+		$findParams = array('findMethod' => 'count', 'query' => $query);
+
+		$i = 0;
+		$Model = $this->getMock('Model', array('escapeField', 'find'));
+		$Model
+			->expects($this->at($i++))
+			->method('escapeField')
+			->will($this->returnValue('Model.id'));
+		$Model
+			->expects($this->at($i++))
+			->method('find')
+			->with('count', $query);
+
+		$i = 0;
+		$Action = $this
+			->getMockBuilder('EditCrudAction')
+			->disableOriginalConstructor()
+			->setMethods(array('_model', '_getFindMethod', '_trigger'))
+			->getMock();
+		$Action
+			->expects($this->at($i++))
+			->method('_model')
+			->will($this->returnValue($Model));
+		$Action
+			->expects($this->never())
+			->method('_getFindMethod');
+		$Action
+			->expects($this->at($i++))
+			->method('_trigger')
+			->with('beforeFind', $findParams)
+			->will($this->returnValue(new CrudSubject($findParams)));
+
+		$this->setReflectionClassInstance($Action);
+		$this->callProtectedMethod('_findRecord', array(1, 'count'), $Action);
 	}
 
 }


### PR DESCRIPTION
The way the default works means that previously:

```
$existing = $this->_findRecord($id, 'count');
```

Will not perform a count query - because the action is configured to
perform a find First
