### PR TITLE
Add new event: Crud.initialize() to match Component::initialize()

### DIFF
--- a/Controller/Component/CrudComponent.php
+++ b/Controller/Component/CrudComponent.php
@@ -162,6 +162,9 @@ class CrudComponent extends Component {
 
 		$name = str_replace('Component', '', get_class($this));
 		$this->_controller->dispatchComponents[$name] = true;
+
+		$this->_loadListeners();
+		$this->trigger('initialize');
 	}
 
 /**

--- a/Controller/Crud/CrudListener.php
+++ b/Controller/Crud/CrudListener.php
@@ -16,8 +16,9 @@ abstract class CrudListener extends CrudBaseObject {
  * Returns a list of all events that will fire in the controller during it's life cycle.
  * You can override this function to add you own listener callbacks
  *
+ * - initialize: Called at the same time as CrudComponent::initialize()
+ * - startup: Called at the same time as CrudComponent::startup()
  * - beforeHandle : Called before CrudAction is executed
- * - startup: Called after the Controller::beforeFilter() and before the Crud action is invoked
  * - recordNotFound : Called if a find() did not return any records
  * - beforePaginate : Called right before any paginate() method
  * - afterPaginate : Called right after any paginate() method
@@ -28,8 +29,10 @@ abstract class CrudListener extends CrudBaseObject {
  */
 	public function implementedEvents() {
 		$eventMap = array(
-			'Crud.beforeHandle' => 'beforeHandle',
+			'Crud.initialize' => 'initialize',
 			'Crud.startup' => 'startup',
+
+			'Crud.beforeHandle' => 'beforeHandle',
 
 			'Crud.beforePaginate' => 'beforePaginate',
 			'Crud.afterPaginate' => 'afterPaginate',

--- a/Controller/Crud/Listener/ApiListener.php
+++ b/Controller/Crud/Listener/ApiListener.php
@@ -45,7 +45,7 @@ class ApiListener extends CrudListener {
  */
 	public function implementedEvents() {
 		return array(
-			'Crud.startup' => array('callable' => 'startup', 'priority' => 5),
+			'Crud.initialize' => array('callable' => 'initialize', 'priority' => 5),
 			'Crud.beforeHandle' => array('callable' => 'beforeHandle', 'priority' => 10),
 			'Crud.setFlash' => array('callable' => 'setFlash', 'priority' => 5),
 
@@ -55,13 +55,12 @@ class ApiListener extends CrudListener {
 	}
 
 /**
- * Called when all listeners has been loaded,
- * and before the crud action is actually executed
+ * Called before Controller::beforeFilter
  *
  * @param CakeEvent $event
  * @return void
  */
-	public function startup(CakeEvent $event) {
+	public function initialize(CakeEvent $event) {
 		$this->setupDetectors();
 	}
 

--- a/Test/Case/Controller/Component/CrudComponentTest.php
+++ b/Test/Case/Controller/Component/CrudComponentTest.php
@@ -256,7 +256,13 @@ class CrudComponentTest extends ControllerTestCase {
 				'Mylistener' => 'MyPlugin.Mylistener'
 			)
 		);
-		$Crud = new CrudComponent($Collection, $settings);
+		$Crud = $this->getMock('CrudComponent', array('_loadListeners', 'trigger'), array($Collection, $settings));
+		$Crud
+			->expects($this->once())
+			->method('_loadListeners');
+		$Crud
+			->expects($this->once())
+			->method('trigger');
 		$Crud->initialize($this->controller);
 
 		$expected = array(

--- a/Test/Case/Controller/Crud/Listener/ApiListenerTest.php
+++ b/Test/Case/Controller/Crud/Listener/ApiListenerTest.php
@@ -70,11 +70,11 @@ class ApiListenerTest extends CrudTestCase {
 	}
 
 /**
- * testStartup
+ * testInitialize
  *
  * @return void
  */
-	public function testStartup() {
+	public function testInitialize() {
 		$listener = $this
 			->getMockBuilder('ApiListener')
 			->setMethods(array('setupDetectors'))
@@ -85,7 +85,7 @@ class ApiListenerTest extends CrudTestCase {
 			->expects($this->once())
 			->method('setupDetectors');
 
-		$listener->startup(new CakeEvent('Crud.startup'));
+		$listener->initialize(new CakeEvent('Crud.initialize'));
 	}
 
 /**
@@ -315,7 +315,7 @@ class ApiListenerTest extends CrudTestCase {
 		$subject = $this->getMock('CrudSubject');
 		$apiListener = new ApiListener($subject);
 		$expected = array(
-			'Crud.startup' => array('callable' => 'startup', 'priority' => 5),
+			'Crud.initialize' => array('callable' => 'initialize', 'priority' => 5),
 			'Crud.beforeHandle' => array('callable' => 'beforeHandle', 'priority' => 10),
 			'Crud.setFlash' => array('callable' => 'setFlash', 'priority' => 5),
 


### PR DESCRIPTION
Without this callback, the ApiListenr cannot inject its API detectors so they are usable in beforeFilter
