### PR TITLE
Adds Travis configuration for gh-pages.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+branches:
+  except:
+    - /^gh-pages.*$/


### PR DESCRIPTION
Travis always needs a .travis.yml file or it will build the gh-pages branch. This configuration also excludes branches prefixed with gh-pages.

See: http://about.travis-ci.org/docs/user/build-configuration/#White--or-blacklisting-branches

Let's see if this actually works.
