### PR TITLE
Removes false claim that 'className' is required.

### DIFF
--- a/docs/listeners/api-transformation.md
+++ b/docs/listeners/api-transformation.md
@@ -118,9 +118,6 @@ class SamplesController extends AppController {
         'Api',
         'ApiTransformation' => [
 
-          // Required.
-          'className' => 'ApiTransformation',
-
           // Remove top model and nest associations.
           'changeNesting' => true,
 


### PR DESCRIPTION
You were right.
