### PR TITLE
Throw a more user-friendly exception when the SearchBehavior is not attached

### DIFF
--- a/src/Listener/SearchListener.php
+++ b/src/Listener/SearchListener.php
@@ -52,7 +52,15 @@ class SearchListener extends BaseListener
             return;
         }
 
-        $filterParams = $this->_table()->filterParams($this->_request()->query);
+        $table = $this->_table();
+        if (!method_exists($table, 'filterParams')) {
+            throw new RuntimeException(sprintf(
+                'Missing Search.Search behavior on %s',
+                get_class($table)
+            ));
+        }
+
+        $filterParams = $table->filterParams($this->_request()->query);
         $event->subject->query->find('search', $filterParams);
     }
 }


### PR DESCRIPTION
Rather than throw the following error/exception:

```
Unknown method "filterParams"
```

We throw a RuntimeException that informs the developer that they have misconfigured their application, allowing them to more quickly debug the issue.