### PR TITLE
Initial pass at a BulkAction base handler

### DIFF
--- a/docs/_partials/events/after_bulk.rst
+++ b/docs/_partials/events/after_bulk.rst
@@ -1,0 +1,26 @@
+Crud.afterBulk
+^^^^^^^^^^^^^^^^
+
+This event is emitted after calling ``_bulk()`` on a Bulk Crud action.
+
+The :ref:`Crud Subject <crud-subject>` contains two keys:
+
+- **success** if ``true`` the ``_bulk()`` call succeeded, ``false`` otherwise
+- **ids** A list of ids of entities, from the request data
+- **repository** An instance of the ``Repository`` (``Table``) which the query will be executed against.
+- **query** A ``Query`` object from the ``Repository`` where ``$PrimaryKey => $IdFromRequest`` is already added to the conditions.
+
+Check Success
+"""""""""""""
+
+.. code-block:: phpinline
+
+  public function bulk($id) {
+    $this->Crud->on('afterBulk', function(\Cake\Event\Event $event) {
+      if (!$event->subject->success) {
+        $this->log("Bulk action failed");
+      }
+    });
+
+    return $this->Crud->execute();
+  }

--- a/docs/_partials/events/before_bulk.rst
+++ b/docs/_partials/events/before_bulk.rst
@@ -1,0 +1,29 @@
+Crud.beforeBulk
+^^^^^^^^^^^^^^^^^
+
+This event is emitted before ``_bulk()`` is called on a Bulk Crud action.
+
+The :ref:`Crud Subject <crud-subject>` contains the following keys:
+
+- **ids** A list of ids of entities, from the request data
+- **repository** An instance of the ``Repository`` (``Table``) which the query will be executed against.
+- **query** A ``Query`` object from the ``Repository`` where ``$PrimaryKey => $IdFromRequest`` is already added to the conditions.
+
+To abort a bulk action, simply stop the event by calling
+``$event->stopPropagation()``.
+
+Stop Bulk Action
+""""""""""""""""
+
+.. code-block:: phpinline
+
+  public function bulk($id) {
+    $this->Crud->on('beforeBulk', function(\Cake\Event\Event $event) {
+      // Stop the bulk event, the action will not continue
+      if ($event->subject->item->author !== 'admin') {
+        $event->stopPropagation();
+      }
+    });
+
+    return $this->Crud->execute();
+  }

--- a/docs/actions.rst
+++ b/docs/actions.rst
@@ -142,4 +142,8 @@ More On Actions
 	actions/add
 	actions/edit
 	actions/delete
+  actions/bulk
+  actions/bulk-delete
+  actions/bulk-set-value
+  actions/bulk-toggle
 	actions/custom

--- a/docs/actions.rst
+++ b/docs/actions.rst
@@ -142,8 +142,8 @@ More On Actions
 	actions/add
 	actions/edit
 	actions/delete
-  actions/bulk
-  actions/bulk-delete
-  actions/bulk-set-value
-  actions/bulk-toggle
+	actions/bulk
+	actions/bulk-delete
+	actions/bulk-set-value
+	actions/bulk-toggle
 	actions/custom

--- a/docs/actions/bulk-delete.rst
+++ b/docs/actions/bulk-delete.rst
@@ -1,0 +1,40 @@
+Bulk Delete
+===========
+
+You can use the ``Bulk\DeleteAction`` class to delete a group of database records.
+
+.. code:: php
+
+  <?php
+  namespace App\Controller;
+
+  class PostsController extends AppController
+  {
+    public function initialize()
+    {
+      parent::initialize();
+      $this->Crud->mapAction('deleteAll', 'Crud.Bulk/Delete');
+    }
+  }
+
+Configuration
+-------------
+
+.. include:: /_partials/actions/configuration_intro.rst
+.. include:: /_partials/actions/configuration/enabled.rst
+.. include:: /_partials/actions/configuration/find_method.rst
+
+Events
+------
+
+This is a list of events emitted from actions that extend ``Bulk\BaseAction``.
+
+Please see the :doc:`events documentation</events>` for a full list of generic
+properties and how to use the event system correctly.
+
+.. include:: /_partials/events/startup.rst
+.. include:: /_partials/events/before_filter.rst
+.. include:: /_partials/events/before_bulk.rst
+.. include:: /_partials/events/after_bulk.rst
+.. include:: /_partials/events/set_flash.rst
+.. include:: /_partials/events/before_redirect.rst

--- a/docs/actions/bulk-set-value.rst
+++ b/docs/actions/bulk-set-value.rst
@@ -1,0 +1,45 @@
+Bulk Set Value
+==============
+
+You can use the ``Bulk\SetValueAction`` class to specify the value of a
+given field for a group of database records.
+
+.. code:: php
+
+  <?php
+  namespace App\Controller;
+
+  class PostsController extends AppController
+  {
+    public function initialize()
+    {
+      parent::initialize();
+      $this->Crud->mapAction('publishAll', [
+        'className' => 'Crud.Bulk/SetValue',
+        'field' => 'status',
+        'value' => 'publish',
+      ]);
+    }
+  }
+
+Configuration
+-------------
+
+.. include:: /_partials/actions/configuration_intro.rst
+.. include:: /_partials/actions/configuration/enabled.rst
+.. include:: /_partials/actions/configuration/find_method.rst
+
+Events
+------
+
+This is a list of events emitted from actions that extend ``Bulk\BaseAction``.
+
+Please see the :doc:`events documentation</events>` for a full list of generic
+properties and how to use the event system correctly.
+
+.. include:: /_partials/events/startup.rst
+.. include:: /_partials/events/before_filter.rst
+.. include:: /_partials/events/before_bulk.rst
+.. include:: /_partials/events/after_bulk.rst
+.. include:: /_partials/events/set_flash.rst
+.. include:: /_partials/events/before_redirect.rst

--- a/docs/actions/bulk-toggle.rst
+++ b/docs/actions/bulk-toggle.rst
@@ -1,0 +1,44 @@
+Bulk Toggle
+===========
+
+You can use the ``Bulk\ToggleAction`` class to toggle the value of a
+boolean field for a group of database records.
+
+.. code:: php
+
+  <?php
+  namespace App\Controller;
+
+  class PostsController extends AppController
+  {
+    public function initialize()
+    {
+      parent::initialize();
+      $this->Crud->mapAction('toggleActive', [
+        'className' => 'Crud.Bulk/Toggle',
+        'field' => 'toggle',
+      ]);
+    }
+  }
+
+Configuration
+-------------
+
+.. include:: /_partials/actions/configuration_intro.rst
+.. include:: /_partials/actions/configuration/enabled.rst
+.. include:: /_partials/actions/configuration/find_method.rst
+
+Events
+------
+
+This is a list of events emitted from actions that extend ``Bulk\BaseAction``.
+
+Please see the :doc:`events documentation</events>` for a full list of generic
+properties and how to use the event system correctly.
+
+.. include:: /_partials/events/startup.rst
+.. include:: /_partials/events/before_filter.rst
+.. include:: /_partials/events/before_bulk.rst
+.. include:: /_partials/events/after_bulk.rst
+.. include:: /_partials/events/set_flash.rst
+.. include:: /_partials/events/before_redirect.rst

--- a/docs/actions/bulk.rst
+++ b/docs/actions/bulk.rst
@@ -1,0 +1,62 @@
+Bulk
+====
+
+If you need to perform an action against a number of records, you can extend
+the abstract ``Bulk\BaseAction`` class to create your own.
+
+Three BulkAction classes exist in the core:
+
+- :doc:`Delete</actions/bulk-delete>`: Deletes a set of entities
+- :doc:`SetValue</actions/bulk-set-value>`: Sets a field to a value for a set of entities
+- :doc:`Toggle</actions/bulk-toggle>`: Toggles the value of a boolean field for a set of entities
+
+To create your own BulkAction, simply create a new action class with a ``_bulk``
+method. This method takes a CakePHP ``Query`` object as it's first argument
+
+.. code:: php
+
+  <?php
+  namespace App\Crud\Action;
+
+  use Cake\ORM\Query;
+  use Crud\Action\Bulk\BaseAction;
+
+  class ApproveAction extends BaseAction
+  {
+    /**
+     * Set the value of the approved field to true
+     * for a set of entities
+     *
+     * @param \Cake\ORM\Query $query The query to act upon
+     * @return boolean
+     */
+    protected function _handle(Query $query)
+    {
+      $query->update()->set(['approved' => true]);
+      $statement = $query->execute();
+      $statement->closeCursor();
+      return $statement->rowCount();
+    }
+  }
+
+Configuration
+-------------
+
+.. include:: /_partials/actions/configuration_intro.rst
+.. include:: /_partials/actions/configuration/enabled.rst
+.. include:: /_partials/actions/configuration/find_method.rst
+
+Events
+------
+
+This is a list of events emitted from actions that extend ``Bulk\BaseAction``.
+
+Please see the :doc:`events documentation</events>` for a full list of generic
+properties and how to use the event system correctly.
+
+.. include:: /_partials/events/startup.rst
+.. include:: /_partials/events/before_filter.rst
+.. include:: /_partials/events/before_bulk.rst
+.. include:: /_partials/events/after_bulk.rst
+.. include:: /_partials/events/set_flash.rst
+.. include:: /_partials/events/before_redirect.rst

--- a/src/Action/Bulk/BaseAction.php
+++ b/src/Action/Bulk/BaseAction.php
@@ -5,7 +5,6 @@ use Cake\Event\Event;
 use Cake\Network\Exception\BadRequestException;
 use Cake\ORM\Query;
 use Cake\Utility\Hash;
-use Crud\Error\Exception\ActionNotConfiguredException;
 use Crud\Event\Subject;
 use Crud\Traits\RedirectTrait;
 

--- a/src/Action/Bulk/BaseAction.php
+++ b/src/Action/Bulk/BaseAction.php
@@ -145,7 +145,7 @@ abstract class BaseAction extends BaseAction
      * Handle a bulk event
      *
      * @param \Cake\ORM\Query $query The query to act upon
-     * @return boolean
+     * @return bool
      */
     abstract protected function _bulk(Query $query);
 }

--- a/src/Action/Bulk/BaseAction.php
+++ b/src/Action/Bulk/BaseAction.php
@@ -4,6 +4,7 @@ namespace Crud\Action\Bulk;
 use Cake\Event\Event;
 use Cake\Network\Exception\BadRequestException;
 use Cake\ORM\Query;
+use Crud\Action\BaseAction as CrudBaseAction;
 use Cake\Utility\Hash;
 use Crud\Event\Subject;
 use Crud\Traits\RedirectTrait;
@@ -14,7 +15,7 @@ use Crud\Traits\RedirectTrait;
  * Licensed under The MIT License
  * For full copyright and license information, please see the LICENSE.txt
  */
-abstract class BaseAction extends BaseAction
+abstract class BaseAction extends CrudBaseAction
 {
     use RedirectTrait;
 

--- a/src/Action/Bulk/BaseAction.php
+++ b/src/Action/Bulk/BaseAction.php
@@ -90,7 +90,8 @@ abstract class BaseAction extends CrudBaseAction
             }
         }
 
-        return array_filter($ids);
+        $ids = array_filter($ids);
+        return array_keys($ids);
     }
 
     /**

--- a/src/Action/Bulk/BaseAction.php
+++ b/src/Action/Bulk/BaseAction.php
@@ -20,7 +20,7 @@ abstract class BaseAction extends BaseAction
     use RedirectTrait;
 
     /**
-     * Default settings for 'lookup' actions
+     * Default settings for 'base' actions
      *
      * @var array
      */
@@ -42,7 +42,7 @@ abstract class BaseAction extends BaseAction
     /**
      * Handle a bulk event
      *
-     * @return void
+     * @return \Cake\Network\Response
      */
     protected function _handle()
     {
@@ -145,7 +145,8 @@ abstract class BaseAction extends BaseAction
     /**
      * Handle a bulk event
      *
-     * @return void
+     * @param \Cake\ORM\Query $query The query to act upon
+     * @return boolean
      */
     abstract protected function _bulk(Query $query);
 }

--- a/src/Action/Bulk/BaseAction.php
+++ b/src/Action/Bulk/BaseAction.php
@@ -7,6 +7,7 @@ use Cake\ORM\Query;
 use Cake\Utility\Hash;
 use Crud\Error\Exception\ActionNotConfiguredException;
 use Crud\Event\Subject;
+use Crud\Traits\RedirectTrait;
 
 /**
  * Handles 'Bulk' Crud actions
@@ -16,6 +17,8 @@ use Crud\Event\Subject;
  */
 abstract class BaseAction extends BaseAction
 {
+    use RedirectTrait;
+
     /**
      * Default settings for 'lookup' actions
      *

--- a/src/Action/Bulk/BaseAction.php
+++ b/src/Action/Bulk/BaseAction.php
@@ -25,7 +25,7 @@ abstract class BaseAction extends BaseAction
      * @var array
      */
     protected $_defaultConfig = [
-        'enabled' => false,
+        'enabled' => true,
         'scope' => 'table',
         'findMethod' => 'all',
         'actionName' => 'Bulk',

--- a/src/Action/Bulk/BaseAction.php
+++ b/src/Action/Bulk/BaseAction.php
@@ -46,7 +46,7 @@ abstract class BaseAction extends BaseAction
     protected function _handle()
     {
         $ids = $this->_controller()->request->data('id');
-        if (!is_array($data) || !Hash::numeric(array_keys($data))) {
+        if (!is_array($ids) || !Hash::numeric(array_keys($ids))) {
             throw new BadRequestException('Bad request data');
         }
         $ids = array_filter($ids);

--- a/src/Action/Bulk/BaseAction.php
+++ b/src/Action/Bulk/BaseAction.php
@@ -49,7 +49,7 @@ abstract class BaseAction extends CrudBaseAction
     protected function _handle()
     {
         $ids = $this->_processIds();
-        $subject = $this->_findQuery($ids);
+        $subject = $this->_constructSubject($ids);
 
         $event = $this->_trigger('beforeBulk', $subject);
         if ($event->isStopped()) {
@@ -100,7 +100,7 @@ abstract class BaseAction extends CrudBaseAction
      * @param array $ids An array of ids to retrieve
      * @return \Cake\Event\Subject
      */
-    protected function _findQuery(array $ids)
+    protected function _constructSubject(array $ids)
     {
         $repository = $this->_table();
 

--- a/src/Action/Bulk/BaseAction.php
+++ b/src/Action/Bulk/BaseAction.php
@@ -47,9 +47,23 @@ abstract class BaseAction extends CrudBaseAction
     protected function _handle()
     {
         $ids = $this->_controller()->request->data('id');
+
+        $all = false;
+        if (is_array($ids)) {
+            $all = Hash::get((array)$ids, '_all', false);
+            unset($ids['_all']);
+        }
+
         if (!is_array($ids) || !Hash::numeric(array_keys($ids))) {
             throw new BadRequestException('Bad request data');
         }
+
+        if ($all) {
+            foreach ($ids as $key => $value) {
+                $ids[$key] = 1;
+            }
+        }
+
         $ids = array_filter($ids);
 
         $subject = $this->_subject();

--- a/src/Action/Bulk/BaseAction.php
+++ b/src/Action/Bulk/BaseAction.php
@@ -130,6 +130,7 @@ abstract class BaseAction extends CrudBaseAction
 
         $ids = $ids;
         $primaryKey = $this->_table()->primaryKey();
+        $config['conditions'] = [];
         $config['conditions'][] = function ($exp) use ($primaryKey, $ids) {
             return $exp->in($primaryKey, $ids);
         };

--- a/src/Action/Bulk/BaseAction.php
+++ b/src/Action/Bulk/BaseAction.php
@@ -26,7 +26,7 @@ abstract class BaseAction extends CrudBaseAction
      */
     protected $_defaultConfig = [
         'enabled' => true,
-        'scope' => 'table',
+        'scope' => 'bulk',
         'findMethod' => 'all',
         'actionName' => 'Bulk',
         'messages' => [

--- a/src/Action/Bulk/BaseAction.php
+++ b/src/Action/Bulk/BaseAction.php
@@ -4,8 +4,8 @@ namespace Crud\Action\Bulk;
 use Cake\Event\Event;
 use Cake\Network\Exception\BadRequestException;
 use Cake\ORM\Query;
-use Crud\Action\BaseAction as CrudBaseAction;
 use Cake\Utility\Hash;
+use Crud\Action\BaseAction as CrudBaseAction;
 use Crud\Event\Subject;
 use Crud\Traits\RedirectTrait;
 

--- a/src/Action/Bulk/BaseAction.php
+++ b/src/Action/Bulk/BaseAction.php
@@ -2,7 +2,7 @@
 namespace Crud\Action\Bulk;
 
 use Cake\Event\Event;
-use Cake\Network\Exception\NotImplementedException;
+use Cake\Network\Exception\BadRequestException;
 use Cake\ORM\Query;
 use Cake\Utility\Hash;
 use Crud\Error\Exception\ActionNotConfiguredException;

--- a/src/Action/Bulk/BaseAction.php
+++ b/src/Action/Bulk/BaseAction.php
@@ -1,5 +1,5 @@
 <?php
-namespace Crud\Action;
+namespace Crud\Action\Bulk;
 
 use Cake\Event\Event;
 use Cake\Network\Exception\NotImplementedException;
@@ -14,7 +14,7 @@ use Crud\Event\Subject;
  * Licensed under The MIT License
  * For full copyright and license information, please see the LICENSE.txt
  */
-abstract class BulkAction extends BaseAction
+abstract class BaseAction extends BaseAction
 {
     /**
      * Default settings for 'lookup' actions

--- a/src/Action/Bulk/DeleteAction.php
+++ b/src/Action/Bulk/DeleteAction.php
@@ -21,7 +21,6 @@ class DeleteAction extends BaseAction
      */
     public function __construct(Controller $Controller, $config = [])
     {
-        $this->_defaultConfig['actionName'] = 'Delete';
         $this->_defaultConfig['messages'] = [
             'success' => [
                 'text' => 'Delete completed successfully'

--- a/src/Action/Bulk/DeleteAction.php
+++ b/src/Action/Bulk/DeleteAction.php
@@ -30,7 +30,7 @@ class DeleteAction extends BaseAction
                 'text' => 'Could not complete deletion'
             ]
         ];
-        return parent::__construct($controller, $config);
+        return parent::__construct($Controller, $config);
     }
 
     /**

--- a/src/Action/Bulk/DeleteAction.php
+++ b/src/Action/Bulk/DeleteAction.php
@@ -1,0 +1,49 @@
+<?php
+namespace Crud\Action\Bulk;
+
+use Cake\Controller\Controller;
+use Cake\ORM\Query;
+
+/**
+ * Handles Bulk 'Delete' Crud actions
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ */
+class DeleteAction extends BaseAction
+{
+    /**
+     * Constructor
+     *
+     * @param \Cake\Controller\Controller $Controller Controller instance
+     * @param array $config Default settings
+     * @return void
+     */
+    public function __construct(Controller $Controller, $config = [])
+    {
+        $this->_defaultConfig['actionName'] = 'Delete';
+        $this->_defaultConfig['messages'] = [
+            'success' => [
+                'text' => 'Delete completed successfully'
+            ],
+            'error' => [
+                'text' => 'Could not complete deletion'
+            ]
+        ];
+        return parent::__construct($controller, $config);
+    }
+
+    /**
+     * Handle a bulk delete
+     *
+     * @param \Cake\ORM\Query $query The query to act upon
+     * @return boolean
+     */
+    protected function _bulk(Query $query = null)
+    {
+        $query = $this->query()->delete();
+        $statement = $query->execute();
+        $statement->closeCursor();
+        return $statement->rowCount();
+    }
+}

--- a/src/Action/Bulk/DeleteAction.php
+++ b/src/Action/Bulk/DeleteAction.php
@@ -41,7 +41,7 @@ class DeleteAction extends BaseAction
      */
     protected function _bulk(Query $query = null)
     {
-        $query = $this->query()->delete();
+        $query = $query->delete();
         $statement = $query->execute();
         $statement->closeCursor();
         return $statement->rowCount();

--- a/src/Action/Bulk/DeleteAction.php
+++ b/src/Action/Bulk/DeleteAction.php
@@ -37,7 +37,7 @@ class DeleteAction extends BaseAction
      * Handle a bulk delete
      *
      * @param \Cake\ORM\Query $query The query to act upon
-     * @return boolean
+     * @return bool
      */
     protected function _bulk(Query $query = null)
     {

--- a/src/Action/Bulk/SetValueAction.php
+++ b/src/Action/Bulk/SetValueAction.php
@@ -33,7 +33,7 @@ class SetValueAction extends BaseAction
             ]
         ];
         $this->_defaultConfig['value'] = null;
-        return parent::__construct($controller, $config);
+        return parent::__construct($Controller, $config);
     }
 
     /**

--- a/src/Action/Bulk/SetValueAction.php
+++ b/src/Action/Bulk/SetValueAction.php
@@ -3,8 +3,8 @@ namespace Crud\Action\Bulk;
 
 use Cake\Controller\Controller;
 use Cake\Database\Expression\QueryExpression;
-use Crud\Error\Exception\ActionNotConfiguredException;
 use Cake\ORM\Query;
+use Crud\Error\Exception\ActionNotConfiguredException;
 
 /**
  * Handles Bulk 'SetValue' Crud actions

--- a/src/Action/Bulk/SetValueAction.php
+++ b/src/Action/Bulk/SetValueAction.php
@@ -1,0 +1,69 @@
+<?php
+namespace Crud\Action\Bulk;
+
+use Cake\Controller\Controller;
+use Cake\Database\Expression\QueryExpression;
+use Crud\Error\Exception\ActionNotConfiguredException;
+use Cake\ORM\Query;
+
+/**
+ * Handles Bulk 'SetValue' Crud actions
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ */
+class SetValueAction extends BaseAction
+{
+    /**
+     * Constructor
+     *
+     * @param \Cake\Controller\Controller $Controller Controller instance
+     * @param array $config Default settings
+     * @return void
+     */
+    public function __construct(Controller $Controller, $config = [])
+    {
+        $this->_defaultConfig['actionName'] = 'SetValue';
+        $this->_defaultConfig['messages'] = [
+            'success' => [
+                'text' => 'Set value successfully'
+            ],
+            'error' => [
+                'text' => 'Could not set value'
+            ]
+        ];
+        $this->_defaultConfig['value'] = null;
+        return parent::__construct($controller, $config);
+    }
+
+    /**
+     * Handle a bulk event
+     *
+     * @return \Cake\Network\Response
+     */
+    protected function _handle()
+    {
+        $field = $this->config('field');
+        if (empty($field)) {
+            throw new ActionNotConfiguredException('No field value specified');
+        }
+
+        return parent::_handle();
+    }
+
+    /**
+     * Handle a bulk value set
+     *
+     * @param \Cake\ORM\Query $query The query to act upon
+     * @return boolean
+     */
+    protected function _bulk(Query $query = null)
+    {
+        $field = $this->config('field');
+        $value = $this->config('value');
+        $query->update()->set([$field => $value]);
+        $statement = $query->execute();
+        $statement->closeCursor();
+        return $statement->rowCount();
+    }
+}

--- a/src/Action/Bulk/SetValueAction.php
+++ b/src/Action/Bulk/SetValueAction.php
@@ -55,7 +55,7 @@ class SetValueAction extends BaseAction
      * Handle a bulk value set
      *
      * @param \Cake\ORM\Query $query The query to act upon
-     * @return boolean
+     * @return bool
      */
     protected function _bulk(Query $query = null)
     {

--- a/src/Action/Bulk/SetValueAction.php
+++ b/src/Action/Bulk/SetValueAction.php
@@ -23,7 +23,6 @@ class SetValueAction extends BaseAction
      */
     public function __construct(Controller $Controller, $config = [])
     {
-        $this->_defaultConfig['actionName'] = 'SetValue';
         $this->_defaultConfig['messages'] = [
             'success' => [
                 'text' => 'Set value successfully'

--- a/src/Action/Bulk/ToggleAction.php
+++ b/src/Action/Bulk/ToggleAction.php
@@ -58,7 +58,7 @@ class ToggleAction extends BaseAction
     protected function _bulk(Query $query = null)
     {
         $field = $this->config('field');
-        $expression = [new QueryExpression(sprintf('%s = NOT %s', $field))];
+        $expression = [new QueryExpression(sprintf('%1$s= NOT %1$s', $field))];
         $query->update()->set($expression);
         $statement = $query->execute();
         $statement->closeCursor();

--- a/src/Action/Bulk/ToggleAction.php
+++ b/src/Action/Bulk/ToggleAction.php
@@ -3,7 +3,7 @@ namespace Crud\Action\Bulk;
 
 use Cake\Controller\Controller;
 use Cake\Database\Expression\QueryExpression;
-use Cake\Network\Exception\NotImplementedException;
+use Crud\Error\Exception\ActionNotConfiguredException;
 use Cake\ORM\Query;
 
 /**
@@ -45,7 +45,7 @@ class ToggleAction extends BaseAction
     {
         $field = $this->config('field');
         if (empty($field)) {
-            throw new NotImplementedException('No field value specified');
+            throw new ActionNotConfiguredException('No field value specified');
         }
 
         return parent::_handle();

--- a/src/Action/Bulk/ToggleAction.php
+++ b/src/Action/Bulk/ToggleAction.php
@@ -3,8 +3,8 @@ namespace Crud\Action\Bulk;
 
 use Cake\Controller\Controller;
 use Cake\Database\Expression\QueryExpression;
-use Crud\Error\Exception\ActionNotConfiguredException;
 use Cake\ORM\Query;
+use Crud\Error\Exception\ActionNotConfiguredException;
 
 /**
  * Handles Bulk 'Toggle' Crud actions
@@ -54,7 +54,7 @@ class ToggleAction extends BaseAction
      * Handle a bulk toggle
      *
      * @param \Cake\ORM\Query $query The query to act upon
-     * @return boolean
+     * @return bool
      */
     protected function _bulk(Query $query = null)
     {

--- a/src/Action/Bulk/ToggleAction.php
+++ b/src/Action/Bulk/ToggleAction.php
@@ -1,0 +1,68 @@
+<?php
+namespace Crud\Action\Bulk;
+
+use Cake\Controller\Controller;
+use Cake\Database\Expression\QueryExpression;
+use Cake\Network\Exception\NotImplementedException;
+use Cake\ORM\Query;
+
+/**
+ * Handles Bulk 'Toggle' Crud actions
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ */
+class ToggleAction extends BaseAction
+{
+    /**
+     * Constructor
+     *
+     * @param \Cake\Controller\Controller $Controller Controller instance
+     * @param array $config Default settings
+     * @return void
+     */
+    public function __construct(Controller $Controller, $config = [])
+    {
+        $this->_defaultConfig['actionName'] = 'Toggle';
+        $this->_defaultConfig['messages'] = [
+            'success' => [
+                'text' => 'Value toggled successfully'
+            ],
+            'error' => [
+                'text' => 'Could not toggle value'
+            ]
+        ];
+        return parent::__construct($controller, $config);
+    }
+
+    /**
+     * Handle a bulk event
+     *
+     * @return \Cake\Network\Response
+     */
+    protected function _handle()
+    {
+        $field = $this->config('field');
+        if (empty($field)) {
+            throw new NotImplementedException('No field value specified');
+        }
+
+        return parent::_handle();
+    }
+
+    /**
+     * Handle a bulk toggle
+     *
+     * @param \Cake\ORM\Query $query The query to act upon
+     * @return boolean
+     */
+    protected function _bulk(Query $query = null)
+    {
+        $field = $this->config('field');
+        $expression = new QueryExpression(sprintf('%s = NOT %s', $field));
+        $query->update()->set([$expression]);
+        $statement = $query->execute();
+        $statement->closeCursor();
+        return $statement->rowCount();
+    }
+}

--- a/src/Action/Bulk/ToggleAction.php
+++ b/src/Action/Bulk/ToggleAction.php
@@ -32,6 +32,7 @@ class ToggleAction extends BaseAction
                 'text' => 'Could not toggle value'
             ]
         ];
+        $this->_defaultConfig['value'] = null;
         return parent::__construct($controller, $config);
     }
 
@@ -58,9 +59,12 @@ class ToggleAction extends BaseAction
      */
     protected function _bulk(Query $query = null)
     {
-        $field = $this->config('field');
-        $expression = new QueryExpression(sprintf('%s = NOT %s', $field));
-        $query->update()->set([$expression]);
+        $value = $this->config('value');
+        $expression = [$field => $value];
+        if ($value === null) {
+            $expression = [new QueryExpression(sprintf('%s = NOT %s', $field))];
+        }
+        $query->update()->set($expression);
         $statement = $query->execute();
         $statement->closeCursor();
         return $statement->rowCount();

--- a/src/Action/Bulk/ToggleAction.php
+++ b/src/Action/Bulk/ToggleAction.php
@@ -32,7 +32,6 @@ class ToggleAction extends BaseAction
                 'text' => 'Could not toggle value'
             ]
         ];
-        $this->_defaultConfig['value'] = null;
         return parent::__construct($controller, $config);
     }
 
@@ -59,11 +58,8 @@ class ToggleAction extends BaseAction
      */
     protected function _bulk(Query $query = null)
     {
-        $value = $this->config('value');
-        $expression = [$field => $value];
-        if ($value === null) {
-            $expression = [new QueryExpression(sprintf('%s = NOT %s', $field))];
-        }
+        $field = $this->config('field');
+        $expression = [new QueryExpression(sprintf('%s = NOT %s', $field))];
         $query->update()->set($expression);
         $statement = $query->execute();
         $statement->closeCursor();

--- a/src/Action/Bulk/ToggleAction.php
+++ b/src/Action/Bulk/ToggleAction.php
@@ -23,7 +23,6 @@ class ToggleAction extends BaseAction
      */
     public function __construct(Controller $Controller, $config = [])
     {
-        $this->_defaultConfig['actionName'] = 'Toggle';
         $this->_defaultConfig['messages'] = [
             'success' => [
                 'text' => 'Value toggled successfully'

--- a/src/Action/Bulk/ToggleAction.php
+++ b/src/Action/Bulk/ToggleAction.php
@@ -32,7 +32,7 @@ class ToggleAction extends BaseAction
                 'text' => 'Could not toggle value'
             ]
         ];
-        return parent::__construct($controller, $config);
+        return parent::__construct($Controller, $config);
     }
 
     /**

--- a/src/Action/BulkAction.php
+++ b/src/Action/BulkAction.php
@@ -1,0 +1,90 @@
+<?php
+namespace Crud\Action;
+
+use Cake\Network\Exception\NotImplementedException;
+use Cake\Event\Event;
+use Cake\ORM\Query;
+use Crud\Event\Subject;
+use Crud\Error\Exception\ActionNotConfiguredException;
+
+/**
+ * Handles 'Bulk' Crud actions
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ */
+abstract class BulkAction extends BaseAction
+{
+    /**
+     * Default settings for 'lookup' actions
+     *
+     * @var array
+     */
+    protected $_defaultConfig = [
+        'enabled' => false,
+        'scope' => 'table',
+        'findMethod' => 'all'
+    ];
+
+    /**
+     * Handle a bulk event
+     *
+     * @return void
+     */
+    protected function _handle()
+    {
+        if (!method_exists($this, '_bulk')) {
+            throw new NotImplementedException(sprintf(
+                'Action %s does not implement a _bulk handler',
+                get_class($this)
+            ));
+        }
+
+        $ids = $this->_controller()->request->data('id');
+        $ids = array_filter($ids);
+
+        $subject = $this->_subject();
+        $subject->set(['ids' => $ids]);
+
+        $this->_trigger('beforeBulkFind', $subject);
+        $query = $this->_table()->find($this->config('findMethod'), $this->_getFindConfig($subject));
+        $subject->set(['query' => $query]);
+
+        $this->_trigger('afterBulkFind', $subject);
+
+        $this->_bulk($query);
+    }
+
+    /**
+     * Get the query configuration
+     *
+     * @return array
+     */
+    protected function _getFindConfig(Subject $subject)
+    {
+        $config = (array)$this->config('findConfig');
+        if (!empty($config)) {
+            return $config;
+        }
+
+        $alias = $this->_table()->alias();
+        $primaryKey = $this->_table()->primaryKey();
+        if (is_array($primaryKey)) {
+            $name = $this->config('action');
+            throw new ActionNotConfiguredException(sprintf('Action "%s" does not have a proper findConfig', $name));
+        }
+
+        $config['conditions'] = [
+            "{$alias}.{$primaryKey}" => $subject->ids,
+        ];
+
+        return $config;
+    }
+
+    /**
+     * Handle a bulk event
+     *
+     * @return void
+     */
+    abstract protected function _bulk(Query $query);
+}

--- a/src/Action/BulkAction.php
+++ b/src/Action/BulkAction.php
@@ -4,6 +4,7 @@ namespace Crud\Action;
 use Cake\Event\Event;
 use Cake\Network\Exception\NotImplementedException;
 use Cake\ORM\Query;
+use Cake\Utility\Hash;
 use Crud\Error\Exception\ActionNotConfiguredException;
 use Crud\Event\Subject;
 
@@ -34,6 +35,9 @@ abstract class BulkAction extends BaseAction
     protected function _handle()
     {
         $ids = $this->_controller()->request->data('id');
+        if (!is_array($data) || !Hash::numeric(array_keys($data))) {
+            throw new BadRequestException('Bad request data');
+        }
         $ids = array_filter($ids);
 
         $subject = $this->_subject();

--- a/src/Action/BulkAction.php
+++ b/src/Action/BulkAction.php
@@ -49,7 +49,13 @@ abstract class BulkAction extends BaseAction
 
         $this->_trigger('afterBulkFind', $subject);
 
-        $this->_bulk($query);
+        if ($this->_bulk($query)) {
+            $this->_success($subject);
+        } else {
+            $this->_error($subject);
+        }
+
+        return $this->_redirect($subject, ['action' => 'index']);
     }
 
     /**

--- a/src/Action/BulkAction.php
+++ b/src/Action/BulkAction.php
@@ -1,11 +1,11 @@
 <?php
 namespace Crud\Action;
 
-use Cake\Network\Exception\NotImplementedException;
 use Cake\Event\Event;
+use Cake\Network\Exception\NotImplementedException;
 use Cake\ORM\Query;
-use Crud\Event\Subject;
 use Crud\Error\Exception\ActionNotConfiguredException;
+use Crud\Event\Subject;
 
 /**
  * Handles 'Bulk' Crud actions

--- a/src/Action/BulkAction.php
+++ b/src/Action/BulkAction.php
@@ -33,13 +33,6 @@ abstract class BulkAction extends BaseAction
      */
     protected function _handle()
     {
-        if (!method_exists($this, '_bulk')) {
-            throw new NotImplementedException(sprintf(
-                'Action %s does not implement a _bulk handler',
-                get_class($this)
-            ));
-        }
-
         $ids = $this->_controller()->request->data('id');
         $ids = array_filter($ids);
 

--- a/src/Action/BulkAction.php
+++ b/src/Action/BulkAction.php
@@ -68,7 +68,7 @@ abstract class BulkAction extends BaseAction
         }
 
         $config['conditions'] = [
-            "{$alias}.{$primaryKey}" => $subject->ids,
+            "{$alias}.{$primaryKey} IN" => $subject->ids,
         ];
 
         return $config;

--- a/src/Action/BulkAction.php
+++ b/src/Action/BulkAction.php
@@ -25,6 +25,7 @@ abstract class BulkAction extends BaseAction
         'enabled' => false,
         'scope' => 'table',
         'findMethod' => 'all',
+        'actionName' => 'Bulk',
         'messages' => [
             'success' => [
                 'text' => 'Bulk action successfully completed'
@@ -51,13 +52,15 @@ abstract class BulkAction extends BaseAction
         $subject = $this->_subject();
         $subject->set(['ids' => $ids]);
 
-        $this->_trigger('beforeBulkFind', $subject);
+        $actionName = $this->config('actionName');
+
+        $this->_trigger(sprintf('before%sFind', $actionName), $subject);
         $query = $this->_table()->find($this->config('findMethod'), $this->_getFindConfig($subject));
         $subject->set(['query' => $query]);
 
-        $this->_trigger('afterBulkFind', $subject);
+        $this->_trigger(sprintf('after%sFind', $actionName), $subject);
 
-        $event = $this->_trigger('beforeBulk', $subject);
+        $event = $this->_trigger(sprintf('before%s', $actionName), $subject);
         if ($event->isStopped()) {
             return $this->_stopped($subject);
         }
@@ -100,8 +103,9 @@ abstract class BulkAction extends BaseAction
      */
     protected function _success(Subject $subject)
     {
+        $actionName = $this->config('actionName');
         $subject->set(['success' => true]);
-        $this->_trigger('afterBulk', $subject);
+        $this->_trigger(sprintf('after%s', $actionName), $subject);
 
         $this->setFlash('success', $subject);
     }
@@ -114,8 +118,9 @@ abstract class BulkAction extends BaseAction
      */
     protected function _error(Subject $subject)
     {
+        $actionName = $this->config('actionName');
         $subject->set(['success' => false]);
-        $this->_trigger('afterBulk', $subject);
+        $this->_trigger(sprintf('after%s', $actionName), $subject);
 
         $this->setFlash('error', $subject);
     }

--- a/src/Action/BulkAction.php
+++ b/src/Action/BulkAction.php
@@ -60,16 +60,11 @@ abstract class BulkAction extends BaseAction
             return $config;
         }
 
-        $alias = $this->_table()->alias();
+        $ids = $subject->ids;
         $primaryKey = $this->_table()->primaryKey();
-        if (is_array($primaryKey)) {
-            $name = $this->config('action');
-            throw new ActionNotConfiguredException(sprintf('Action "%s" does not have a proper findConfig', $name));
-        }
-
-        $config['conditions'] = [
-            "{$alias}.{$primaryKey} IN" => $subject->ids,
-        ];
+        $config['conditions'][] = function ($exp) use ($primaryKey, $ids) {
+            return $exp->in($primaryKey, $ids);
+        };
 
         return $config;
     }

--- a/src/Action/IndexAction.php
+++ b/src/Action/IndexAction.php
@@ -46,10 +46,10 @@ class IndexAction extends BaseAction
      */
     protected function _handle()
     {
-        $subject = $this->_subject(['success' => true, 'object' => null]);
+        $subject = $this->_subject(['success' => true, 'query' => null]);
 
         $this->_trigger('beforePaginate', $subject);
-        $items = $this->_controller()->paginate($subject->object);
+        $items = $this->_controller()->paginate($subject->query);
         $subject->set(['entities' => $items]);
 
         $this->_trigger('afterPaginate', $subject);

--- a/tests/App/Controller/BlogsController.php
+++ b/tests/App/Controller/BlogsController.php
@@ -24,6 +24,10 @@ class BlogsController extends Controller
                 'deleteAll' => [
                     'className' => 'Crud.Bulk/Delete',
                 ],
+                'toggleActiveAll' => [
+                    'className' => 'Crud.Bulk/Toggle',
+                    'field' => 'is_active',
+                ],
             ],
             'listeners' => [
                 'Crud.Api',

--- a/tests/App/Controller/BlogsController.php
+++ b/tests/App/Controller/BlogsController.php
@@ -28,6 +28,11 @@ class BlogsController extends Controller
                     'className' => 'Crud.Bulk/Toggle',
                     'field' => 'is_active',
                 ],
+                'activateAll' => [
+                    'className' => 'Crud.Bulk/SetValue',
+                    'field' => 'is_active',
+                    'value' => true,
+                ],
             ],
             'listeners' => [
                 'Crud.Api',

--- a/tests/App/Controller/BlogsController.php
+++ b/tests/App/Controller/BlogsController.php
@@ -28,10 +28,10 @@ class BlogsController extends Controller
                     'className' => 'Crud.Bulk/Toggle',
                     'field' => 'is_active',
                 ],
-                'activateAll' => [
+                'deactivateAll' => [
                     'className' => 'Crud.Bulk/SetValue',
                     'field' => 'is_active',
-                    'value' => 1,
+                    'value' => false,
                 ],
             ],
             'listeners' => [

--- a/tests/App/Controller/BlogsController.php
+++ b/tests/App/Controller/BlogsController.php
@@ -20,7 +20,10 @@ class BlogsController extends Controller
                 'Crud.Add',
                 'Crud.Edit',
                 'Crud.View',
-                'Crud.Delete'
+                'Crud.Delete',
+                'deleteAll' => [
+                    'className' => 'Crud.Bulk/Delete',
+                ],
             ],
             'listeners' => [
                 'Crud.Api',

--- a/tests/App/Controller/BlogsController.php
+++ b/tests/App/Controller/BlogsController.php
@@ -31,7 +31,7 @@ class BlogsController extends Controller
                 'activateAll' => [
                     'className' => 'Crud.Bulk/SetValue',
                     'field' => 'is_active',
-                    'value' => true,
+                    'value' => 1,
                 ],
             ],
             'listeners' => [

--- a/tests/TestCase/Action/Bulk/DeleteActionTest.php
+++ b/tests/TestCase/Action/Bulk/DeleteActionTest.php
@@ -1,0 +1,134 @@
+<?php
+namespace Crud\Test\TestCase\Action\Bulk;
+
+use Cake\Routing\DispatcherFactory;
+use Cake\Routing\Router;
+use Crud\TestSuite\IntegrationTestCase;
+
+/**
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ */
+class DeleteActionTest extends IntegrationTestCase
+{
+
+    /**
+     * fixtures property
+     *
+     * @var array
+     */
+    public $fixtures = ['plugin.crud.blogs'];
+
+    /**
+     * Table class to mock on
+     *
+     * @var string
+     */
+    public $tableClass = 'Crud\Test\App\Model\Table\BlogsTable';
+
+    /**
+     * Data provider with all HTTP verbs
+     *
+     * @return array
+     */
+    public function allHttpMethodProvider()
+    {
+        return [
+            ['post'],
+            ['put'],
+        ];
+    }
+
+    /**
+     * Test the normal HTTP flow for all HTTP verbs
+     *
+     * @dataProvider allHttpMethodProvider
+     * @return void
+     */
+    public function testAllRequestMethods($method)
+    {
+        $this->_eventManager->attach(
+            function ($event) {
+                $this->_controller->Flash = $this->getMock(
+                    'Cake\Controller\Component\Flash',
+                    ['set']
+                );
+
+                $this->_controller->Flash
+                    ->expects($this->once())
+                    ->method('set')
+                    ->with(
+                        'Delete completed successfully',
+                        [
+                            'element' => 'default',
+                            'params' => ['class' => 'message success', 'original' => 'Delete completed successfully'],
+                            'key' => 'flash'
+                        ]
+                    );
+
+                $this->_subscribeToEvents($this->_controller);
+            },
+            'Dispatcher.beforeDispatch',
+            ['priority' => 1000]
+        );
+
+        $this->{$method}('/blogs/deleteAll', [
+            'id' => [
+                1 => 1,
+                2 => 2,
+            ],
+        ]);
+
+        $this->assertEvents(['beforeBulk', 'afterBulk', 'setFlash', 'beforeRedirect']);
+        $this->assertTrue($this->_subject->success);
+        $this->assertRedirect('/blogs');
+    }
+
+    /**
+     * Test the flow when the beforeDelete event is stopped
+     *
+     * @return void
+     */
+    public function testStopDelete()
+    {
+        $this->_eventManager->attach(
+            function ($event) {
+                $this->_controller->Flash = $this->getMock(
+                    'Cake\Controller\Component\Flash',
+                    ['set']
+                );
+
+                $this->_controller->Flash
+                    ->expects($this->once())
+                    ->method('set')
+                    ->with(
+                        'Could not complete deletion',
+                        [
+                            'element' => 'default',
+                            'params' => ['class' => 'message error', 'original' => 'Could not complete deletion'],
+                            'key' => 'flash'
+                        ]
+                    );
+
+                $this->_subscribeToEvents($this->_controller);
+
+                $this->_controller->Crud->on('beforeBulk', function ($event) {
+                    $event->stopPropagation();
+                });
+            },
+            'Dispatcher.beforeDispatch',
+            ['priority' => 1000]
+        );
+
+        $this->post('/blogs/deleteAll', [
+            'id' => [
+                1 => 1,
+                2 => 2,
+            ],
+        ]);
+
+        $this->assertEvents(['beforeBulk', 'setFlash', 'beforeRedirect']);
+        $this->assertFalse($this->_subject->success);
+        $this->assertRedirect('/blogs');
+    }
+}

--- a/tests/TestCase/Action/Bulk/DeleteActionTest.php
+++ b/tests/TestCase/Action/Bulk/DeleteActionTest.php
@@ -85,11 +85,11 @@ class DeleteActionTest extends IntegrationTestCase
     }
 
     /**
-     * Test the flow when the beforeDelete event is stopped
+     * Test the flow when the beforeBulk event is stopped
      *
      * @return void
      */
-    public function testStopDelete()
+    public function testStopBeforeBulk()
     {
         $this->_eventManager->attach(
             function ($event) {

--- a/tests/TestCase/Action/Bulk/SetValueActionTest.php
+++ b/tests/TestCase/Action/Bulk/SetValueActionTest.php
@@ -85,11 +85,11 @@ class SetValueActionTest extends IntegrationTestCase
     }
 
     /**
-     * Test the flow when the beforeDelete event is stopped
+     * Test the flow when the beforeSetValue event is stopped
      *
      * @return void
      */
-    public function testStopDelete()
+    public function testStopSetValue()
     {
         $this->_eventManager->attach(
             function ($event) {

--- a/tests/TestCase/Action/Bulk/SetValueActionTest.php
+++ b/tests/TestCase/Action/Bulk/SetValueActionTest.php
@@ -1,0 +1,134 @@
+<?php
+namespace Crud\Test\TestCase\Action\Bulk;
+
+use Cake\Routing\DispatcherFactory;
+use Cake\Routing\Router;
+use Crud\TestSuite\IntegrationTestCase;
+
+/**
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ */
+class SetValueActionTest extends IntegrationTestCase
+{
+
+    /**
+     * fixtures property
+     *
+     * @var array
+     */
+    public $fixtures = ['plugin.crud.blogs'];
+
+    /**
+     * Table class to mock on
+     *
+     * @var string
+     */
+    public $tableClass = 'Crud\Test\App\Model\Table\BlogsTable';
+
+    /**
+     * Data provider with all HTTP verbs
+     *
+     * @return array
+     */
+    public function allHttpMethodProvider()
+    {
+        return [
+            ['post'],
+            ['put'],
+        ];
+    }
+
+    /**
+     * Test the normal HTTP flow for all HTTP verbs
+     *
+     * @dataProvider allHttpMethodProvider
+     * @return void
+     */
+    public function testAllRequestMethods($method)
+    {
+        $this->_eventManager->attach(
+            function ($event) {
+                $this->_controller->Flash = $this->getMock(
+                    'Cake\Controller\Component\Flash',
+                    ['set']
+                );
+
+                $this->_controller->Flash
+                    ->expects($this->once())
+                    ->method('set')
+                    ->with(
+                        'Set value successfully',
+                        [
+                            'element' => 'default',
+                            'params' => ['class' => 'message success', 'original' => 'Set value successfully'],
+                            'key' => 'flash'
+                        ]
+                    );
+
+                $this->_subscribeToEvents($this->_controller);
+            },
+            'Dispatcher.beforeDispatch',
+            ['priority' => 1000]
+        );
+
+        $this->{$method}('/blogs/activateAll', [
+            'id' => [
+                1 => 1,
+                2 => 2,
+            ],
+        ]);
+
+        $this->assertEvents(['beforeBulk', 'afterBulk', 'setFlash', 'beforeRedirect']);
+        $this->assertTrue($this->_subject->success);
+        $this->assertRedirect('/blogs');
+    }
+
+    /**
+     * Test the flow when the beforeDelete event is stopped
+     *
+     * @return void
+     */
+    public function testStopDelete()
+    {
+        $this->_eventManager->attach(
+            function ($event) {
+                $this->_controller->Flash = $this->getMock(
+                    'Cake\Controller\Component\Flash',
+                    ['set']
+                );
+
+                $this->_controller->Flash
+                    ->expects($this->once())
+                    ->method('set')
+                    ->with(
+                        'Could not set value',
+                        [
+                            'element' => 'default',
+                            'params' => ['class' => 'message error', 'original' => 'Could not set value'],
+                            'key' => 'flash'
+                        ]
+                    );
+
+                $this->_subscribeToEvents($this->_controller);
+
+                $this->_controller->Crud->on('beforeBulk', function ($event) {
+                    $event->stopPropagation();
+                });
+            },
+            'Dispatcher.beforeDispatch',
+            ['priority' => 1000]
+        );
+
+        $this->post('/blogs/activateAll', [
+            'id' => [
+                1 => 1,
+                2 => 2,
+            ],
+        ]);
+
+        $this->assertEvents(['beforeBulk', 'setFlash', 'beforeRedirect']);
+        $this->assertFalse($this->_subject->success);
+        $this->assertRedirect('/blogs');
+    }
+}

--- a/tests/TestCase/Action/Bulk/SetValueActionTest.php
+++ b/tests/TestCase/Action/Bulk/SetValueActionTest.php
@@ -85,11 +85,11 @@ class SetValueActionTest extends IntegrationTestCase
     }
 
     /**
-     * Test the flow when the beforeSetValue event is stopped
+     * Test the flow when the beforeBulk event is stopped
      *
      * @return void
      */
-    public function testStopSetValue()
+    public function testStopBeforeBulk()
     {
         $this->_eventManager->attach(
             function ($event) {

--- a/tests/TestCase/Action/Bulk/SetValueActionTest.php
+++ b/tests/TestCase/Action/Bulk/SetValueActionTest.php
@@ -72,7 +72,7 @@ class SetValueActionTest extends IntegrationTestCase
             ['priority' => 1000]
         );
 
-        $this->{$method}('/blogs/activateAll', [
+        $this->{$method}('/blogs/deactivateAll', [
             'id' => [
                 1 => 1,
                 2 => 2,
@@ -120,7 +120,7 @@ class SetValueActionTest extends IntegrationTestCase
             ['priority' => 1000]
         );
 
-        $this->post('/blogs/activateAll', [
+        $this->post('/blogs/deactivateAll', [
             'id' => [
                 1 => 1,
                 2 => 2,

--- a/tests/TestCase/Action/Bulk/ToggleActionTest.php
+++ b/tests/TestCase/Action/Bulk/ToggleActionTest.php
@@ -1,0 +1,134 @@
+<?php
+namespace Crud\Test\TestCase\Action\Bulk;
+
+use Cake\Routing\DispatcherFactory;
+use Cake\Routing\Router;
+use Crud\TestSuite\IntegrationTestCase;
+
+/**
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ */
+class ToggleActionTest extends IntegrationTestCase
+{
+
+    /**
+     * fixtures property
+     *
+     * @var array
+     */
+    public $fixtures = ['plugin.crud.blogs'];
+
+    /**
+     * Table class to mock on
+     *
+     * @var string
+     */
+    public $tableClass = 'Crud\Test\App\Model\Table\BlogsTable';
+
+    /**
+     * Data provider with all HTTP verbs
+     *
+     * @return array
+     */
+    public function allHttpMethodProvider()
+    {
+        return [
+            ['post'],
+            ['put'],
+        ];
+    }
+
+    /**
+     * Test the normal HTTP flow for all HTTP verbs
+     *
+     * @dataProvider allHttpMethodProvider
+     * @return void
+     */
+    public function testAllRequestMethods($method)
+    {
+        $this->_eventManager->attach(
+            function ($event) {
+                $this->_controller->Flash = $this->getMock(
+                    'Cake\Controller\Component\Flash',
+                    ['set']
+                );
+
+                $this->_controller->Flash
+                    ->expects($this->once())
+                    ->method('set')
+                    ->with(
+                        'Value toggled successfully',
+                        [
+                            'element' => 'default',
+                            'params' => ['class' => 'message success', 'original' => 'Value toggled successfully'],
+                            'key' => 'flash'
+                        ]
+                    );
+
+                $this->_subscribeToEvents($this->_controller);
+            },
+            'Dispatcher.beforeDispatch',
+            ['priority' => 1000]
+        );
+
+        $this->{$method}('/blogs/toggleActiveAll', [
+            'id' => [
+                1 => 1,
+                2 => 2,
+            ],
+        ]);
+
+        $this->assertEvents(['beforeBulk', 'afterBulk', 'setFlash', 'beforeRedirect']);
+        $this->assertTrue($this->_subject->success);
+        $this->assertRedirect('/blogs');
+    }
+
+    /**
+     * Test the flow when the beforeDelete event is stopped
+     *
+     * @return void
+     */
+    public function testStopDelete()
+    {
+        $this->_eventManager->attach(
+            function ($event) {
+                $this->_controller->Flash = $this->getMock(
+                    'Cake\Controller\Component\Flash',
+                    ['set']
+                );
+
+                $this->_controller->Flash
+                    ->expects($this->once())
+                    ->method('set')
+                    ->with(
+                        'Could not toggle value',
+                        [
+                            'element' => 'default',
+                            'params' => ['class' => 'message error', 'original' => 'Could not toggle value'],
+                            'key' => 'flash'
+                        ]
+                    );
+
+                $this->_subscribeToEvents($this->_controller);
+
+                $this->_controller->Crud->on('beforeBulk', function ($event) {
+                    $event->stopPropagation();
+                });
+            },
+            'Dispatcher.beforeDispatch',
+            ['priority' => 1000]
+        );
+
+        $this->post('/blogs/toggleActiveAll', [
+            'id' => [
+                1 => 1,
+                2 => 2,
+            ],
+        ]);
+
+        $this->assertEvents(['beforeBulk', 'setFlash', 'beforeRedirect']);
+        $this->assertFalse($this->_subject->success);
+        $this->assertRedirect('/blogs');
+    }
+}

--- a/tests/TestCase/Action/Bulk/ToggleActionTest.php
+++ b/tests/TestCase/Action/Bulk/ToggleActionTest.php
@@ -85,11 +85,11 @@ class ToggleActionTest extends IntegrationTestCase
     }
 
     /**
-     * Test the flow when the beforeDelete event is stopped
+     * Test the flow when the beforeToggle event is stopped
      *
      * @return void
      */
-    public function testStopDelete()
+    public function testStopToggle()
     {
         $this->_eventManager->attach(
             function ($event) {

--- a/tests/TestCase/Action/Bulk/ToggleActionTest.php
+++ b/tests/TestCase/Action/Bulk/ToggleActionTest.php
@@ -85,11 +85,11 @@ class ToggleActionTest extends IntegrationTestCase
     }
 
     /**
-     * Test the flow when the beforeToggle event is stopped
+     * Test the flow when the beforeBulk event is stopped
      *
      * @return void
      */
-    public function testStopToggle()
+    public function testStopBeforeBulk()
     {
         $this->_eventManager->attach(
             function ($event) {


### PR DESCRIPTION
This will allow us to implement `_bulk` handlers for actions that occur from `index`-like pages. Any subclass that implements a `_bulk` method will be given a $query object that can be used to reference a set of database objects. The classes can then do whatever they like - such as publish all posts, or delete records.

This sort of method is more useful for admin modules than for apis, but is a common task in application development