### PR TITLE
uses proper method to generate listeners names.

### DIFF
--- a/src/Controller/Component/CrudComponent.php
+++ b/src/Controller/Component/CrudComponent.php
@@ -149,7 +149,7 @@ class CrudComponent extends Component {
 			}
 
 			list(, $name) = pluginSplit($objectName);
-			$name = strtolower($name);
+			$name = Inflector::variable($name);
 			$normal[$name] = ['className' => $objectName, 'config' => $config];
 		}
 


### PR DESCRIPTION
Calling Selector::variable give us the best conventions to use variable names. fix #204
