### PR TITLE
Rename executeAction to execute

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -194,7 +194,7 @@ public function index() {
   // Get the current configuration
   $config = $this->Crud->action()->findMethod();
 
-  return $this->Crud->executeAction();
+  return $this->Crud->execute();
 }
 
 public function admin_index() {
@@ -203,7 +203,7 @@ public function admin_index() {
   // Get the current configuration
   $config = $this->Crud->action()->findMethod();
 
-  return $this->Crud->executeAction();
+  return $this->Crud->execute();
 }
 ?>
 {% endhighlight %}
@@ -247,7 +247,7 @@ public function index() {
   // Get the current configuration
   $config = $this->Crud->action()->view();
 
-  return $this->Crud->executeAction();
+  return $this->Crud->execute();
 }
 
 public function admin_index() {
@@ -256,7 +256,7 @@ public function admin_index() {
   // Get the current configuration
   $config = $this->Crud->action()->view();
 
-  return $this->Crud->executeAction();
+  return $this->Crud->execute();
 }
 ?>
 {% endhighlight %}
@@ -299,7 +299,7 @@ public function index() {
   // Get the current configuration
   $config = $this->Crud->action()->viewVar();
 
-  return $this->Crud->executeAction();
+  return $this->Crud->execute();
 }
 
 public function admin_index() {
@@ -308,7 +308,7 @@ public function admin_index() {
   // Get the current configuration
   $config = $this->Crud->action()->viewVar();
 
-  return $this->Crud->executeAction();
+  return $this->Crud->execute();
 }
 ?>
 {% endhighlight %}

--- a/docs/events.md
+++ b/docs/events.md
@@ -167,7 +167,7 @@ public function _beforeSave(CakeEvent $event) {
 Very much like the other `Closure` examples above.
 
 When implementing callbacks inside the controller action, it's very important to call the
-`executeAction` in `Crud`.
+`execute` in `Crud`.
 
 This will allow Crud to continue to do it's magic just as if the method didn't exist at all in the
 controller in the first place.
@@ -182,7 +182,7 @@ class DemoController extends AppController {
 		}
 
 		// Important for the ViewCrudAction to be executed
-		return $this->Crud->executeAction();
+		return $this->Crud->execute();
 	}
 
 }

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -126,13 +126,13 @@ abstract class AppController extends Controller {
 						continue;
 					}
 
-					// Skip if executeAction isn't defined in the Component
-					if (!method_exists($this->{$component}, 'executeAction')) {
+					// Skip if execute isn't defined in the Component
+					if (!method_exists($this->{$component}, 'execute')) {
 						continue;
 					}
 
 					// Execute the callback, can return CakeResponse object
-					return $this->{$component}->executeAction();
+					return $this->{$component}->execute();
 				}
 			}
 


### PR DESCRIPTION
To keep consistency with `enable`.

Also #108 
