### PR TITLE
optional flash messages

### DIFF
--- a/src/Listener/ApiListener.php
+++ b/src/Listener/ApiListener.php
@@ -32,6 +32,7 @@ class ApiListener extends BaseListener
             'json' => 'Json',
             'xml' => 'Xml'
         ],
+        'setFlash' => false,
         'detectors' => [
             'json' => ['ext' => 'json', 'accepts' => 'application/json'],
             'xml' => ['ext' => 'xml', 'accepts' => 'text/xml']
@@ -390,7 +391,9 @@ class ApiListener extends BaseListener
      */
     public function setFlash(Event $event)
     {
-        $event->stopPropagation();
+        if (!$this->config('setFlash')) {
+            $event->stopPropagation();
+        }
     }
 
     /**

--- a/src/Listener/ApiListener.php
+++ b/src/Listener/ApiListener.php
@@ -32,7 +32,6 @@ class ApiListener extends BaseListener
             'json' => 'Json',
             'xml' => 'Xml'
         ],
-        'setFlash' => false,
         'detectors' => [
             'json' => ['ext' => 'json', 'accepts' => 'application/json'],
             'xml' => ['ext' => 'xml', 'accepts' => 'text/xml']
@@ -42,7 +41,8 @@ class ApiListener extends BaseListener
             'class' => 'Cake\Network\Exception\BadRequestException',
             'message' => 'Unknown error',
             'code' => 0
-        ]
+        ],
+        'setFlash' => false
     ];
 
     /**

--- a/tests/TestCase/Listener/ApiListenerTest.php
+++ b/tests/TestCase/Listener/ApiListenerTest.php
@@ -236,7 +236,8 @@ class ApiListenerTest extends TestCase
                 'class' => 'Cake\Network\Exception\BadRequestException',
                 'message' => 'Unknown error',
                 'code' => 0
-            ]
+            ],
+            'setFlash' => false
         ];
         $result = $listener->config();
         $this->assertEquals($expected, $result);
@@ -844,6 +845,37 @@ class ApiListenerTest extends TestCase
 
         $stopped = $event->isStopped();
         $this->assertTrue($stopped, 'Set flash event is expected to be stopped');
+    }
+
+    /**
+     * testFlashMessageEnabled
+     *
+     * There are use cases where you want to
+     * enable flash messages.
+     *
+     * @return void
+     */
+    public function testFlashMessageEnabled()
+    {
+        $Request = new \Cake\Network\Request();
+        $Request->addDetector('api', ['callback' => function () {
+            return true;
+        }]);
+
+        $subject = new \Crud\Event\Subject(['request' => $Request]);
+
+        $apiListener = $listener = $this
+            ->getMockBuilder('\Crud\Listener\ApiListener')
+            ->setMethods(null)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $event = new \Cake\Event\Event('Crud.setFlash', $subject);
+        $apiListener->config(['setFlash' => true]);
+        $apiListener->setFlash($event);
+
+        $stopped = $event->isStopped();
+        $this->assertFalse($stopped);
     }
 
     /**


### PR DESCRIPTION
In general I agree that flash messages are not necessary for api requests. Let me explain with the following use case why an optional flash message may be useful.

I want to use `deleteAll` in a normal cake template context. Regarding issues with `<form>` in `<form>` I decided to execute `deleteAll` with an AJAX request. Therefore I loaded the API listener to get a well-formed response for my AJAX request. Now I want to refresh my page in jQuery's `success` callback and want to show a flash message to the user after the reload is done.

What do you think?

EDIT:
As usual, test cases follow after you're fine with the changes itself.