### PR TITLE
Improvements and fixes

### DIFF
--- a/src/Action/IndexAction.php
+++ b/src/Action/IndexAction.php
@@ -46,10 +46,11 @@ class IndexAction extends BaseAction
      */
     protected function _handle()
     {
-        $subject = $this->_subject(['success' => true, 'object' => null]);
+        $query = $this->_table()->find();
+        $subject = $this->_subject(['success' => true, 'query' => $query]);
 
         $this->_trigger('beforePaginate', $subject);
-        $items = $this->_controller()->paginate($subject->object);
+        $items = $this->_controller()->paginate($subject->query);
         $subject->set(['entities' => $items]);
 
         $this->_trigger('afterPaginate', $subject);

--- a/src/Action/IndexAction.php
+++ b/src/Action/IndexAction.php
@@ -46,10 +46,10 @@ class IndexAction extends BaseAction
      */
     protected function _handle()
     {
-        $subject = $this->_subject(['success' => true, 'query' => null]);
+        $subject = $this->_subject(['success' => true, 'object' => null]);
 
         $this->_trigger('beforePaginate', $subject);
-        $items = $this->_controller()->paginate($subject->query);
+        $items = $this->_controller()->paginate($subject->object);
         $subject->set(['entities' => $items]);
 
         $this->_trigger('afterPaginate', $subject);

--- a/src/Action/LookupAction.php
+++ b/src/Action/LookupAction.php
@@ -36,11 +36,11 @@ class LookupAction extends BaseAction
      */
     protected function _handle()
     {
-        $subject = $this->_subject(['success' => true]);
+        $query = $this->_table()->find($this->config('findMethod'), $this->_getFindConfig());
+        $subject = $this->_subject(['success' => true, 'query' => $query]);
 
         $this->_trigger('beforeLookup', $subject);
-        $query = $this->_table()->find($this->config('findMethod'), $this->_getFindConfig());
-        $subject->set(['entities' => $this->_controller()->paginate($query)]);
+        $subject->set(['entities' => $this->_controller()->paginate($subject->query)]);
         $this->_trigger('afterLookup', $subject);
 
         $this->_trigger('beforeRender', $subject);
@@ -57,7 +57,7 @@ class LookupAction extends BaseAction
 
         $config = (array)$this->config('findConfig');
         if ($idField = $request->query('id')) {
-            $config['idField'] = $idField;
+            $config['keyField'] = $idField;
         }
 
         if ($valueField = $request->query('value')) {

--- a/tests/App/Controller/BlogsController.php
+++ b/tests/App/Controller/BlogsController.php
@@ -21,6 +21,7 @@ class BlogsController extends Controller
                 'Crud.Edit',
                 'Crud.View',
                 'Crud.Delete',
+                'Crud.Lookup',
                 'deleteAll' => [
                     'className' => 'Crud.Bulk/Delete',
                 ],

--- a/tests/TestCase/Action/IndexActionTest.php
+++ b/tests/TestCase/Action/IndexActionTest.php
@@ -83,4 +83,25 @@ class IndexActionTest extends IntegrationTestCase
         $this->assertNotNull($this->viewVariable('items'));
         $this->assertNotNull($this->viewVariable('success'));
     }
+
+    /**
+     * Tests that it is posisble to modify the pagination query in beforePaginate
+     *
+     * @return void
+     */
+    public function testModifyQueryInEvent()
+    {
+        $this->_eventManager->on(
+            'Dispatcher.beforeDispatch',
+            ['priority' => 1000],
+            function () {
+                $this->_controller->Crud->on('beforePaginate', function ($event) {
+                    $event->subject->query->where(['id <' => 2]);
+                });
+            }
+        );
+
+        $this->get('/blogs');
+        $this->assertContains('Page 1 of 1, showing 1 records out of 1 total', $this->_response->body());
+    }
 }

--- a/tests/TestCase/Action/LookupActionTest.php
+++ b/tests/TestCase/Action/LookupActionTest.php
@@ -1,0 +1,107 @@
+<?php
+namespace Crud\Test\TestCase\Action;
+
+use Cake\Routing\DispatcherFactory;
+use Cake\Routing\Router;
+use Crud\TestSuite\IntegrationTestCase;
+
+/**
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ */
+class LookupActionTest extends IntegrationTestCase
+{
+
+    /**
+     * fixtures property
+     *
+     * @var array
+     */
+    public $fixtures = ['plugin.crud.blogs'];
+
+    /**
+     * Test with no extra options
+     *
+     * @return void
+     */
+    public function testGet()
+    {
+        $this->_eventManager->on(
+            'Dispatcher.beforeDispatch',
+            ['priority' => 1000],
+            function () {
+                $this->_subscribeToEvents($this->_controller);
+            }
+        );
+
+        $expected = [
+            '1' => '1st post',
+            '2' => '2nd post',
+            '3' => '3rd post',
+        ];
+
+        $this->get('/blogs/lookup.json');
+        $this->assertEvents(['beforeLookup', 'afterLookup', 'beforeRender']);
+        $this->assertNotNull($this->viewVariable('viewVar'));
+        $this->assertNotNull($this->viewVariable('blogs'));
+        $this->assertNotNull($this->viewVariable('success'));
+        $this->assertEquals($expected, $this->viewVariable('blogs')->toArray());
+    }
+
+    /**
+     * Test changing the id field and value field
+     *
+     * @return void
+     */
+    public function testGetWithCustomParams()
+    {
+        $this->_eventManager->on(
+            'Dispatcher.beforeDispatch',
+            ['priority' => 1000],
+            function () {
+                $this->_subscribeToEvents($this->_controller);
+            }
+        );
+
+        $expected = [
+            '1st post' => '1',
+            '2nd post' => '2',
+            '3rd post' => '3',
+        ];
+
+        $this->get('/blogs/lookup.json?id=name&value=id');
+        $this->assertEvents(['beforeLookup', 'afterLookup', 'beforeRender']);
+        $this->assertNotNull($this->viewVariable('viewVar'));
+        $this->assertNotNull($this->viewVariable('blogs'));
+        $this->assertNotNull($this->viewVariable('success'));
+        $this->assertEquals($expected, $this->viewVariable('blogs')->toArray());
+    }
+
+
+    /**
+     * Tests that the beforeLookup can be used to modify the query
+     *
+     * @return void
+     */
+    public function testGetWithQueryModification()
+    {
+        $this->_eventManager->on(
+            'Dispatcher.beforeDispatch',
+            ['priority' => 1000],
+            function () {
+                $this->_controller->Crud->on('beforeLookup', function ($event) {
+                    $event->subject->query->where(['id <' => 2]);
+                });
+            }
+        );
+
+        $expected = [
+            '1' => '1st post',
+        ];
+
+        $this->get('/blogs/lookup.json');
+        $this->assertNotNull($this->viewVariable('viewVar'));
+        $this->assertEquals($expected, $this->viewVariable('blogs')->toArray());
+    }
+}


### PR DESCRIPTION
This PR includes the following changes:

* Allows `beforePaginate` to alter the query before it is executed
* Fixes warning in LookupAction
* Adds the ability to alter the query in LookupAction