### PR TITLE
Update listeners.rst

### DIFF
--- a/docs/listeners.rst
+++ b/docs/listeners.rst
@@ -14,7 +14,7 @@ The event system allows you to hook into the most important part of the
 needs.
 
 The Anatomy Of A Listener
-^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The listener system is simply the
 `Events System <http://book.cakephp.org/3.0/en/core-libraries/events.html>`_ from


### PR DESCRIPTION
Fixed a typo.

An is only used instead of A if the next letter is a vowel.
