### PR TITLE
Corrects incorrect afterSave() subject key name

### DIFF
--- a/docs/_partials/events/after_save.rst
+++ b/docs/_partials/events/after_save.rst
@@ -12,7 +12,7 @@ The :ref:`Crud Subject <crud-subject>` contains the following keys:
 - **id** The newly inserted ID. It's only available if the call to ``Table::save()`` was successful.
 - **success** indicates whether or not the ``Table::save()`` call succeed or not.
 - **created** ``true`` if the record was ``created`` and ``false`` if the record was ``updated``.
-- **item** An ``entity`` object marshaled with the ``HTTP POST`` data from the request and the ``save()`` logic.
+- **entity** An ``entity`` object marshaled with the ``HTTP POST`` data from the request and the ``save()`` logic.
 
 Check Created Status
 """"""""""""""""""""


### PR DESCRIPTION
The `afterSave()` event documentation indicates that `item` is one of the keys of the event `subject()`.  This is incorrect.  The correct name of the key is `entity`.  This PR makes the necessary correction to the documentation.