### PR TITLE
Fallback to default factory for controller

### DIFF
--- a/src/Core/ProxyTrait.php
+++ b/src/Core/ProxyTrait.php
@@ -111,7 +111,7 @@ trait ProxyTrait
     protected function _table()
     {
         return $this->_controller()
-            ->loadModel(null, $this->config('modelFactory') ?: 'Table');
+            ->loadModel(null, $this->config('modelFactory') ?: $this->_controller()->modelType());
     }
 
     /**


### PR DESCRIPTION
Right now, if one defines a default factory the cake promoted way using `ModelAwareTrait::modelType()`, the plugin doesn't automatically detect it.

This change will fix the behavior and help avoiding to set the factory twice (for controller and for Crud's proxy).