### PR TITLE
Simplify ExceptionRenderer::_outputMessage()

### DIFF
--- a/src/Error/ExceptionRenderer.php
+++ b/src/Error/ExceptionRenderer.php
@@ -4,9 +4,9 @@ namespace Crud\Error;
 use Cake\Core\Configure;
 use Cake\Core\Exception\MissingPluginException;
 use Cake\Datasource\ConnectionManager;
+use Cake\Error\Debugger;
 use Cake\Event\Event;
 use Cake\View\Exception\MissingViewException;
-use Cake\Error\Debugger;
 use Exception;
 
 /**

--- a/src/Error/ExceptionRenderer.php
+++ b/src/Error/ExceptionRenderer.php
@@ -6,6 +6,7 @@ use Cake\Core\Exception\MissingPluginException;
 use Cake\Datasource\ConnectionManager;
 use Cake\Event\Event;
 use Cake\View\Exception\MissingViewException;
+use Cake\Error\Debugger;
 use Exception;
 
 /**
@@ -60,42 +61,19 @@ class ExceptionRenderer extends \Cake\Error\ExceptionRenderer
      */
     protected function _outputMessage($template)
     {
-        try {
-            $viewVars = ['success', 'data'];
-            $this->controller->set('success', false);
-            $this->controller->set('data', $this->_getErrorData());
-            if (Configure::read('debug')) {
-                $queryLog = $this->_getQueryLog();
-                if ($queryLog) {
-                    $this->controller->set(compact('queryLog'));
-                    $viewVars[] = 'queryLog';
-                }
+        $viewVars = ['success', 'data'];
+        $this->controller->set('success', false);
+        $this->controller->set('data', $this->_getErrorData());
+        if (Configure::read('debug')) {
+            $queryLog = $this->_getQueryLog();
+            if ($queryLog) {
+                $this->controller->set(compact('queryLog'));
+                $viewVars[] = 'queryLog';
             }
-            $this->controller->set('_serialize', $viewVars);
-            $this->controller->render($template);
-            $event = new Event('Controller.shutdown', $this->controller);
-            $this->controller->afterFilter($event);
-            return $this->controller->response;
-        } catch (MissingViewException $e) {
-            $attributes = $e->getAttributes();
-            if (isset($attributes['file']) && strpos($attributes['file'], 'error500') !== false) {
-                return $this->_outputMessageSafe('error500');
-            }
-            return $this->_outputMessage('error500');
-        } catch (MissingPluginException $e) {
-            $attributes = $e->getAttributes();
-            if (isset($attributes['plugin']) && $attributes['plugin'] === $this->controller->plugin) {
-                $this->controller->plugin = null;
-            }
-            return $this->_outputMessageSafe('error500');
-        } catch (\Exception $e) {
-            $this->controller->set([
-                'error' => $e,
-                'message' => $e->getMessage(),
-                'code' => $e->getCode()
-            ]);
-            return $this->_outputMessageSafe('error500');
         }
+        $this->controller->set('_serialize', $viewVars);
+
+        return parent::_outputMessage($template);
     }
 
     /**
@@ -119,8 +97,14 @@ class ExceptionRenderer extends \Cake\Error\ExceptionRenderer
                 'class' => get_class($viewVars['error']),
                 'code' => $viewVars['error']->getCode(),
                 'message' => $viewVars['error']->getMessage(),
-                'trace' => preg_split('@\n@', $viewVars['error']->getTraceAsString()),
             ];
+
+            if (!isset($data['trace'])) {
+                $data['trace'] = Debugger::formatTrace($viewVars['error']->getTrace(), [
+                    'format' => 'array',
+                    'args' => false
+                ]);
+            }
         }
 
         return $data;

--- a/tests/TestCase/Error/ExceptionRendererTest.php
+++ b/tests/TestCase/Error/ExceptionRendererTest.php
@@ -59,7 +59,7 @@ class ExceptionRendererTest extends TestCase
             ]
         ];
         $actual = $viewVars['data'];
-        unset($actual['exception']['trace']);
+        unset($actual['trace']);
         $this->assertEquals($expected, $actual);
 
         $this->assertTrue(!isset($actual['queryLog']));
@@ -136,7 +136,7 @@ class ExceptionRendererTest extends TestCase
         $actual = $viewVars['data'];
         $queryLog = $viewVars['queryLog'];
 
-        unset($actual['exception']['trace']);
+        unset($actual['trace']);
         $this->assertEquals($expected, $actual);
 
         $this->assertTrue(!empty($queryLog));
@@ -198,7 +198,7 @@ class ExceptionRendererTest extends TestCase
             ]
         ];
         $actual = $viewVars['data'];
-        unset($actual['exception']['trace']);
+        unset($actual['trace']);
         $this->assertEquals($expected, $actual);
 
         $this->assertTrue(isset($viewVars['success']));
@@ -254,7 +254,7 @@ class ExceptionRendererTest extends TestCase
             ]
         ];
         $actual = $viewVars['data'];
-        unset($actual['exception']['trace']);
+        unset($actual['trace']);
         $this->assertEquals($expected, $actual);
 
         $this->assertTrue(isset($viewVars['success']));
@@ -319,7 +319,7 @@ class ExceptionRendererTest extends TestCase
             ]
         ];
         $actual = $viewVars['data'];
-        unset($actual['exception']['trace']);
+        unset($actual['trace']);
         $this->assertEquals($expected, $actual);
 
         $this->assertTrue(isset($viewVars['success']));
@@ -410,8 +410,8 @@ class ExceptionRendererTest extends TestCase
         $Renderer->__construct($Exception);
         $Renderer->render();
 
-        $this->assertContains('trace', array_keys($Controller->viewVars['data']['exception']));
-        unset($Controller->viewVars['data']['exception']['trace']);
+        $this->assertContains('trace', array_keys($Controller->viewVars['data']));
+        unset($Controller->viewVars['data']['trace']);
 
         $expected = [
             'code' => 412,
@@ -482,7 +482,7 @@ class ExceptionRendererTest extends TestCase
             ]
         ];
         $data = $Controller->viewVars['data'];
-        unset($data['exception']['trace']);
+        unset($data['trace']);
         $this->assertEquals($expected, $data);
     }
 }


### PR DESCRIPTION
Set trace info in response only if not already added by
core's ExceptionRenderer::render()