### PR TITLE
Bringing back "limit delete action methods"

### DIFF
--- a/src/Action/DeleteAction.php
+++ b/src/Action/DeleteAction.php
@@ -49,12 +49,12 @@ class DeleteAction extends BaseAction
     ];
 
     /**
-     * HTTP DELETE handler
+     * HTTP POST handler
      *
      * @param string $id Record id
      * @return void
      */
-    protected function _handle($id = null)
+    protected function _post($id = null)
     {
         $subject = $this->_subject();
         $subject->set(['id' => $id]);
@@ -73,6 +73,17 @@ class DeleteAction extends BaseAction
         }
 
         return $this->_redirect($subject, ['action' => 'index']);
+    }
+
+    /**
+     * HTTP DELETE handler
+     *
+     * @param string $id Record id
+     * @return void
+     */
+    protected function _delete($id = null)
+    {
+        $this->_post($id);
     }
 
     /**

--- a/tests/TestCase/Action/DeleteActionTest.php
+++ b/tests/TestCase/Action/DeleteActionTest.php
@@ -27,22 +27,20 @@ class DeleteActionTest extends IntegrationTestCase
     public $tableClass = 'Crud\Test\App\Model\Table\BlogsTable';
 
     /**
-     * Data provider with all HTTP verbs
+     * Data provider with HTTP verbs
      *
      * @return array
      */
     public function allHttpMethodProvider()
     {
         return [
-            ['get'],
             ['post'],
-            ['put'],
             ['delete']
         ];
     }
 
     /**
-     * Test the normal HTTP flow for all HTTP verbs
+     * Test the normal HTTP flow for HTTP verbs
      *
      * @dataProvider allHttpMethodProvider
      * @return void
@@ -138,7 +136,7 @@ class DeleteActionTest extends IntegrationTestCase
             }
         );
 
-        $this->get('/blogs/delete/1');
+        $this->post('/blogs/delete/1');
 
         $this->assertEvents(['beforeFind', 'afterFind', 'beforeDelete', 'setFlash', 'beforeRedirect']);
         $this->assertFalse($this->_subject->success);


### PR DESCRIPTION
In the of the discussion in the previous revert, namely that the cakephp 3 version introduced a regression compared to cake 2 and that the current handler is by default exploitable by trivial attack CSRF vectors, I'm bringing back the code that was reverted.