### PR TITLE
Combine AddAction and EditAction logic into BaseCreateAction

### DIFF
--- a/src/Action/AddAction.php
+++ b/src/Action/AddAction.php
@@ -83,7 +83,7 @@ class AddAction extends BaseCreateAction
      *
      * @param \Crud\Event\Subject $subject Event subject
      * @param mixed $id Record id
-     * @return void
+     * @return \Crud\Event\Subject
      */
     protected function _getSubject(Subject $subject, $id = null)
     {
@@ -99,7 +99,7 @@ class AddAction extends BaseCreateAction
      *
      * @param \Crud\Event\Subject $subject Event subject
      * @param mixed $id Record id
-     * @return void
+     * @return \Cake\ORM\Entity
      */
     protected function _postEntity(Subject $subject, $id = null)
     {

--- a/src/Action/BaseCreateAction.php
+++ b/src/Action/BaseCreateAction.php
@@ -116,7 +116,7 @@ abstract class BaseCreateAction extends BaseAction
      *
      * @param \Crud\Event\Subject $subject Event subject
      * @param mixed $id Record id
-     * @return void
+     * @return \Crud\Event\Subject
      */
     abstract protected function _getSubject(Subject $subject, $id = null);
 
@@ -125,7 +125,7 @@ abstract class BaseCreateAction extends BaseAction
      *
      * @param \Crud\Event\Subject $subject Event subject
      * @param mixed $id Record id
-     * @return void
+     * @return \Cake\ORM\Entity
      */
     abstract protected function _postEntity(Subject $subject, $id = null);
 }

--- a/src/Action/BaseCreateAction.php
+++ b/src/Action/BaseCreateAction.php
@@ -1,0 +1,131 @@
+<?php
+namespace Crud\Action;
+
+use Crud\Event\Subject;
+use Crud\Traits\FindMethodTrait;
+use Crud\Traits\RedirectTrait;
+use Crud\Traits\SaveMethodTrait;
+use Crud\Traits\SerializeTrait;
+use Crud\Traits\ViewTrait;
+use Crud\Traits\ViewVarTrait;
+
+/**
+ * Base Create/Update Crud class
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ */
+abstract class BaseCreateAction extends BaseAction
+{
+
+    use FindMethodTrait;
+    use RedirectTrait;
+    use SaveMethodTrait;
+    use SerializeTrait;
+    use ViewTrait;
+    use ViewVarTrait;
+
+    /**
+     * HTTP GET handler
+     *
+     * @return void
+     */
+    protected function _get($id = null)
+    {
+        $subject = $this->_getSubject($this->_subject(), $id);
+        $this->_trigger('beforeRender', $subject);
+    }
+
+    /**
+     * HTTP POST handler
+     *
+     * @param mixed $id Record id
+     * @return void|\Cake\Network\Response
+     */
+    protected function _post($id = null)
+    {
+        return $this->_createOrUpdate($id);
+    }
+
+    /**
+     * HTTP PUT handler
+     *
+     * @param mixed $id Record id
+     * @return void|\Cake\Network\Response
+     */
+    protected function _put($id = null)
+    {
+        return $this->_createOrUpdate($id);
+    }
+
+    /**
+     * Create or Update a record
+     *
+     * @param mixed $id Record id
+     * @return void|\Cake\Network\Response
+     */
+    protected function _createOrUpdate($id = null)
+    {
+        $subject = $this->_subject();
+        $subject->set(['id' => $id]);
+        $subject->set(['saveMethod' => $this->saveMethod()]);
+        $subject->set(['saveOptions' => $this->saveOptions()]);
+        $subject->set(['entity' => $this->_postEntity($subject, $id)]);
+
+        $this->_trigger('beforeSave', $subject);
+
+        $saveCallback = [$this->_table(), $subject->saveMethod];
+        if (call_user_func($saveCallback, $subject->entity, $subject->saveOptions)) {
+            return $this->_success($subject);
+        }
+
+        return $this->_error($subject);
+    }
+
+
+    /**
+     * Post success callback
+     *
+     * @param \Crud\Event\Subject $subject Event subject
+     * @return \Cake\Network\Response
+     */
+    protected function _success(Subject $subject)
+    {
+        $subject->set(['success' => true, 'created' => $this->config('entityCreated')]);
+        $this->_trigger('afterSave', $subject);
+        $this->setFlash('success', $subject);
+        return $this->_redirect($subject, ['action' => 'index']);
+    }
+
+    /**
+     * Post error callback
+     *
+     * @param \Crud\Event\Subject $subject Event subject
+     * @return void
+     */
+    protected function _error(Subject $subject)
+    {
+        $subject->set(['success' => false, 'created' => false]);
+        $this->_trigger('afterSave', $subject);
+        $this->setFlash('error', $subject);
+        $this->_trigger('beforeRender', $subject);
+    }
+
+    /**
+     * Returns the subject for GET requests
+     *
+     * @param \Crud\Event\Subject $subject Event subject
+     * @param mixed $id Record id
+     * @return void
+     */
+    abstract protected function _getSubject(Subject $subject, $id = null);
+
+    /**
+     * Returns the entity for POST/PUT requests
+     *
+     * @param \Crud\Event\Subject $subject Event subject
+     * @param mixed $id Record id
+     * @return void
+     */
+    abstract protected function _postEntity(Subject $subject, $id = null);
+}

--- a/src/Action/EditAction.php
+++ b/src/Action/EditAction.php
@@ -2,11 +2,6 @@
 namespace Crud\Action;
 
 use Crud\Event\Subject;
-use Crud\Traits\FindMethodTrait;
-use Crud\Traits\RedirectTrait;
-use Crud\Traits\SaveMethodTrait;
-use Crud\Traits\ViewTrait;
-use Crud\Traits\ViewVarTrait;
 
 /**
  * Handles 'Edit' Crud actions
@@ -14,14 +9,8 @@ use Crud\Traits\ViewVarTrait;
  * Licensed under The MIT License
  * For full copyright and license information, please see the LICENSE.txt
  */
-class EditAction extends BaseAction
+class EditAction extends BaseCreateAction
 {
-
-    use FindMethodTrait;
-    use RedirectTrait;
-    use SaveMethodTrait;
-    use ViewTrait;
-    use ViewVarTrait;
 
     /**
      * Default settings for 'edit' actions
@@ -50,6 +39,7 @@ class EditAction extends BaseAction
         'view' => null,
         'relatedModels' => true,
         'saveOptions' => [],
+        'entityCreated' => false,
         'messages' => [
             'success' => [
                 'text' => 'Successfully updated {name}'
@@ -86,88 +76,32 @@ class EditAction extends BaseAction
     ];
 
     /**
-     * HTTP GET handler
+     * Returns the subject for GET requests
      *
-     * @param string $id Record id
+     * @param \Crud\Event\Subject $subject Event subject
+     * @param mixed $id Record id
      * @return void
-     * @throws \Cake\Network\Exception\NotFoundException If record not found
      */
-    protected function _get($id = null)
+    protected function _getSubject(Subject $subject, $id = null)
     {
-        $subject = $this->_subject();
         $subject->set(['id' => $id]);
         $subject->set(['entity' => $this->_findRecord($id, $subject)]);
-
-        $this->_trigger('beforeRender', $subject);
+        return $subject;
     }
 
     /**
-     * HTTP PUT handler
+     * Returns the entity for POST/PUT requests
      *
+     * @param \Crud\Event\Subject $subject Event subject
      * @param mixed $id Record id
-     * @return void|\Cake\Network\Response
+     * @return void
      */
-    protected function _put($id = null)
+    protected function _postEntity(Subject $subject, $id = null)
     {
-        $subject = $this->_subject();
-        $subject->set(['id' => $id]);
-
-        $entity = $this->_table()->patchEntity(
+        return $this->_table()->patchEntity(
             $this->_findRecord($id, $subject),
             $this->_request()->data,
             $this->saveOptions()
         );
-
-        $this->_trigger('beforeSave', $subject);
-        if (call_user_func([$this->_table(), $this->saveMethod()], $entity, $this->saveOptions())) {
-            return $this->_success($subject);
-        }
-
-        return $this->_error($subject);
-    }
-
-    /**
-     * HTTP POST handler
-     *
-     * Thin proxy for _put
-     *
-     * @param mixed $id Record id
-     * @return void|\Cake\Network\Response
-     */
-    protected function _post($id = null)
-    {
-        return $this->_put($id);
-    }
-
-    /**
-     * Success callback
-     *
-     * @param \Crud\Event\Subject $subject Event subject
-     * @return \Cake\Network\Response
-     */
-    protected function _success(Subject $subject)
-    {
-        $subject->set(['success' => true, 'created' => false]);
-        $this->_trigger('afterSave', $subject);
-
-        $this->setFlash('success', $subject);
-
-        return $this->_redirect($subject, ['action' => 'index']);
-    }
-
-    /**
-     * Error callback
-     *
-     * @param \Crud\Event\Subject $subject Event subject
-     * @return void
-     */
-    protected function _error(Subject $subject)
-    {
-        $subject->set(['success' => false, 'created' => false]);
-        $this->_trigger('afterSave', $subject);
-
-        $this->setFlash('error', $subject);
-
-        $this->_trigger('beforeRender', $subject);
     }
 }

--- a/src/Action/EditAction.php
+++ b/src/Action/EditAction.php
@@ -80,7 +80,7 @@ class EditAction extends BaseCreateAction
      *
      * @param \Crud\Event\Subject $subject Event subject
      * @param mixed $id Record id
-     * @return void
+     * @return \Crud\Event\Subject
      */
     protected function _getSubject(Subject $subject, $id = null)
     {
@@ -94,7 +94,7 @@ class EditAction extends BaseCreateAction
      *
      * @param \Crud\Event\Subject $subject Event subject
      * @param mixed $id Record id
-     * @return void
+     * @return \Cake\ORM\Entity
      */
     protected function _postEntity(Subject $subject, $id = null)
     {


### PR DESCRIPTION
This change provides a single interface into creating/updating
records. The logic from both classes was highly similar, with only
the retrieval of the initial GET subject and the entity being posted
being different.

One possibility this change introduces is the ability to have a
`CreateOrUpdateAction`, wherein the entity will be created regardless
of it's initial existence. Users can simply subclass the
`BaseCreateAction` class and define the two methods necessary to
handle the cases they wish to handle.