### PR TITLE
deprecated method viewClassMap

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         }
     ],
     "require":{
-        "cakephp/cakephp": "~3.0"
+        "cakephp/cakephp": "~3.1"
     },
     "require-dev": {
         "phpunit/phpunit": "3.7.33",

--- a/src/Listener/ApiListener.php
+++ b/src/Listener/ApiListener.php
@@ -354,7 +354,7 @@ class ApiListener extends BaseListener
     {
         $controller = $this->_controller();
         foreach ($this->config('viewClasses') as $type => $class) {
-            $controller->RequestHandler->viewClassMap($type, $class);
+            $controller->RequestHandler->config('viewClassMap', [$type => $class]);
         }
     }
 

--- a/tests/TestCase/Listener/ApiListenerTest.php
+++ b/tests/TestCase/Listener/ApiListenerTest.php
@@ -1211,15 +1211,15 @@ class ApiListenerTest extends TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $controller->RequestHandler = $this->getMock('RequestHandler', ['viewClassMap']);
+        $controller->RequestHandler = $this->getMock('RequestHandler', ['config']);
         $controller->RequestHandler
             ->expects($this->at(0))
-            ->method('viewClassMap')
-            ->with('json', 'Json');
+            ->method('config')
+            ->with('viewClassMap', ['json' => 'Json']);
         $controller->RequestHandler
             ->expects($this->at(1))
-            ->method('viewClassMap')
-            ->with('xml', 'Xml');
+            ->method('config')
+            ->with('viewClassMap', ['xml' => 'Xml']);
 
         $apiListener = $this->getMockBuilder('\Crud\Listener\ApiListener')
             ->disableOriginalConstructor()


### PR DESCRIPTION
refs http://book.cakephp.org/3.0/en/appendices/3-1-migration-guide.html#requesthandlercomponent

Has anyone an idea why the other test cases fail? It should be working like before without to change the test cases.