### PR TITLE
Update action dispatching via CRUD.

### DIFF
--- a/src/Action/BaseAction.php
+++ b/src/Action/BaseAction.php
@@ -86,10 +86,6 @@ abstract class BaseAction extends Object {
 
 		$controller = $this->_controller();
 		$actionName = $this->config('action');
-
-		if (!in_array($actionName, $controller->methods)) {
-			$controller->methods[] = $actionName;
-		}
 	}
 
 /**

--- a/src/Controller/Component/CrudComponent.php
+++ b/src/Controller/Component/CrudComponent.php
@@ -162,19 +162,12 @@ class CrudComponent extends Component {
 	}
 
 /**
- * Make sure to update the list of known controller methods before startup is called.
- *
- * The reason for this is that if we don't, the Auth component won't execute any callbacks on the controller
- * like isAuthorized.
+ * Add self to list of components capable of dispatching an action.
  *
  * @param \Cake\Event\Event $event Event instance
  * @return void
  */
 	public function initialize(Event $event) {
-		$this->_controller->methods = array_keys(
-			array_flip($this->_controller->methods) +
-			array_flip(array_keys($this->_config['actions']))
-		);
 		$this->_action = $this->_controller->request->action;
 		$this->_request = $this->_controller->request;
 

--- a/tests/TestCase/Action/BaseActionTest.php
+++ b/tests/TestCase/Action/BaseActionTest.php
@@ -222,9 +222,6 @@ class CrudActionTest extends TestCase {
 			->will($this->returnValue('add'));
 
 		$Action->enable();
-
-		$actual = array_search('add', $this->Controller->methods);
-		$this->assertTrue($actual !== false, '"add" was not added to the controller::$methods array');
 	}
 
 /**


### PR DESCRIPTION
Controller::$methods has been removed and instead Controller::isAction() is
now used to determine if a valid controller method exists for an action.
