### PR TITLE
make public-but-protected config settings unprefixed

### DIFF
--- a/Controller/Crud/Listener/ApiTransformationListener.php
+++ b/Controller/Crud/Listener/ApiTransformationListener.php
@@ -175,7 +175,7 @@ class ApiTransformationListener extends CrudListener {
 			}
 
 			foreach ($variable as $k => &$value) {
-				$this->_recurse($value, $key ? "$key.$k" : $k);
+				$this->_recurse($value, $key === null ? $k : "$key.$k");
 			}
 
 			return;


### PR DESCRIPTION
Since these settings are not internal, but supposed to be user editable via the config - name them without an underscore prefix.

Also add the key to transformation callbacks so that it's possible to apply transformations to only one particular key.
