### PR TITLE
Replace deprecated eventManager methods

### DIFF
--- a/src/Controller/Component/CrudComponent.php
+++ b/src/Controller/Component/CrudComponent.php
@@ -411,7 +411,7 @@ class CrudComponent extends Component
                 $event = $this->_config['eventPrefix'] . '.' . $event;
             }
 
-            $this->_eventManager->attach($callback, $event, $options);
+            $this->_eventManager->on($event, $options, $callback);
         }
     }
 
@@ -468,7 +468,7 @@ class CrudComponent extends Component
         }
 
         if (isset($this->_listenerInstances[$name])) {
-            $this->_eventManager->detach($this->_listenerInstances[$name]);
+            $this->_eventManager->off($this->_listenerInstances[$name]);
             unset($this->_listenerInstances[$name]);
         }
 
@@ -657,7 +657,7 @@ class CrudComponent extends Component
             unset($config['className']);
             $this->_listenerInstances[$name]->config($config);
 
-            $this->_eventManager->attach($this->_listenerInstances[$name]);
+            $this->_eventManager->on($this->_listenerInstances[$name]);
 
             if (is_callable([$this->_listenerInstances[$name], 'setup'])) {
                 $this->_listenerInstances[$name]->setup();


### PR DESCRIPTION
I've updated the component to use the new `on` and `off` methods as the old ones have been deprecated. As such I've done my best to update the main component test so that it passes.

Although there is what I think is a bug, which I've detailed in #283 

The Action integration tests are also broken due to `assertTag()` having been deprecated. There is a replacement in the works, but the methods have not been ported yet. More information, see https://github.com/phpunit/phpunit-dom-assertions/issues/3