### PR TITLE
Use php5.5 for coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ matrix:
     - php: 7.0
       env: PHPCS=1 DEFAULT=0
 
-    - php: 5.4
+    - php: 5.5
       env: COVERALLS=1 DEFAULT=0
 
     - php: hhvm


### PR DESCRIPTION
Solves [failing coveralls build](https://travis-ci.org/FriendsOfCake/crud/jobs/99232151) due to requirement changing from 5.4 to 5.5.

