### PR TITLE
3.0 - Update add action to prevent showing validation errors on GET request.

### DIFF
--- a/src/Action/AddAction.php
+++ b/src/Action/AddAction.php
@@ -97,7 +97,7 @@ class AddAction extends BaseAction
     {
         $subject = $this->_subject([
             'success' => true,
-            'entity' => $this->_entity($this->_request()->query, $this->saveOptions())
+            'entity' => $this->_entity($this->_request()->query ?: null, $this->saveOptions())
         ]);
 
         $this->_trigger('beforeRender', $subject);

--- a/src/Core/ProxyTrait.php
+++ b/src/Core/ProxyTrait.php
@@ -123,7 +123,7 @@ trait ProxyTrait
      * @param options $options A list of options for the object hydration.
      * @return \Cake\ORM\Entity
      */
-    protected function _entity(array $data = [], array $options = [])
+    protected function _entity(array $data = null, array $options = [])
     {
         if ($this->_entity && empty($data)) {
             return $this->_entity;


### PR DESCRIPTION
Due to the change on the validation layer in CakePHP, validation errors are shown on a empty GET request.