### PR TITLE
Change default scope to 'entity'.

### DIFF
--- a/src/Action/AddAction.php
+++ b/src/Action/AddAction.php
@@ -42,7 +42,7 @@ class AddAction extends BaseAction {
  */
 	protected $_defaultConfig = [
 		'enabled' => true,
-		'scope' => 'table',
+		'scope' => 'entity',
 		'inflection' => 'singular',
 		'saveMethod' => 'save',
 		'view' => null,


### PR DESCRIPTION
Because the add actions default scope was set to 'table', the default viewVar for the add action was in plural form whereas the edit action was in singular form.

https://github.com/FriendsOfCake/crud/blob/cake3/src/Traits/ViewVarTrait.php#L51
