### PR TITLE
Adding Crud::list action

### DIFF
--- a/src/Action/ListAction.php
+++ b/src/Action/ListAction.php
@@ -1,0 +1,46 @@
+<?php
+namespace Crud\Action;
+
+use Crud\Traits\FindMethodTrait;
+use Crud\Traits\ViewTrait;
+use Crud\Traits\ViewVarTrait;
+
+/**
+ * Handles 'List' Crud actions
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ */
+class ListAction extends BaseAction
+{
+
+    use FindMethodTrait;
+    use ViewTrait;
+    use ViewVarTrait;
+
+    /**
+     * Default settings for 'list' actions
+     *
+     * @var array
+     */
+    protected $_defaultConfig = [
+        'enabled' => true,
+        'scope' => 'table',
+        'findMethod' => 'all',
+        'view' => null,
+        'viewVar' => null,
+        'serialize' => []
+    ];
+
+    /**
+     * Generic handler for all HTTP verbs
+     *
+     * @return void
+     */
+    protected function _handle()
+    {
+        $subject = $this->_subject();
+        $this->_findAll($subject);
+        $this->_trigger('beforeRender', $subject);
+    }
+}

--- a/src/Traits/FindMethodTrait.php
+++ b/src/Traits/FindMethodTrait.php
@@ -56,6 +56,35 @@ trait FindMethodTrait
     }
 
     /**
+     * Find all records
+     *
+     * @param \Crud\Event\Subject $subject Event subject
+     * @return \Cake\ORM\Entity
+     */
+    protected function _findAll(Subject $subject)
+    {
+        $repository = $this->_table();
+
+        $query = $repository->find($this->findMethod());
+
+        $subject->set([
+            'repository' => $repository,
+            'query' => $query
+        ]);
+
+        $this->_trigger('beforeFind', $subject);
+        $entities = $query->all();
+
+        if (!$entities) {
+            return $this->_notFound($id, $subject);
+        }
+
+        $subject->set(['entities' => $entities, 'success' => true]);
+        $this->_trigger('afterFind', $subject);
+        return $entities;
+    }
+
+    /**
      * Throw exception if a record is not found
      *
      * @param string $id Record id

--- a/tests/App/Controller/BlogsController.php
+++ b/tests/App/Controller/BlogsController.php
@@ -22,6 +22,7 @@ class BlogsController extends Controller
                 'Crud.View',
                 'Crud.Delete',
                 'Crud.Lookup',
+                'Crud.List',
                 'deleteAll' => [
                     'className' => 'Crud.Bulk/Delete',
                 ],

--- a/tests/TestCase/Action/ListActionTest.php
+++ b/tests/TestCase/Action/ListActionTest.php
@@ -1,0 +1,85 @@
+<?php
+namespace Crud\Test\TestCase\Action;
+
+use Cake\Routing\DispatcherFactory;
+use Cake\Routing\Router;
+use Crud\TestSuite\IntegrationTestCase;
+
+/**
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ */
+class ListActionTest extends IntegrationTestCase
+{
+
+    /**
+     * fixtures property
+     *
+     * @var array
+     */
+    public $fixtures = ['plugin.crud.blogs'];
+
+    /**
+     * Data provider with all HTTP verbs
+     *
+     * @return array
+     */
+    public function allHttpMethodProvider()
+    {
+        return [
+            ['get'],
+            ['post'],
+            ['put'],
+            ['delete']
+        ];
+    }
+
+    /**
+     * Test the normal HTTP flow for all HTTP verbs
+     *
+     * @dataProvider allHttpMethodProvider
+     * @return void
+     */
+    public function testGet($method)
+    {
+        $this->_eventManager->on(
+            'Dispatcher.beforeDispatch',
+            ['priority' => 1000],
+            function ($event) {
+                $this->_subscribeToEvents($this->_controller);
+            }
+        );
+
+        $this->{$method}('/blogs/list');
+
+        $this->assertEvents(['beforeFind', 'afterFind', 'beforeRender']);
+        $this->assertNotNull($this->viewVariable('viewVar'));
+        $this->assertNotNull($this->viewVariable('blogs'));
+        $this->assertNotNull($this->viewVariable('success'));
+    }
+
+    /**
+     * Test that changing the viewVar reflects in controller::$viewVar
+     *
+     * @return void
+     */
+    public function testGetWithViewVar()
+    {
+        $this->_eventManager->on(
+            'Dispatcher.beforeDispatch',
+            ['priority' => 1000],
+            function ($event) {
+                $this->_controller->Crud->action('list')->viewVar('items');
+                $this->_subscribeToEvents($this->_controller);
+            }
+        );
+
+        $this->get('/blogs/list');
+
+        $this->assertEvents(['beforeFind', 'afterFind', 'beforeRender']);
+        $this->assertNotNull($this->viewVariable('viewVar'));
+        $this->assertNotNull($this->viewVariable('items'));
+        $this->assertNotNull($this->viewVariable('success'));
+    }
+}

--- a/tests/TestCase/Controller/Component/CrudComponentTest.php
+++ b/tests/TestCase/Controller/Component/CrudComponentTest.php
@@ -66,7 +66,8 @@ class CrudExamplesController extends \Cake\Controller\Controller
                 'Crud.Add',
                 'Crud.Edit',
                 'Crud.Delete',
-                'Crud.View'
+                'Crud.View',
+                'Crud.List'
             ]
         ]
     ];
@@ -119,6 +120,16 @@ class CrudExamplesController extends \Cake\Controller\Controller
     public function index()
     {
         return $this->Crud->execute('index');
+    }
+
+    /**
+     * Test it should render 'list'
+     *
+     * @return void
+     */
+    public function listing()
+    {
+        return $this->Crud->execute('list');
     }
 }
 
@@ -206,7 +217,8 @@ class CrudComponentTest extends TestCase
                 'Crud.Add',
                 'Crud.Edit',
                 'Crud.View',
-                'Crud.Delete'
+                'Crud.Delete',
+                'Crud.List'
             ]
         ];
 


### PR DESCRIPTION
Like `index` action but without pagination. So you don't have to do `limit => 9999` to get a list of all your categories (or other table).