### PR TITLE
Remove verson in readme's install command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 For CakePHP 3.x compatible version:
 
 ```
-composer require friendsofcake/crud:~4.0
+composer require friendsofcake/crud
 ```
 
 For CakePHP 2.x compatible version:


### PR DESCRIPTION
This way the latest stable release will be installed.