### PR TITLE
adding the missing return

### DIFF
--- a/src/Action/DeleteAction.php
+++ b/src/Action/DeleteAction.php
@@ -83,7 +83,7 @@ class DeleteAction extends BaseAction
      */
     protected function _delete($id = null)
     {
-        $this->_post($id);
+        return $this->_post($id);
     }
 
     /**

--- a/tests/App/Template/Blogs/delete.ctp
+++ b/tests/App/Template/Blogs/delete.ctp
@@ -1,1 +1,0 @@
-Hello World


### PR DESCRIPTION
Hey,

This missing return statement makes the Response to be null so no redirect is made.

I couldn't figure out how the tests are passing for `delete` method.

Best,
Pedro.