### PR TITLE
Fix check for missing behavior

### DIFF
--- a/src/Listener/SearchListener.php
+++ b/src/Listener/SearchListener.php
@@ -53,7 +53,7 @@ class SearchListener extends BaseListener
         }
 
         $table = $this->_table();
-        if (!method_exists($table, 'filterParams')) {
+        if (!$table->behaviors()->hasMethod('filterParams')) {
             throw new RuntimeException(sprintf(
                 'Missing Search.Search behavior on %s',
                 get_class($table)


### PR DESCRIPTION
- The method exists on a behavior, and is proxied, so therefore `method_exists` is a bad check.
- You can't simply check for `hasBehavior('Search')` as a user can alias a behavior to another one.
- Since we are calling `filterParams` and that is the only dependency, simply checking if the method is in the `BehaviorRegistry::$methodMap` is enough.