### PR TITLE
Corrected typo in CrudSubject::hasEvent() docblock

### DIFF
--- a/Controller/Crud/CrudSubject.php
+++ b/Controller/Crud/CrudSubject.php
@@ -102,7 +102,7 @@ class CrudSubject {
 	}
 
 /**
- * Returns whether the specified event is in the list the list of events
+ * Returns whether the specified event is in the list of events
  * this subject has passed through
  *
  * @param string $name name of event


### PR DESCRIPTION
Simple duplication of "the list."  :abc: 
