### PR TITLE
Fix RelatedModel association types

### DIFF
--- a/src/Listener/RelatedModelsListener.php
+++ b/src/Listener/RelatedModelsListener.php
@@ -69,7 +69,7 @@ class RelatedModelsListener extends BaseListener
         $settings = $this->relatedModels(null, $action);
 
         if ($settings === true) {
-            return $this->getAssociatedByType(['oneToOne', 'belongsToMany', 'manyToOne']);
+            return $this->getAssociatedByType(['oneToOne', 'manyToMany', 'manyToOne']);
         }
 
         if (empty($settings)) {

--- a/tests/TestCase/Listener/RelatedModelsListenerTest.php
+++ b/tests/TestCase/Listener/RelatedModelsListenerTest.php
@@ -110,7 +110,7 @@ class RelatedModelListenerTest extends TestCase
         $listener
             ->expects($this->once())
             ->method('getAssociatedByType')
-            ->with(['oneToOne', 'belongsToMany', 'manyToOne']);
+            ->with(['oneToOne', 'manyToMany', 'manyToOne']);
 
         $result = $listener->models();
     }


### PR DESCRIPTION
The type for belongsToMany is manyToMany, so RelatedModel didn't fetch associated models with belongsToMany association.

https://github.com/cakephp/cakephp/blob/master/src/ORM/Association.php#L78