### PR TITLE
Resolves #287

### DIFF
--- a/src/Listener/RelatedModelsListener.php
+++ b/src/Listener/RelatedModelsListener.php
@@ -27,6 +27,19 @@ class RelatedModelsListener extends BaseListener
     }
 
     /**
+     * Automatically parse and contain related table classes
+     *
+     * @param Event $event
+     * @return void
+     */
+    public function beforePaginate(Event $event)
+    {
+        if (!$event->subject()->query->contain()) {
+            $event->subject()->query->contain($this->relatedModels());
+        }
+    }
+
+    /**
      * Find and publish all related models to the view
      * for an action
      *


### PR DESCRIPTION
Added a `beforePaginate` event hook to the RelatedModelsListener so that paginated data will contain related table classes.