### PR TITLE
Fixed issue caused by validation of query string

### DIFF
--- a/src/Action/AddAction.php
+++ b/src/Action/AddAction.php
@@ -97,7 +97,7 @@ class AddAction extends BaseAction
     {
         $subject = $this->_subject([
             'success' => true,
-            'entity' => $this->_entity($this->_request()->query ?: null, $this->saveOptions())
+            'entity' => $this->_entity($this->_request()->query ?: null, ['validate' => false] + $this->saveOptions())
         ]);
 
         $this->_trigger('beforeRender', $subject);


### PR DESCRIPTION
When displaying an add form and sending some of the fields in the query string,
it is better to not pre-validate the full form as it will obviously contain errors.