### PR TITLE
Fix for "Fatal Error: Class 'String' not found" in CakePHP 2.7.x

### DIFF
--- a/Controller/Crud/CrudAction.php
+++ b/Controller/Crud/CrudAction.php
@@ -3,6 +3,7 @@
 App::uses('CrudBaseObject', 'Crud.Controller/Crud');
 App::uses('Hash', 'Utility');
 App::uses('Validation', 'Utility');
+App::uses('String', 'Utility');
 
 /**
  * Base Crud class


### PR DESCRIPTION
Following line causes "Fatal Error: Class 'String' not found" in CakePHP 2.7.x
https://github.com/FriendsOfCake/crud/blob/3.0/Controller/Crud/CrudAction.php#L239
This patch fixes the problem