### PR TITLE
related-models docs

### DIFF
--- a/docs/listeners/related-models.rst
+++ b/docs/listeners/related-models.rst
@@ -25,6 +25,21 @@ configure statically or use dynamic methods.
 Configuring
 -----------
 
+Before you're able to configure your ``relatedModels`` you need to load the listener.
+
+.. code-block:: php
+
+  <?php
+  class AppController extends Controller {
+
+    public function initialize()
+    {
+      parent::initialize();
+      $this->Crud->addListener('relatedModels', 'Crud.RelatedModels');
+    }
+
+.. code-block:: php
+
 You can enable and disable which model relations you want to have automatically
 fetched very easily, as shown below.
 


### PR DESCRIPTION
Before the docs improvement it's not clear that the listener needs to be loaded. It sounds like that `relatedModels` will work without any additional configuration. Especially because the following explanation:

```
By default all related model lists for main CRUD table instance will be fetched, but only for add, edit and corresponding admin actions.
```