### PR TITLE
Removed default class passed to flash

### DIFF
--- a/src/Action/BaseAction.php
+++ b/src/Action/BaseAction.php
@@ -146,7 +146,6 @@ abstract class BaseAction extends Object
 
         $config = Hash::merge([
             'element' => 'default',
-            'params' => ['class' => 'message'],
             'key' => 'flash',
             'type' => $this->config('action') . '.' . $type,
             'name' => $this->resourceName()
@@ -170,8 +169,7 @@ abstract class BaseAction extends Object
             $replacements + ['name' => $config['name']],
             ['before' => '{', 'after' => '}']
         );
-
-        $config['params']['class'] .= ' ' . $type;
+        
         return $config;
     }
 

--- a/src/Action/BaseAction.php
+++ b/src/Action/BaseAction.php
@@ -151,6 +151,20 @@ abstract class BaseAction extends Object
             'name' => $this->resourceName()
         ], $config);
 
+        if (!isset($config['params']['class']) || $config['params']['class'] !== false) {
+            if (empty($config['params']['class'])) {
+                $config['params']['class'] = 'messsage';
+            }
+
+            if (is_array($config['params']['class'])) {
+                $config['params']['class'][] = $type;
+            } else {
+                $config['params']['class'] .= ' ' . $type;
+            }
+        } else {
+            unset($config['params']['class']);
+        }
+
         if (!isset($config['text'])) {
             throw new \Exception(sprintf('Invalid message config for "%s" no text key found', $type));
         }
@@ -169,7 +183,7 @@ abstract class BaseAction extends Object
             $replacements + ['name' => $config['name']],
             ['before' => '{', 'after' => '}']
         );
-        
+
         return $config;
     }
 

--- a/src/Action/BaseAction.php
+++ b/src/Action/BaseAction.php
@@ -153,7 +153,7 @@ abstract class BaseAction extends Object
 
         if (!isset($config['params']['class']) || $config['params']['class'] !== false) {
             if (empty($config['params']['class'])) {
-                $config['params']['class'] = 'messsage';
+                $config['params']['class'] = 'message';
             }
 
             if (is_array($config['params']['class'])) {


### PR DESCRIPTION
Removed adding `$type` as class.

This because the `class` could also be an array. And, in some cases we don't want to add `$type` to it the array, can't we do this better manually in the config?

This change makes it also compatible with the `bootstrap-ui` plugin (I was using both plugins, which, didn't work properly without making these changes to `crud`)