### PR TITLE
Fix a bug where Api Pagination does not work for plugins.

### DIFF
--- a/src/Listener/ApiPaginationListener.php
+++ b/src/Listener/ApiPaginationListener.php
@@ -47,7 +47,7 @@ class ApiPaginationListener extends BaseListener
         }
 
         $controller = $this->_controller();
-        $modelClass = $controller->modelClass;
+        list(, $modelClass) = pluginSplit($controller->modelClass);
 
         if (!array_key_exists($modelClass, $request->paging)) {
             return;


### PR DESCRIPTION
When ApiPaginationListener is used from a plugin, $controller->modelClass is set to 'pluginname.model', which then fails on "array_key_exists($modelClass, $request->paging)".