### PR TITLE
Fix incorrect subject key name in docs

### DIFF
--- a/docs/_partials/events/before_redirect.rst
+++ b/docs/_partials/events/before_redirect.rst
@@ -8,7 +8,7 @@ The :ref:`Crud Subject <crud-subject>` contains the following keys:
 - **url** 		The 1st argument to ``Controller::redirect()``.
 - **status** 	The 2nd argument to ``Controller::redirect()``.
 - **exit** 		The 3rd argument to ``Controller::redirect()``.
-- **item**	 	(Optional) The ``Entity`` from the previously emitted event.
+- **entity**	(Optional) The ``Entity`` from the previously emitted event.
 
 All keys can be modified as you see fit, at the end of the event cycle they will be passed
 directly to ``Controller::redirect()``.

--- a/docs/_partials/events/set_flash.rst
+++ b/docs/_partials/events/set_flash.rst
@@ -9,7 +9,7 @@ The :ref:`Crud Subject <crud-subject>` contains the following keys:
 - **element** The 2nd argument to ``SessionComponent::setFlash``.
 - **params** 	The 3rd argument to ``SessionComponent::setFlash``.
 - **key** 		The 4th argument to ``SessionComponent::setFlash``.
-- **item**	 	(Optional) The ``Entity`` from the previously emitted event.
+- **entity** 	(Optional) The ``Entity`` from the previously emitted event.
 
 All keys can be modified as you see fit, at the end of the event cycle they will be passed
 directly to ``SessionComponent::setFlash``.


### PR DESCRIPTION
The documentation incorrectly indicated that a key named `item` was available as part of the event subject for the `beforeRedirect` and `setFlash` events.  The correct name for the key is `entity`.  This PR corrects the documentation.