### PR TITLE
remove _cancel handling

### DIFF
--- a/Controller/Crud/Action/AddCrudAction.php
+++ b/Controller/Crud/Action/AddCrudAction.php
@@ -93,12 +93,6 @@ class AddCrudAction extends CrudAction {
 		$request = $this->_request();
 		$model = $this->_model();
 
-		if ($request->data('_cancel')) {
-			$subject = $this->_trigger('beforeCancel');
-			$controller = $this->_controller();
-			return $this->_redirect($subject, $controller->referer(array('action' => 'index')));
-		}
-
 		$this->_trigger('beforeSave');
 		if (call_user_func(array($model, $this->saveMethod()), $request->data, $this->saveOptions())) {
 			$this->setFlash('success');

--- a/Controller/Crud/Action/DeleteCrudAction.php
+++ b/Controller/Crud/Action/DeleteCrudAction.php
@@ -62,12 +62,6 @@ class DeleteCrudAction extends CrudAction {
 		$request = $this->_request();
 		$model = $this->_model();
 
-		if ($request->data('_cancel')) {
-			$subject = $this->_trigger('beforeCancel', array('id' => $id));
-			$controller = $this->_controller();
-			return $this->_redirect($subject, $controller->referer(array('action' => 'index')));
-		}
-
 		$query = array();
 		$query['conditions'] = array($model->escapeField() => $id);
 

--- a/Controller/Crud/Action/EditCrudAction.php
+++ b/Controller/Crud/Action/EditCrudAction.php
@@ -128,12 +128,6 @@ class EditCrudAction extends CrudAction {
 			$request->data[$model->primaryKey] = $id;
 		}
 
-		if ($request->data('_cancel')) {
-			$subject = $this->_trigger('beforeCancel', array('id' => $id));
-			$controller = $this->_controller();
-			return $this->_redirect($subject, $controller->referer(array('action' => 'index')));
-		}
-
 		$this->_trigger('beforeSave', compact('id'));
 		if (call_user_func(array($model, $this->saveMethod()), $request->data, $this->saveOptions())) {
 			$this->setFlash('success');

--- a/Controller/Crud/CrudListener.php
+++ b/Controller/Crud/CrudListener.php
@@ -52,8 +52,6 @@ abstract class CrudListener extends CrudBaseObject {
 
 			'Crud.beforeDelete' => 'beforeDelete',
 			'Crud.afterDelete' => 'afterDelete',
-
-			'Crud.beforeCancel' => 'beforeCancel',
 		);
 
 		$events = array();

--- a/Test/Case/Controller/Crud/Action/AddCrudActionTest.php
+++ b/Test/Case/Controller/Crud/Action/AddCrudActionTest.php
@@ -221,18 +221,18 @@ class AddCrudActionTest extends CrudTestCase {
 			->method('_trigger')
 			->with('afterSave', array('success' => true, 'created' => true, 'id' => 1))
 			->will($this->returnValue($CrudSubject));
-    $Request
-      ->expects($this->at(1))
-      ->method('data')
-      ->with('_add')
-      ->will($this->returnValue(true));
-    $Action
-      ->expects($this->at($i++))
-      ->method('_redirect')
-      ->with($CrudSubject, array('action' => 'add'));
-    $Action
-      ->expects($this->exactly(2))
-      ->method('_trigger');
+		$Request
+			->expects($this->at(0))
+			->method('data')
+			->with('_add')
+			->will($this->returnValue(true));
+		$Action
+			->expects($this->at($i++))
+			->method('_redirect')
+			->with($CrudSubject, array('action' => 'add'));
+		$Action
+			->expects($this->exactly(2))
+			->method('_trigger');
 
 		$this->setReflectionClassInstance($Action);
 		$this->callProtectedMethod('_post', array(), $Action);
@@ -301,23 +301,23 @@ class AddCrudActionTest extends CrudTestCase {
 			->method('_trigger')
 			->with('afterSave', array('success' => true, 'created' => true, 'id' => 1))
 			->will($this->returnValue($CrudSubject));
-    $Request
-      ->expects($this->at(1))
-      ->method('data')
-      ->with('_add')
-      ->will($this->returnValue(false));
-    $Request
-      ->expects($this->at(2))
-      ->method('data')
-      ->with('_edit')
-      ->will($this->returnValue(true));
-    $Action
-      ->expects($this->at($i++))
-      ->method('_redirect')
-      ->with($CrudSubject, array('action' => 'edit', 1));
-    $Action
-      ->expects($this->exactly(2))
-      ->method('_trigger');
+		$Request
+			->expects($this->at(0))
+			->method('data')
+			->with('_add')
+			->will($this->returnValue(false));
+		$Request
+			->expects($this->at(1))
+			->method('data')
+			->with('_edit')
+			->will($this->returnValue(true));
+		$Action
+			->expects($this->at($i++))
+			->method('_redirect')
+			->with($CrudSubject, array('action' => 'edit', 1));
+		$Action
+			->expects($this->exactly(2))
+			->method('_trigger');
 
 		$this->setReflectionClassInstance($Action);
 		$this->callProtectedMethod('_post', array(), $Action);
@@ -384,77 +384,6 @@ class AddCrudActionTest extends CrudTestCase {
 		$expected = $Request->data;
 		$expected['model'] = true;
 		$this->assertEqual($result, $expected, 'The Request::$data and Model::$data was not merged');
-	}
-
-/**
- * Test that calling HTTP POST on an add action
- * with `_cancel` set in the POST data will cancel the form submission
- *
- * @covers AddCrudAction::_post
- * @return void
- */
-	public function testActionCancel() {
-    $data = array(
-      '_cancel' => '_cancel',
-    );
-
-    $CrudSubject = new CrudSubject();
-
-    $Request = $this->getMock('CakeRequest');
-    $Request->setMethods(array('data'));
-    $Request->data = $data;
-
-    $Controller = $this
-      ->getMockBuilder('Controller')
-      ->disableOriginalConstructor()
-      ->setMethods(array('referer'))
-      ->getMock();
-
-    $Model = $this->getMock('Model');
-
-		$i = 0;
-		$Action = $this
-			->getMockBuilder('AddCrudAction')
-			->disableOriginalConstructor()
-      ->setMethods(array(
-        '_request', '_model', '_trigger',
-        '_controller', '_redirect'
-      ))
-			->getMock();
-		$Action
-			->expects($this->at($i++))
-			->method('_request')
-			->will($this->returnValue($Request));
-		$Action
-			->expects($this->at($i++))
-			->method('_model')
-			->will($this->returnValue($Model));
-    $Request
-      ->expects($this->at(0))
-      ->method('data')
-      ->with('_cancel')
-      ->will($this->returnValue(true));
-		$Action
-			->expects($this->at($i++))
-			->method('_trigger')
-			->with('beforeCancel')
-			->will($this->returnValue($CrudSubject));
-		$Action
-			->expects($this->at($i++))
-			->method('_controller')
-			->will($this->returnValue($Controller));
-		$Controller
-			->expects($this->at(0))
-			->method('referer')
-			->with(array('action' => 'index'))
-			->will($this->returnValue(array('action' => 'index')));
-		$Action
-			->expects($this->at($i++))
-			->method('_redirect')
-			->with($CrudSubject, array('action' => 'index'));
-
-		$this->setReflectionClassInstance($Action);
-		$this->callProtectedMethod('_post', array(), $Action);
 	}
 
 }

--- a/Test/Case/Controller/Crud/Action/DeleteCrudActionTest.php
+++ b/Test/Case/Controller/Crud/Action/DeleteCrudActionTest.php
@@ -23,7 +23,7 @@ class DeleteCrudActionTest extends CrudTestCase {
  * @return void
  */
 	public function testDeleteOnDelete() {
-    $Action = $this->_actionSuccess();
+		$Action = $this->_actionSuccess();
 		$this->setReflectionClassInstance($Action);
 		$this->callProtectedMethod('_delete', array(1), $Action);
 	}
@@ -37,7 +37,7 @@ class DeleteCrudActionTest extends CrudTestCase {
  * @return void
  */
 	public function testDeleteOnPost() {
-    $Action = $this->_actionSuccess();
+		$Action = $this->_actionSuccess();
 		$this->setReflectionClassInstance($Action);
 		$this->callProtectedMethod('_post', array(1), $Action);
 	}
@@ -151,13 +151,13 @@ class DeleteCrudActionTest extends CrudTestCase {
  * @return void
  */
 	public function testActiondeleteWithAddRedirect() {
-    $data = array(
-      '_edit' => '_edit',
-    );
+		$data = array(
+			'_edit' => '_edit',
+		);
 
 		$Request = $this->getMock('CakeRequest');
-    $Request->setMethods(array('data'));
-    $Request->data = $data;
+		$Request->setMethods(array('data'));
+		$Request->data = $data;
 
 		$Model = $this
 			->getMockBuilder('Model')
@@ -239,11 +239,11 @@ class DeleteCrudActionTest extends CrudTestCase {
 			->method('_trigger')
 			->with('afterDelete', array('id' => 1, 'success' => true))
 			->will($this->returnValue($CrudSubject));
-    $Request
-      ->expects($this->at(1))
-      ->method('data')
-      ->with('_add')
-      ->will($this->returnValue(true));
+		$Request
+			->expects($this->at(0))
+			->method('data')
+			->with('_add')
+			->will($this->returnValue(true));
 		$Action
 			->expects($this->at($i++))
 			->method('_redirect')
@@ -586,82 +586,5 @@ class DeleteCrudActionTest extends CrudTestCase {
 		$this->setReflectionClassInstance($Action);
 		$this->callProtectedMethod('_delete', array(1), $Action);
 	}
-
-/**
- * Test that calling HTTP DELETE on an edit action
- * with `_cancel` set in the POST data will cancel the form submission
- *
- * @covers DeleteCrudAction::_delete
- * @return void
- */
-  public function testDeleteActionCancel() {
-    $data = array(
-      '_cancel' => '_cancel',
-      'Model' => array('id' => 1)
-    );
-
-    $CrudSubject = new CrudSubject();
-
-    $Request = $this->getMock('CakeRequest');
-    $Request->setMethods(array('data'));
-    $Request->data = $data;
-
-    $Controller = $this
-      ->getMockBuilder('Controller')
-      ->disableOriginalConstructor()
-      ->setMethods(array('referer'))
-      ->getMock();
-
-    $Model = $this->getMock('Model');
-
-    $i = 0;
-    $Action = $this
-      ->getMockBuilder('DeleteCrudAction')
-      ->disableOriginalConstructor()
-      ->setMethods(array(
-        '_validateId', '_request', '_model', '_trigger',
-        '_controller', '_redirect'
-      ))
-      ->getMock();
-    $Action
-      ->expects($this->at($i++))
-      ->method('_validateId')
-      ->with(1)
-      ->will($this->returnValue(true));
-    $Action
-      ->expects($this->at($i++))
-      ->method('_request')
-      ->will($this->returnValue($Request));
-    $Action
-      ->expects($this->at($i++))
-      ->method('_model')
-      ->will($this->returnValue($Model));
-    $Request
-      ->expects($this->at(0))
-      ->method('data')
-      ->with('_cancel')
-      ->will($this->returnValue(true));
-    $Action
-      ->expects($this->at($i++))
-      ->method('_trigger')
-      ->with('beforeCancel')
-      ->will($this->returnValue($CrudSubject));
-    $Action
-      ->expects($this->at($i++))
-      ->method('_controller')
-      ->will($this->returnValue($Controller));
-    $Controller
-      ->expects($this->at(0))
-      ->method('referer')
-      ->with(array('action' => 'index'))
-      ->will($this->returnValue(array('action' => 'index')));
-    $Action
-      ->expects($this->at($i++))
-      ->method('_redirect')
-      ->with($CrudSubject, array('action' => 'index'));
-
-    $this->setReflectionClassInstance($Action);
-    $this->callProtectedMethod('_delete', array(1), $Action);
-  }
 
 }

--- a/Test/Case/Controller/Crud/Action/EditCrudActionTest.php
+++ b/Test/Case/Controller/Crud/Action/EditCrudActionTest.php
@@ -274,11 +274,6 @@ class EditCrudActionTest extends CrudTestCase {
 			->method('_findRecord')
 			->with(1, 'count')
 			->will($this->returnValue(true));
-		$Request
-			->expects($this->at(0))
-			->method('data')
-			->with('_cancel')
-			->will($this->returnValue(false));
 		$Action
 			->expects($this->at($i++))
 			->method('_trigger')
@@ -302,7 +297,7 @@ class EditCrudActionTest extends CrudTestCase {
 			->with('afterSave', array('success' => true, 'created' => false, 'id' => 1))
 			->will($this->returnValue($CrudSubject));
 		$Request
-			->expects($this->at(1))
+			->expects($this->at(0))
 			->method('data')
 			->with('_add')
 			->will($this->returnValue(true));
@@ -376,11 +371,6 @@ class EditCrudActionTest extends CrudTestCase {
 			->method('_findRecord')
 			->with(1, 'count')
 			->will($this->returnValue(true));
-		$Request
-			->expects($this->at(0))
-			->method('data')
-			->with('_cancel')
-			->will($this->returnValue(false));
 		$Action
 			->expects($this->at($i++))
 			->method('_trigger')
@@ -404,12 +394,12 @@ class EditCrudActionTest extends CrudTestCase {
 			->with('afterSave', array('success' => true, 'created' => false, 'id' => 1))
 			->will($this->returnValue($CrudSubject));
 		$Request
-			->expects($this->at(1))
+			->expects($this->at(0))
 			->method('data')
 			->with('_add')
 			->will($this->returnValue(false));
 		$Request
-			->expects($this->at(2))
+			->expects($this->at(1))
 			->method('data')
 			->with('_edit')
 			->will($this->returnValue(true));
@@ -723,87 +713,6 @@ class EditCrudActionTest extends CrudTestCase {
 
 		$this->setReflectionClassInstance($Action);
 		$this->callProtectedMethod('_get', array(1), $Action);
-	}
-
-/**
- * Test that calling HTTP PUT on an edit action
- * with `_cancel` set in the POST data will cancel the form submission
- *
- * @return void
- */
-	public function testPutActionCancel() {
-		$data = array(
-			'_cancel' => '_cancel',
-			'Model' => array('id' => 1)
-		);
-
-		$CrudSubject = new CrudSubject();
-
-		$Request = $this->getMock('CakeRequest');
-		$Request->setMethods(array('data'));
-		$Request->data = $data;
-
-		$Controller = $this
-			->getMockBuilder('Controller')
-			->disableOriginalConstructor()
-			->setMethods(array('referer'))
-			->getMock();
-
-		$Model = $this->getMock('Model');
-
-		$i = 0;
-		$Action = $this
-			->getMockBuilder('EditCrudAction')
-			->disableOriginalConstructor()
-			->setMethods(array(
-				'_validateId', '_request', '_model', '_trigger',
-				'_controller', '_redirect', '_findRecord'
-			))
-			->getMock();
-		$Action
-			->expects($this->at($i++))
-			->method('_validateId')
-			->with(1)
-			->will($this->returnValue(true));
-		$Action
-			->expects($this->at($i++))
-			->method('_request')
-			->will($this->returnValue($Request));
-		$Action
-			->expects($this->at($i++))
-			->method('_model')
-			->will($this->returnValue($Model));
-		$Action
-			->expects($this->at($i++))
-			->method('_findRecord')
-			->with(1, 'count')
-			->will($this->returnValue(true));
-		$Request
-			->expects($this->at(0))
-			->method('data')
-			->with('_cancel')
-			->will($this->returnValue(true));
-		$Action
-			->expects($this->at($i++))
-			->method('_trigger')
-			->with('beforeCancel')
-			->will($this->returnValue($CrudSubject));
-		$Action
-			->expects($this->at($i++))
-			->method('_controller')
-			->will($this->returnValue($Controller));
-		$Controller
-			->expects($this->at(0))
-			->method('referer')
-			->with(array('action' => 'index'))
-			->will($this->returnValue(array('action' => 'index')));
-		$Action
-			->expects($this->at($i++))
-			->method('_redirect')
-			->with($CrudSubject, array('action' => 'index'));
-
-		$this->setReflectionClassInstance($Action);
-		$this->callProtectedMethod('_put', array(1), $Action);
 	}
 
 /**


### PR DESCRIPTION
If the user cancels they should not be submitting post data at all.
Where this logic was going to be used, we'll replace with a link.

This is the easy part of a larger task - the _add and _edit handling needs to be moved to a listener (not part of this PR).
