### PR TITLE
Swap out getEventManager() with eventManager()

### DIFF
--- a/Action/BaseAction.php
+++ b/Action/BaseAction.php
@@ -49,13 +49,13 @@ abstract class BaseAction extends Object {
 
 		if (method_exists($this, $method)) {
 			$this->_responding = true;
-			$this->_controller()->getEventManager()->attach($this);
+			$this->_controller()->eventManager()->attach($this);
 			return call_user_func_array([$this, $method], $args);
 		}
 
 		if (method_exists($this, '_handle')) {
 			$this->_responding = true;
-			$this->_controller()->getEventManager()->attach($this);
+			$this->_controller()->eventManager()->attach($this);
 			return call_user_func_array([$this, '_handle'], $args);
 		}
 

--- a/Controller/Component/CrudComponent.php
+++ b/Controller/Component/CrudComponent.php
@@ -132,7 +132,7 @@ class CrudComponent extends Component {
 		$settings['listeners'] = $this->normalizeArray($settings['listeners']);
 
 		$this->_controller = $collection->getController();
-		$this->_eventManager = $this->_controller->getEventManager();
+		$this->_eventManager = $this->_controller->eventManager();
 
 		parent::__construct($collection, $settings);
 	}

--- a/Test/TestCase/Controller/Component/CrudComponentTest.php
+++ b/Test/TestCase/Controller/Component/CrudComponentTest.php
@@ -259,7 +259,7 @@ class CrudComponentTest extends ControllerTestCase {
 	public function testOn() {
 		$this->Crud->on('event', 'fakeCallback');
 
-		$return = $this->controller->getEventManager()->listeners('Crud.event');
+		$return = $this->controller->eventManager()->listeners('Crud.event');
 
 		$expected = array(
 			array(
@@ -279,7 +279,7 @@ class CrudComponentTest extends ControllerTestCase {
 		$this->Crud->on('event', 'fakeHighPriority', array('priority' => 1));
 		$this->Crud->on('event', 'fakeLowPriority', array('priority' => 99999));
 
-		$return = $this->controller->getEventManager()->listeners('Crud.event');
+		$return = $this->controller->eventManager()->listeners('Crud.event');
 
 		$expected = array(
 			array(


### PR DESCRIPTION
Due to a recentish update to the Cake3 repo, the getEventManager method has been renamed to just eventManager in the base Controller class, causing all of Crud to fail with a missing method error. This updates Crud to use the new API.
See also: https://github.com/cakephp/cakephp/commit/9a3e0db66ccc13c7612c13c3a458c4584d4068d0
