### PR TITLE
Overhaul of docs

### DIFF
--- a/docs/_code/action_index.php
+++ b/docs/_code/action_index.php
@@ -1,27 +1,29 @@
 <?php
 namespace Crud\Action;
 
-class Index extends BaseAction {
+class Index extends BaseAction
+{
 
-	/**
-	 * Generic handler for all HTTP verbs
-	 *
-	 * @return void
-	 */
-	protected function _handle() {
-		$subject = $this->_subject();
-		$subject->set(['success' => true, 'viewVar' => $this->viewVar()]);
+    /**
+     * Generic handler for all HTTP verbs
+     *
+     * @return void
+     */
+    protected function _handle()
+    {
+        $subject = $this->_subject();
+        $subject->set(['success' => true, 'viewVar' => $this->viewVar()]);
 
-		$this->_trigger('beforePaginate', $subject);
+        $this->_trigger('beforePaginate', $subject);
 
-		$controller = $this->_controller();
-		$items = $controller->paginate();
-		$subject->set(['items' => $items]);
+        $controller = $this->_controller();
+        $items = $controller->paginate();
+        $subject->set(['items' => $items]);
 
-		$this->_trigger('afterPaginate', $subject);
+        $this->_trigger('afterPaginate', $subject);
 
-		$controller->set(['success' => $subject->success, $subject->viewVar => $subject->items]);
-		$this->_trigger('beforeRender', $subject);
-	}
+        $controller->set(['success' => $subject->success, $subject->viewVar => $subject->items]);
+        $this->_trigger('beforeRender', $subject);
+    }
 
 }

--- a/docs/_code/listener_example.php
+++ b/docs/_code/listener_example.php
@@ -5,8 +5,7 @@ class Example extends \Crud\Listener\BaseListener
 {
 
     /**
-     * Returns a list of all events that will fire in the lister during the
-     * CRUD life-cycle.
+     * Returns a list of all events that will fire in the lister during the Crud life-cycle.
      *
      * @return array
      */
@@ -18,9 +17,9 @@ class Example extends \Crud\Listener\BaseListener
     }
 
     /**
-     * Executed when Crud.beforeRender is emitted
+     * Executed when Crud.beforeRender is emitted.
      *
-     * @param \Cake\Event\Event $event
+     * @param \Cake\Event\Event $event Event instance
      *
      * @return void
      */

--- a/docs/_code/listener_example.php
+++ b/docs/_code/listener_example.php
@@ -1,28 +1,32 @@
 <?php
 namespace Crud\Listener;
 
-class Example extends \Crud\Listener\BaseListener {
+class Example extends \Crud\Listener\BaseListener
+{
 
-/**
- * Returns a list of all events that will fire in the lister during the
- * CRUD life-cycle.
- *
- * @return array
- */
-  public function implementedEvents() {
-    return [
-      'Crud.beforeRender' => ['callable' => 'beforeRender']
-    ];
-  }
+    /**
+     * Returns a list of all events that will fire in the lister during the
+     * CRUD life-cycle.
+     *
+     * @return array
+     */
+    public function implementedEvents()
+    {
+        return [
+            'Crud.beforeRender' => ['callable' => 'beforeRender']
+        ];
+    }
 
-/**
- * Executed when Crud.beforeRender is emitted
- *
- * @param \Cake\Event\Event $event
- * @return void
- */
-  public function beforeRender(Cake\Event\Event $event) {
-    $this->_response()->header('X-Powered-By', 'CRUD 4.0');
-  }
+    /**
+     * Executed when Crud.beforeRender is emitted
+     *
+     * @param \Cake\Event\Event $event
+     *
+     * @return void
+     */
+    public function beforeRender(\Cake\Event\Event $event)
+    {
+        $this->_response()->header('X-Powered-By', 'CRUD 4.0');
+    }
 
 }

--- a/docs/_partials/actions/configuration/enabled.rst
+++ b/docs/_partials/actions/configuration/enabled.rst
@@ -6,6 +6,11 @@ Test or modify if the Crud Action is enabled or not.
 When a CrudAction is disabled, Crud will not handle any requests to the action, and CakePHP will raise the normal
 ``\Cake\Error\MissingActionException`` exception if you haven't implemented the action in your controller.
 
+.. warning::
+
+    If you have enabled Crud and you are still receiving a ``MissingActionException``, ensure the action is enabled and
+    that the controller has the ``\Crud\Controller\ControllerTrait`` implemented.
+
 To test if an action is enabled, call the ``enabled`` method on the action.
 
 .. code-block:: phpinline

--- a/docs/_partials/actions/configuration/related_models.rst
+++ b/docs/_partials/actions/configuration/related_models.rst
@@ -3,7 +3,7 @@ relatedModels
 
 .. note::
 
-    If you have the :doc:`RelatedModels listener </listeners/related-models>` configured, you can have Crud automatically load related data
+    If you have the :doc:`RelatedModels listener </listeners/related-models>` configured, you can have Crud automatically load related data.
 
 .. code-block:: phpinline
 

--- a/docs/_partials/actions/configuration/related_models.rst
+++ b/docs/_partials/actions/configuration/related_models.rst
@@ -1,4 +1,13 @@
-Related models
-^^^^^^^^^^^^^^
+relatedModels
+^^^^^^^^^^^^^
 
-related_models
+.. note::
+
+    If you have the :doc:`RelatedModels listener </listeners/related-models>` configured, you can have Crud automatically load related data
+
+.. code-block:: phpinline
+
+    <?php
+    $this->Crud->listener('relatedModels')->relatedModels(true);
+
+Find out more about the :doc:`RelatedModels listener </listeners/related-models>` in the :doc:`Listeners chapter </listeners>`.

--- a/docs/_partials/events/after_bulk.rst
+++ b/docs/_partials/events/after_bulk.rst
@@ -1,5 +1,5 @@
 Crud.afterBulk
-^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^
 
 This event is emitted after calling ``_bulk()`` on a Bulk Crud action.
 
@@ -16,11 +16,11 @@ Check Success
 .. code-block:: phpinline
 
   public function bulk($id) {
-    $this->Crud->on('afterBulk', function(\Cake\Event\Event $event) {
-      if (!$event->subject->success) {
-        $this->log("Bulk action failed");
-      }
-    });
+      $this->Crud->on('afterBulk', function(\Cake\Event\Event $event) {
+          if (!$event->subject()->success) {
+            $this->log("Bulk action failed");
+          }
+      });
 
-    return $this->Crud->execute();
+      return $this->Crud->execute();
   }

--- a/docs/_partials/events/after_delete.rst
+++ b/docs/_partials/events/after_delete.rst
@@ -15,11 +15,11 @@ Check Success
 .. code-block:: phpinline
 
   public function delete($id) {
-    $this->Crud->on('afterDelete', function(\Cake\Event\Event $event) {
-      if (!$event->subject->success) {
-        $this->log("Delete failed for entity $event->subject->id");
-      }
-    });
+      $this->Crud->on('afterDelete', function(\Cake\Event\Event $event) {
+          if (!$event->subject()->success) {
+            $this->log("Delete failed for entity " . $event->subject()->id);
+          }
+      });
 
-    return $this->Crud->execute();
+      return $this->Crud->execute();
   }

--- a/docs/_partials/events/after_find.rst
+++ b/docs/_partials/events/after_find.rst
@@ -18,9 +18,9 @@ Logging the Found Item
 .. code-block:: phpinline
 
   public function delete($id) {
-    $this->Crud->on('afterFind', function(\Cake\Event\Event $event) {
-      $this->log("Found item: $event->subject->entity->id in the database");
-    });
+      $this->Crud->on('afterFind', function(\Cake\Event\Event $event) {
+          $this->log("Found item: " . $event->subject()->entity->id . " in the database");
+      });
 
-    return $this->Crud->execute();
+      return $this->Crud->execute();
   }

--- a/docs/_partials/events/after_lookup.rst
+++ b/docs/_partials/events/after_lookup.rst
@@ -1,5 +1,5 @@
 Crud.afterLookup
-^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^
 
 This event is emitted right after the call to ``Controller::paginate()`` in the Lookup Action.
 
@@ -11,11 +11,11 @@ Modify the Result
 .. code-block:: phpinline
 
   public function lookup() {
-    $this->Crud->on('afterLookup', function(\Cake\Event\Event $event) {
-      foreach ($event->subject->entities as $entity) {
-        // $entity is an entity
-      }
-    });
+      $this->Crud->on('afterLookup', function(\Cake\Event\Event $event) {
+          foreach ($event->subject()->entities as $entity) {
+            // $entity is an entity
+          }
+      });
 
-    return $this->Crud->execute();
+      return $this->Crud->execute();
   }

--- a/docs/_partials/events/after_paginate.rst
+++ b/docs/_partials/events/after_paginate.rst
@@ -11,11 +11,11 @@ Modify the Result
 .. code-block:: phpinline
 
   public function index() {
-    $this->Crud->on('afterPaginate', function(\Cake\Event\Event $event) {
-      foreach ($event->subject->entities as $entity) {
-        // $entity is an entity
-      }
-    });
+      $this->Crud->on('afterPaginate', function(\Cake\Event\Event $event) {
+          foreach ($event->subject()->entities as $entity) {
+              // $entity is an entity
+          }
+      });
 
-    return $this->Crud->execute();
+      return $this->Crud->execute();
   }

--- a/docs/_partials/events/after_save.rst
+++ b/docs/_partials/events/after_save.rst
@@ -20,15 +20,15 @@ Check Created Status
 .. code-block:: phpinline
 
   public function edit($id) {
-    $this->Crud->on('afterSave', function(\Cake\Event\Event $event) {
-      if ($event->subject->created) {
-        $this->log("The entity was created");
-      } else {
-        $this->log("The entity was updated");
-      }
-    });
+      $this->Crud->on('afterSave', function(\Cake\Event\Event $event) {
+          if ($event->subject()->created) {
+              $this->log("The entity was created");
+          } else {
+              $this->log("The entity was updated");
+          }
+      });
 
-    return $this->Crud->execute();
+      return $this->Crud->execute();
   }
 
 Check Success Status
@@ -37,15 +37,15 @@ Check Success Status
 .. code-block:: phpinline
 
   public function edit($id) {
-    $this->Crud->on('afterSave', function(\Cake\Event\Event $event) {
-      if ($event->subject->success) {
-        $this->log("The entity was saved successfully");
-      } else {
-        $this->log("The entity was NOT saved successfully");
-      }
-    });
+      $this->Crud->on('afterSave', function(\Cake\Event\Event $event) {
+          if ($event->subject()->success) {
+              $this->log("The entity was saved successfully");
+          } else {
+              $this->log("The entity was NOT saved successfully");
+          }
+      });
 
-    return $this->Crud->execute();
+      return $this->Crud->execute();
   }
 
 Get Entity ID
@@ -54,11 +54,11 @@ Get Entity ID
 .. code-block:: phpinline
 
   public function add() {
-    $this->Crud->on('afterSave', function(\Cake\Event\Event $event) {
-    if ($event->subject->created) {
-        $this->log("The entity was created with id: $event->subject->id");
-      }
-    });
+      $this->Crud->on('afterSave', function(\Cake\Event\Event $event) {
+        if ($event->subject()->created) {
+            $this->log("The entity was created with id: " . $event->subject()->id);
+        }
+      });
 
-    return $this->Crud->execute();
+      return $this->Crud->execute();
   }

--- a/docs/_partials/events/before_bulk.rst
+++ b/docs/_partials/events/before_bulk.rst
@@ -1,5 +1,5 @@
 Crud.beforeBulk
-^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^
 
 This event is emitted before ``_bulk()`` is called on a Bulk Crud action.
 
@@ -18,12 +18,12 @@ Stop Bulk Action
 .. code-block:: phpinline
 
   public function bulk($id) {
-    $this->Crud->on('beforeBulk', function(\Cake\Event\Event $event) {
-      // Stop the bulk event, the action will not continue
-      if ($event->subject->item->author !== 'admin') {
-        $event->stopPropagation();
-      }
-    });
+      $this->Crud->on('beforeBulk', function(\Cake\Event\Event $event) {
+          // Stop the bulk event, the action will not continue
+          if ($event->subject()->item->author !== 'admin') {
+              $event->stopPropagation();
+          }
+      });
 
-    return $this->Crud->execute();
+      return $this->Crud->execute();
   }

--- a/docs/_partials/events/before_delete.rst
+++ b/docs/_partials/events/before_delete.rst
@@ -17,12 +17,12 @@ Stop Delete
 .. code-block:: phpinline
 
   public function delete($id) {
-    $this->Crud->on('beforeDelete', function(\Cake\Event\Event $event) {
-      // Stop the delete event, the entity will not be deleted
-      if ($event->subject->item->author !== 'admin') {
-        $event->stopPropagation();
-      }
-    });
+      $this->Crud->on('beforeDelete', function(\Cake\Event\Event $event) {
+          // Stop the delete event, the entity will not be deleted
+          if ($event->subject()->item->author !== 'admin') {
+              $event->stopPropagation();
+          }
+      });
 
-    return $this->Crud->execute();
+      return $this->Crud->execute();
   }

--- a/docs/_partials/events/before_filter.rst
+++ b/docs/_partials/events/before_filter.rst
@@ -1,5 +1,5 @@
 Crud.beforeFilter
-^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^
 
 Triggered when a ``CrudAction`` is going to handle a CakePHP request.
 

--- a/docs/_partials/events/before_find.rst
+++ b/docs/_partials/events/before_find.rst
@@ -24,17 +24,18 @@ If a record is found the ``Crud.afterFind`` event is emitted.
 
 .. warning::
 
-  If no record is found in the database, the :doc:`Crud.recordNotFound` event is emitted instead of ``Crud.afterFind``.
+  If no record is found in the database, the ``recordNotFound`` event is emitted instead of ``Crud.afterFind``.
 
 Add Conditions
 """"""""""""""
 
 .. code-block:: phpinline
 
-  public function delete($id) {
-    $this->Crud->on('beforeFind', function(\Cake\Event\Event $event) {
-      $event->subject->query->where(['author' => $this->Auth->user('id')]);
-    });
+  public function delete($id)
+  {
+      $this->Crud->on('beforeFind', function(\Cake\Event\Event $event) {
+          $event->subject()->query->where(['author' => $this->Auth->user('id')]);
+      });
 
-    return $this->Crud->execute();
+      return $this->Crud->execute();
   }

--- a/docs/_partials/events/before_lookup.rst
+++ b/docs/_partials/events/before_lookup.rst
@@ -1,5 +1,5 @@
 Crud.beforeLookup
-^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^
 
 This event is emitted before ``Controller::paginate()`` is called inside the Lookup Action.
 
@@ -9,9 +9,9 @@ Add Conditions
 .. code-block:: phpinline
 
   public function lookup() {
-    $this->Crud->on('beforeLookup', function(\Cake\Event\Event $event) {
-      $this->paginate['conditions']['is_active'] = true;
-    });
+      $this->Crud->on('beforeLookup', function(\Cake\Event\Event $event) {
+          $this->paginate['conditions']['is_active'] = true;
+      });
 
-    return $this->Crud->execute();
+      return $this->Crud->execute();
   }

--- a/docs/_partials/events/before_paginate.rst
+++ b/docs/_partials/events/before_paginate.rst
@@ -8,10 +8,11 @@ Add Conditions
 
 .. code-block:: phpinline
 
-  public function index() {
-    $this->Crud->on('beforePaginate', function(\Cake\Event\Event $event) {
-      $this->paginate['conditions']['is_active'] = true;
-    });
+  public function index()
+  {
+      $this->Crud->on('beforePaginate', function(\Cake\Event\Event $event) {
+          $this->paginate['conditions']['is_active'] = true;
+      });
 
-    return $this->Crud->execute();
+      return $this->Crud->execute();
   }

--- a/docs/actions.rst
+++ b/docs/actions.rst
@@ -1,5 +1,6 @@
+*******
 Actions
-=======
+*******
 
 .. note::
 
@@ -7,34 +8,26 @@ Actions
 	``Delete`` actions,	so you do not need to implement these on your own.
 	You can find the documentation for these actions in the menu to the left.
 
-Actions are the backbone of CRUD - this is where most of the logic happens.
-
-A ``Crud Action`` contains more or less the exact same code as a normal
-controller action.
-
-The main difference between your normal Controller actions and a CRUD Action
-is that the CRUD Action is highly generic and flexible.
+Crud Actions are the backbone of the plugin, this is where most of the logic happens.
 
 What Is An Action?
-^^^^^^^^^^^^^^^^^^
+==================
 
-A CRUD action roughly translates to a normal Controller action.
+A Crud action roughly translates to a normal Controller action. The primary difference is that CRUD actions are made to
+be as generic and secure out of the box as possible.
 
-The primary difference is that CRUD actions are made to be as generic and secure
-out of the box as possible.
+You can consider a CRUD action as a more flexible PHP trait that fits nicely within the CakePHP ecosystem.
 
-You can consider a CRUD action as a more flexible PHP trait that fits nicely
-within the CakePHP ecosystem.
+A nice added bonus is that if all your controllers share a generic controller action, you only have to unit test once,
+to test every controller in your application.
 
 The Anatomy Of An Action
-^^^^^^^^^^^^^^^^^^^^^^^^
+========================
 
 Below is the code for the :doc:`Index Crud Action<actions/index>`
 
 In the next few sections we will walk through the code and explain how it works,
-and what every single line of code does.
-
-For each section, the relevant lines of code will be highlighted.
+and what every single line of code does. For each section, the relevant lines of code will be highlighted.
 
 .. literalinclude:: _code/action_index.php
 	 :language: php
@@ -50,6 +43,9 @@ All actions in Crud, even your own, should inherit from the
 ``Crud\Action\Base`` class.
 This class is ``abstract`` and provides numerous auxiliary methods which can be
 useful for you both as a developer as an action creator.
+
+Where you choose to put your custom Crud actions is up to you, but using ``src/Crud`` is a good place. Remember to
+namespace your action class accordingly.
 
 .. literalinclude:: _code/action_index.php
 	 :language: php
@@ -86,20 +82,18 @@ and saving the entity back to the database.
 Events & Subject
 ----------------
 
-All Crud actions emit a range of events, and all of these events always contain a
-:ref:`Crud Subject`<crud-subject>`. The :ref:`Crud Subject`<crud-subject>`
-can change its state between emitted events. This object is a simple ``StdClass``
-which contains the current state of the Crud request.
+All Crud actions emit a range of events, and all of these events always contain a Crud Subject. The Crud Subject can
+change its state between emitted events. This object is a simple ``StdClass`` which contains the current state of the Crud request.
 
 The real beauty of Crud is the events and the flexibility they provide.
 
-All calls to ``_trigger()`` emit an event, that you as a developer can listen to
-and inject your own application logic. These events are in no way magical, they
-are simply normal CakePHP events, dispatched like all other events in CakePHP.
+All calls to ``_trigger()`` emit an event, that you as a developer can listen to and inject your own application logic.
+These events are in no way magical, they are simply normal
+`CakePHP events <http://book.cakephp.org/3.0/en/core-libraries/events.html>`_, dispatched like all
+other `events in CakePHP <http://book.cakephp.org/3.0/en/core-libraries/events.html>`_.
 
-You can for example listen for the ``beforePaginate`` event and add conditions
-to your pagination query, just with a few lines of code. Those few lines
-of code is what makes your application unique. The rest of the code you would
+You can for example listen for the ``beforePaginate`` event and add conditions to your pagination query, just with a
+few lines of code. Those few lines of code is what makes your application unique. The rest of the code you would
 normally have is simply repeated boiler plate code.
 
 .. literalinclude:: _code/action_index.php
@@ -112,30 +106,30 @@ Boilerplate
 
 Only the code that you would normally have in your controller is left now.
 
-While these 3 lines seem simple, and the whole Crud implementation a bit overkill
-at first, the true power of this setup will be clear when your application
-grows and the requirements increase.
+While these 3 lines seem simple, and the whole Crud implementation a bit overkill at first, the true power of this setup
+will be clear when your application grows and the requirements increase.
 
 .. literalinclude:: _code/action_index.php
 	 :language: php
 	 :linenos:
 	 :emphasize-lines: 17,18,23
 
-For example adding an API layer to your application later in time will be
-non-trivial and time consuming if you do not use crud - especially if you have
-many controllers.
+For example :doc:`adding an API layer<api>` to your application later in time will be easy because you don't need to edit
+all your applications many controllers.
 
-Using Crud, it would be as simple as loading the :doc:`API listener<listeners/api>`
-and everything would be taken care of. All validation, exceptions, success
-and error responses would work immediately, and with just a few lines of code.
+Using Crud, it would be as simple as loading the :doc:`API listener<listeners/api>` and everything would be taken care
+of. All validation, exceptions, success and error responses would work immediately, and with just a few lines of code.
 
-This is because the powerful event system can hook into the request and hijack
-the rendering easily and effortlessly -- something baked controllers do not offer.
+This is because the powerful event system can hook into the request and hijack the rendering easily and effortlessly;
+something baked controllers do not offer.
 
-More On Actions
-^^^^^^^^^^^^^^^
+Crud's default actions
+======================
+
+Crud has many actions built-in which come with the plugin.
 
 .. toctree::
+	:maxdepth: 1
 
 	actions/index
 	actions/view
@@ -147,4 +141,4 @@ More On Actions
 	actions/bulk-delete
 	actions/bulk-set-value
 	actions/bulk-toggle
-	actions/custom
+	Custom <actions/custom>

--- a/docs/actions/add.rst
+++ b/docs/actions/add.rst
@@ -1,5 +1,5 @@
 Add
-====
+===
 
 The ``Add Crud Action`` will create a new record if the request is ``POST``
 and the data validates - otherwise it will attempt to render a form to the end-user.

--- a/docs/actions/bulk-delete.rst
+++ b/docs/actions/bulk-delete.rst
@@ -3,18 +3,18 @@ Bulk Delete
 
 You can use the ``Bulk\DeleteAction`` class to delete a group of database records.
 
-.. code:: php
+.. code-block:: phpinline
 
   <?php
   namespace App\Controller;
 
   class PostsController extends AppController
   {
-    public function initialize()
-    {
-      parent::initialize();
-      $this->Crud->mapAction('deleteAll', 'Crud.Bulk/Delete');
-    }
+      public function initialize()
+      {
+          parent::initialize();
+          $this->Crud->mapAction('deleteAll', 'Crud.Bulk/Delete');
+      }
   }
 
 Configuration

--- a/docs/actions/bulk-set-value.rst
+++ b/docs/actions/bulk-set-value.rst
@@ -4,22 +4,22 @@ Bulk Set Value
 You can use the ``Bulk\SetValueAction`` class to specify the value of a
 given field for a group of database records.
 
-.. code:: php
+.. code-block:: phpinline
 
   <?php
   namespace App\Controller;
 
   class PostsController extends AppController
   {
-    public function initialize()
-    {
-      parent::initialize();
-      $this->Crud->mapAction('publishAll', [
-        'className' => 'Crud.Bulk/SetValue',
-        'field' => 'status',
-        'value' => 'publish',
-      ]);
-    }
+      public function initialize()
+      {
+          parent::initialize();
+          $this->Crud->mapAction('publishAll', [
+              'className' => 'Crud.Bulk/SetValue',
+              'field' => 'status',
+              'value' => 'publish'
+          ]);
+      }
   }
 
 Configuration

--- a/docs/actions/bulk-toggle.rst
+++ b/docs/actions/bulk-toggle.rst
@@ -4,21 +4,21 @@ Bulk Toggle
 You can use the ``Bulk\ToggleAction`` class to toggle the value of a
 boolean field for a group of database records.
 
-.. code:: php
+.. code-block:: phpinline
 
   <?php
   namespace App\Controller;
 
   class PostsController extends AppController
   {
-    public function initialize()
-    {
-      parent::initialize();
-      $this->Crud->mapAction('toggleActive', [
-        'className' => 'Crud.Bulk/Toggle',
-        'field' => 'toggle',
-      ]);
-    }
+      public function initialize()
+      {
+          parent::initialize();
+          $this->Crud->mapAction('toggleActive', [
+              'className' => 'Crud.Bulk/Toggle',
+              'field' => 'toggle',
+          ]);
+      }
   }
 
 Configuration

--- a/docs/actions/bulk.rst
+++ b/docs/actions/bulk.rst
@@ -13,7 +13,7 @@ Three BulkAction classes exist in the core:
 To create your own BulkAction, simply create a new action class with a ``_bulk``
 method. This method takes a CakePHP ``Query`` object as it's first argument
 
-.. code:: php
+.. code-block:: phpinline
 
   <?php
   namespace App\Crud\Action;

--- a/docs/actions/custom.rst
+++ b/docs/actions/custom.rst
@@ -1,29 +1,74 @@
-Custom
-======
+Custom Action Classes
+=====================
 
-If you are not satisfied with the :doc:`Actions</actions>` bundled with CRUD -
-you can easily add your own.
+If you need to customise an action for any reason, you can create your own custom Crud action class.
 
 A Crud Action can respond to any ``HTTP`` verb (``GET``, ``POST``, ``PUT``, ``DELETE``).
-Each HTTP verb can be implemented as method, e.g. _get() for HTTP ``GET``,
-_post() for HTTP ``POST`` and _put() for HTTP ``PUT``.
+Each HTTP verb can be implemented as method, e.g. ``_get()`` for HTTP ``GET``,
+``_post()`` for HTTP ``POST`` and ``_put()`` for HTTP ``PUT``.
 
 If no HTTP verb specific method is found in the class, ``_handle()`` will be executed.
 
-.. code:: php
+A default custom index action might be as simple as the following.
 
-	<?php
-	namespace App\Crud\Action;
+.. code-block:: phpinline
 
-	class Index extends \Crud\Action\BaseAction {
+    <?php
+    namespace App\Crud\Action;
 
-		/**
-		* Generic handler for all HTTP verbs
-		*
-		* @return void
-		*/
-		protected function _handle() {
+    class MyIndex extends \Crud\Action\BaseAction
+    {
 
-		}
+        /**
+        * Generic handler for all HTTP verbs
+        *
+        * @return void
+        */
+        protected function _handle()
+        {
+            $query = $this->_table()->find($this->findMethod());
+            $items = $this_controller()->paginate($query);
+        }
 
-	}
+    }
+
+.. note::
+
+  In this basic example, we have removed all the events that are emitted.
+
+Why
+---
+
+The most common use-cases for a custom action class is when you need to have specific code run on all your controllers
+for a certain action. That might be reading from the session or adjusting the query to add dynamic complex conditions.
+
+Remember that in the :doc:`/configuration` you can configure your action classes on a per-action basis, so you might just
+want a custom action for a single action across your controllers.
+
+Using your custom action class
+------------------------------
+
+Once you have created your custom action class, you can configure Crud to use it for specific actions by changing the
+Crud component configuration.
+
+.. code-block:: phpinline
+
+  class AppController extends \Cake\Controller\Controller
+  {
+
+      use \Crud\Controller\ControllerTrait;
+
+      public function initialize()
+      {
+          parent::initialize();
+
+          $this->loadComponent('Crud.Crud', [
+              'actions' => [
+                  'index' => ['className' => '\\App\\Crud\\MyIndexAction']
+              ]
+          ]);
+      }
+
+.. note::
+
+  Ensure that you escape your namespace when loading your own action classes.

--- a/docs/actions/custom.rst
+++ b/docs/actions/custom.rst
@@ -64,7 +64,7 @@ Crud component configuration.
 
           $this->loadComponent('Crud.Crud', [
               'actions' => [
-                  'index' => ['className' => '\\App\\Crud\\MyIndexAction']
+                  'index' => ['className' => '\App\Crud\Action\MyIndexAction']
               ]
           ]);
       }

--- a/docs/actions/custom.rst
+++ b/docs/actions/custom.rst
@@ -1,7 +1,7 @@
 Custom Action Classes
 =====================
 
-If you need to customise an action for any reason, you can create your own custom Crud action class.
+If you need to customize an action for any reason, you can create your own custom Crud action class.
 
 A Crud Action can respond to any ``HTTP`` verb (``GET``, ``POST``, ``PUT``, ``DELETE``).
 Each HTTP verb can be implemented as method, e.g. ``_get()`` for HTTP ``GET``,
@@ -9,7 +9,7 @@ Each HTTP verb can be implemented as method, e.g. ``_get()`` for HTTP ``GET``,
 
 If no HTTP verb specific method is found in the class, ``_handle()`` will be executed.
 
-A default custom index action might be as simple as the following.
+A default custom index action might be as simple as the following:
 
 .. code-block:: phpinline
 
@@ -40,7 +40,7 @@ Why
 ---
 
 The most common use-cases for a custom action class is when you need to have specific code run on all your controllers
-for a certain action. That might be reading from the session or adjusting the query to add dynamic complex conditions.
+for a certain action. For example reading from the session or adjusting the query to add dynamic complex conditions.
 
 Remember that in the :doc:`/configuration` you can configure your action classes on a per-action basis, so you might just
 want a custom action for a single action across your controllers.

--- a/docs/actions/delete.rst
+++ b/docs/actions/delete.rst
@@ -9,7 +9,6 @@ Configuration
 .. include:: /_partials/actions/configuration_intro.rst
 .. include:: /_partials/actions/configuration/enabled.rst
 .. include:: /_partials/actions/configuration/find_method.rst
-.. include:: /_partials/actions/configuration/secure_delete.rst
 .. include:: /_partials/actions/configuration/serialize.rst
 
 Events
@@ -24,7 +23,7 @@ properties and how to use the event system correctly.
 .. include:: /_partials/events/before_filter.rst
 .. include:: /_partials/events/before_find.rst
 .. include:: /_partials/events/after_find.rst
-.. include:: /_partials/events/not_found.rst
+.. include:: /_partials/events/record_not_found.rst
 .. include:: /_partials/events/before_delete.rst
 .. include:: /_partials/events/after_delete.rst
 .. include:: /_partials/events/before_redirect.rst

--- a/docs/actions/lookup.rst
+++ b/docs/actions/lookup.rst
@@ -1,7 +1,7 @@
 Lookup
-====
+======
 
-The ``Lookup Crud Action`` will display a record from a data source for auto-complete purposes. Used mostly for crud-view.
+The ``Lookup Crud Action`` will display a record from a data source for auto-complete purposes. Used mostly for `Crud-View <https://github.com/friendsofcake/crud-view>`_.
 
 Configuration
 -------------

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -2,7 +2,7 @@
 Creating an API
 ***************
 
-Creating a REST API using Crud is very easy and just requires the use of the Api Listener.
+Creating a REST API using Crud is very easy and just requires adding the Api Listener to your application.
 
 `Bravo-Kernel of the CakePHP community has written a great blog post on implementing an Api using Crud. <http://www.bravo-kernel.com/2015/04/how-to-build-a-cakephp-3-rest-api-in-minutes/>`_.
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,0 +1,13 @@
+***************
+Creating an API
+***************
+
+Creating a REST API using Crud is very easy and just requires the use of the Api Listener.
+
+`Bravo-Kernel of the CakePHP community has written a great blog post on implementing an Api using Crud. <http://www.bravo-kernel.com/2015/04/how-to-build-a-cakephp-3-rest-api-in-minutes/>`_.
+
+Implementing the API Listener
+=============================
+
+If you'd like to get started right away with the :doc:`api listener </listeners/api>`, please check the
+:doc:`Listeners chapter </listeners>`.

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -1,49 +1,51 @@
+*************
 Configuration
-=============
+*************
 
-Configuration of Crud is done through the Crud ``component`` - either on the fly
+Configuration of Crud is done through the Crud component - either on the fly
 anywhere in you application, or by providing the configuration in the
-``Controller::$components`` property.
+``Controller::loadComponent()`` method.
 
 Assuming you have followed the :doc:`installation guide<installation>` we will
 now begin the actual configuration of Crud.
 
-Crud is loaded like any other ``Component`` in CakePHP - simply by adding it to
-the ``$components`` variable in the controller
-
 .. code-block:: phpinline
 
   class AppController extends \Cake\Controller\Controller {
 
-    public $components = ['Crud.Crud'];
+    public function initialize()
+    {
+        parent::initialize();
+
+        $this->loadComponent('Crud.Crud');
 
   }
 
-At this time, the Crud Component is loaded and ready for usage.
-
-However, Crud has not been configured to handle any controller actions yet.
+At this time, the Crud Component is loaded, but we need to tell Crud which actions we want it to handle for us.
 
 Actions
--------
+=======
 
-Configuring Crud to handle actions is simple.
+The list of actions is provided either as Component configuration, or on the fly.
 
-The list of actions is provided either as ``Component`` configuration, or on the
-fly.
-
-An example of ``Component`` configuration:
+An example configuration for handling index actions looks like this.
 
 .. code-block:: phpinline
 
-  class AppController extends \Cake\Controller\Controller {
+  class AppController extends \Cake\Controller\Controller
+  {
 
-    public $components = [
-      'Crud.Crud' => [
-        'actions' => ['Crud.Index']
-      ]
-    ];
+    use \Crud\Controller\ControllerTrait;
 
-  }
+    public function initialize()
+    {
+        parent::initialize();
+
+        $this->loadComponent('Crud.Crud', [
+            'actions' => [
+                'Crud.Index'
+            ]
+        ]);
 
 An example of on the fly enabling an Crud action:
 
@@ -63,43 +65,41 @@ The examples above are functionally identical, and instructs Crud to handle the
 .. note::
 
   If you do not wish for Crud to be enabled across all controllers, or even use
-  all ``actions`` provided by Crud
-  you can pick and chose which to use. Crud will not force take-over any
-  application logic, and you can enable/disable
+  all ``actions`` provided by Crud you can pick and chose which to use.
+  Crud will not force take-over any application logic, and you can enable/disable
   them as you see fit.
 
 Action configuration
---------------------
+====================
 
 .. note::
 
-  Each :doc:`Crud Action<actions>` have a different set of configuration
-  settings, please see their individual documentation page for more information.
+  Each :doc:`Crud Action<actions>` can have a different set of configuration
+  settings, please see their individual documentation pages for more information.
 
-Passing in configuration for an action is simple.
-
-.. note::
-
-  In the examples below, we reconfigure the `Index Action` to render
-  ``my_index.ctp`` instead of ``index.ctp``
-
-An example of ``Component`` configuration
+A more verbose example now, where we'll change the view template that Crud will use for index actions to be ``my_index.ctp``
 
 .. code-block:: phpinline
 
-  class AppController extends \Cake\Controller\Controller {
+  class AppController extends \Cake\Controller\Controller
+  {
 
-    public $components = [
-      'Crud.Crud' => [
-        'actions' => [
-          'index' => ['className' => 'Crud.Index', 'view' => 'my_index']
-        ]
-      ]
-    ];
+    use \Crud\Controller\ControllerTrait;
 
-  }
+    public function initialize()
+    {
+        parent::initialize();
 
-An example of on the fly enabling an Crud action with configuration
+        $this->loadComponent('Crud.Crud', [
+            'actions' => [
+                'index' => [
+                  'className' => 'Crud.Index',
+                  'view' => 'my_index'
+                ]
+            ]
+        ]);
+
+An example of on the fly enabling a Crud action with configuration
 
 .. code-block:: phpinline
 
@@ -115,22 +115,33 @@ An example of on the fly enabling an Crud action with configuration
   }
 
 Disabling loaded actions
-------------------------
-If you've loaded an action in eg. your ``AppController`` - but don't want it included in a specific controller, it can be disabled with the ``$this->Crud->disable(['action_name'])``.
+========================
 
-Example of disable a loaded action:
+If you've loaded an action in eg. your ``AppController`` - but don't want it included in a specific controller, it can
+be disabled with the ``$this->Crud->disable(['action_name'])``.
+
+Example of disabling a loaded action, first we show all actions being configured to be handled by Crud, then disabling a
+specific action in our ``PostsController``.
 
 .. code-block:: phpinline
 
-  class AppController extends \Cake\Controller\Controller {
+  class AppController extends \Cake\Controller\Controller
+  {
 
-    public $components = [
-      'Crud.Crud' => [
-        'actions' => ['Crud.Index', 'Crud.View', 'Crud.Delete', 'Crud.Edit']
-      ]
-    ];
+    use \Crud\Controller\ControllerTrait;
 
-  }
+    public function initialize()
+    {
+        parent::initialize();
+
+        $this->loadComponent('Crud.Crud', [
+            'actions' => [
+                'Crud.Index',
+                'Crud.View',
+                'Crud.Delete',
+                'Crud.Edit'
+            ]
+        ]);
 
 .. code-block:: phpinline
 
@@ -145,9 +156,9 @@ Example of disable a loaded action:
   }
 
 Built-in actions
-----------------
+================
 
-Crud provides the default ``CRUD`` actions out of the box.
+Crud provides the default create, read, update and delete actions out of the box.
 
 * :doc:`Index Action<actions/index>`
 * :doc:`View Action<actions/view>`
@@ -159,17 +170,41 @@ Crud provides the default ``CRUD`` actions out of the box.
 * :doc:`Bulk Set Value Action<actions/bulk-set-value>`
 * :doc:`Bulk Field Toggle Action<actions/bulk-toggle>`
 
-It's possible to create your own ``Crud Action`` as well, or overwrite the
-built-in ones.
+Custom action classes
+=====================
 
-Simply provide the ``className`` configuration key for an action, and Crud will
-use that one instead.
+It's possible to create your own custom action classes as well, or overwrite the built-in ones. Simply provide
+the ``className`` configuration key for an action, and Crud will use that one instead.
 
-Listeners
----------
+.. code-block:: phpinline
+
+  class AppController extends \Cake\Controller\Controller
+  {
+
+    use \Crud\Controller\ControllerTrait;
+
+    public function initialize()
+    {
+        parent::initialize();
+
+        $this->loadComponent('Crud.Crud', [
+            'actions' => [
+                'index' => ['className' => '\\App\\Crud\\MyIndexAction'],
+                'view' => ['className' => '\\App\\Crud\\MyViewAction']
+            ]
+        ]);
 
 .. note::
 
-  Each :doc:`Crud Listener<listeners>` have a different set of configuration
-  settings, please see their individual documentation page for more information.
+  Ensure that you escape your namespace when loading your own action classes.
+
+:doc:`Learn more about custom action classes </actions/custom>`.
+
+Listeners
+=========
+
+The other way to customise the behavior of the Crud plugin is through it's many listeners. These provide lots of
+additional functionality to your scaffolding, such as dealing with api's and loading related data.
+
+Check the :doc:`listeners` documentation for more on Crud's included listeners, and how to create your own.
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -189,8 +189,8 @@ the ``className`` configuration key for an action, and Crud will use that one in
 
         $this->loadComponent('Crud.Crud', [
             'actions' => [
-                'index' => ['className' => '\\App\\Crud\\MyIndexAction'],
-                'view' => ['className' => '\\App\\Crud\\MyViewAction']
+                'index' => ['className' => '\App\Crud\Action\MyIndexAction'],
+                'view' => ['className' => '\App\Crud\Action\MyViewAction']
             ]
         ]);
 

--- a/docs/contents.rst
+++ b/docs/contents.rst
@@ -2,15 +2,15 @@ Contents
 ########
 
 .. toctree::
-	 :maxdepth: 3
+	 :maxdepth: 2
 
 	 index
 	 installation
 	 quick-start
 	 configuration
 	 actions
-	 listeners
 	 events
+	 Event subject <crud-subject>
+	 listeners
+	 api
 	 unit-testing
-
-.. todolist::

--- a/docs/crud-subject.rst
+++ b/docs/crud-subject.rst
@@ -1,0 +1,32 @@
+************
+Crud Subject
+************
+.. _crud-subject:
+
+The Crud Subject is the class which is passed as the subject of all the events that the Crud plugin emits during it's
+execution. Depending on the action being scaffolded, and what it's working on the contents of the subject can be
+different.
+
+Core event subjects
+===================
+
+You can find many of the subject contents are included as part of the :ref:`Core Crud Events <core-crud-events>`
+documentation. This is because the subject of the event is very specific to the event being emitted.
+
+When dealing with listeners, you are able to manipulate the subject of the event in order to change Cruds behavior. Such
+as changing pagination, or adding extra conditions to a query.
+
+This is an example of the data passed in a ``beforeFind`` event subject.
+
+.. code-block:: phpinline
+
+    <?php
+    public function view($id)
+    {
+        $this->Crud->on('beforeFind', function (\Cake\Event\Event $event) {
+            $query = $event->subject()->query;
+            $primaryKey = $event->subject()->id;
+            $table = $event->subject()->repository;
+        });
+
+Find more examples in the :ref:`Core Crud Events <core-crud-events>` documentation, for the event you need.

--- a/docs/events.rst
+++ b/docs/events.rst
@@ -1,21 +1,22 @@
+******
 Events
-======
+******
 
-Events are the backbone of CRUD, and your primary gateway into customization of
-CRUD and fitting it to your applications.
+Events are the backbone of Crud, and your primary gateway into customization of
+Crud and fitting it to your applications.
 
 You can subscribe to events from almost everywhere, and in multiple ways.
 
 Controller
-----------
+==========
 
 implementedEvents
-"""""""""""""""""
+-----------------
 
 We override the ``implementedEvents()`` method in the controller, and bind
 the ``Crud.beforeFind`` event to the ``_beforeFind()`` method in the controller.
 
-When using this technique, you need to prefix all the event names with ``Crud.``.
+When using this technique, you need to prefix all the event names with ``Crud.``
 
 Most of the other ways to listen for events do not need this, as it's done
 automatically.
@@ -27,13 +28,13 @@ automatically.
 
   class BlogsController extends AppController {
 
-    public function implementedEvents() {
-      return parent::implementedEvents() + ['Crud.beforeFind' => '_beforeFind'];
-    }
+      public function implementedEvents() {
+          return parent::implementedEvents() + ['Crud.beforeFind' => '_beforeFind'];
+      }
 
-    public function _beforeFind(\Cake\Event\Event $event) {
+      public function _beforeFind(\Cake\Event\Event $event) {
 
-    }
+      }
 
   }
 
@@ -46,19 +47,17 @@ automatically.
   action.
 
 Action
-""""""
+------
 
-You can bind events directly in your controller actions, simply call the ``on()``
-method in CRUD and provide a callback.
-
-The example below uses a ``closure`` for the callback, but everything that is
-valid for ``call_user_func()`` can be used
+You can bind events directly in your controller actions, simply call the ``on()`` method in Crud and provide a
+callback. The example below uses a ``closure`` for the callback, but everything that is valid for ``call_user_func()``
+can be used
 
 .. code-block:: phpinline
 
   public function view($id) {
     $this->Crud->on('beforeFind', function(\Cake\Event\Event $event) {
-      // Will only execute for the view() action
+        // Will only execute for the view() action
     });
 
     return $this->Crud->execute();
@@ -67,37 +66,39 @@ valid for ``call_user_func()`` can be used
 .. note::
 
   When implementing events in your controller actions, it's important to
-  include ``return $this->Crud->execute();`` - else CRUD will not process the
-  action.
+  include ``return $this->Crud->execute();`` otherwise Crud will not process the action.
 
-This is functionality wise more or less the same as using an controller method instead.
-
-The benefit of the controller method is that you can easily share it between two
-actions, like showcased below
+The benefit of the controller method is that you can easily share it between two actions, like below.
 
 .. code-block:: phpinline
 
   public function view($id) {
-    $this->Crud->on('beforeFind', [$this, '_beforeFind']);
-    return $this->Crud->execute();
+      $this->Crud->on('beforeFind', [$this, '_beforeFind']);
+      return $this->Crud->execute();
   }
 
   public function admin_view($id) {
-    $this->Crud->on('beforeFind', [$this, '_beforeFind']);
-    return $this->Crud->execute();
+      $this->Crud->on('beforeFind', [$this, '_beforeFind']);
+      return $this->Crud->execute();
   }
 
   public function _beforeFind(\Cake\Event\Event $event) {
-    // Will execute for both view() and admin_view()
+      // Will execute for both view() and admin_view()
   }
 
-All CRUD Events
----------------
+.. _core-crud-events:
 
-This is a full list of all events emitted from CRUD.
+Core Crud Events
+================
 
-Each individual :doc:`CRUD action <actions>` contains the same documentation, but only the events
-relevant for that action.
+Different :doc:`Crud actions <actions>` will emit a different combination of events during their execution, with different
+:doc:`Subject <crud-subject>` data. If you are looking for events specific to an action, check the specific
+:doc:`Crud action <actions>` documentation page.
+
+Included actions
+----------------
+
+This is a full list of all events emitted from Crud.
 
 .. include:: /_partials/events/before_filter.rst
 .. include:: /_partials/events/startup.rst
@@ -118,6 +119,5 @@ relevant for that action.
 
 .. include:: /_partials/events/before_render.rst
 
-.. include:: /_partials/events/not_found.rst
 .. include:: /_partials/events/record_not_found.rst
 .. include:: /_partials/events/set_flash.rst

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -2,33 +2,33 @@
 Introduction
 ************
 
-CRUD was built to be scaffolding on steroids, and allow developers to have enough flexibility to use it for both
+Crud was built to be scaffolding on steroids, and allow developers to have enough flexibility to use it for both
 rapid prototyping and production applications, even on the same code base saving you time, and your clients money.
 
 Why Use Crud
 ============
 
-* CRUD is :doc:`very fast to install</installation>`, a few minutes tops.
+* Crud is :doc:`very fast to install</installation>`, a few minutes tops.
 
-* CRUD is very flexible and has tons of :doc:`configuration options</configuration>` (but very sane defaults, just like CakePHP).
+* Crud is very flexible and has tons of :doc:`configuration options</configuration>` (but very sane defaults, just like CakePHP).
 
-* CRUD aims to stay out of your way, and if it happens to get in your way, you can change the undesired behavior very easily.
+* Crud aims to stay out of your way, and if it happens to get in your way, you can change the undesired behavior very easily.
 
-* CRUD relies heavily on CakePHP events making it possible to override, extend, or disable almost all of CRUD's functionality either globally or for one specific action.
+* Crud relies heavily on CakePHP events making it possible to override, extend, or disable almost all of Crud's functionality either globally or for one specific action.
 
-* CRUD removes the boilerplate code from your controllers, which mean less code to maintain, and less code to spend time unit testing.
+* Crud removes the boilerplate code from your controllers, which mean less code to maintain, and less code to spend time unit testing.
 
-* CRUD will dynamically add the actions to your controller so you don't have to re-implement them over and over again.
+* Crud will dynamically add the actions to your controller so you don't have to re-implement them over and over again.
 
-* CRUD allows you to hook into all stages of a request, only building the controller code needed specifically for your business logic, outsourcing all the heavy boiler-plating to CRUD.
+* Crud allows you to hook into all stages of a request, only building the controller code needed specifically for your business logic, outsourcing all the heavy boiler-plating to Crud.
 
-* CRUD allows you to use your own views, baked or hand-crafted, in addition to adding the code needed to fulfill your application logic, using :doc:`events<events>`. It is by default compatible with CakePHP's baked views.
+* Crud allows you to use your own views, baked or hand-crafted, in addition to adding the code needed to fulfill your application logic, using :doc:`events<events>`. It is by default compatible with CakePHP's baked views.
 
 * Optionally there is the `Crud-View plugin <https://github.com/FriendsOfCake/crud-view>`_ for automatic generation of your admin area templates.
 
-* CRUD also provides built in features for JSON :doc:`API<listeners/api>` for any action you have enabled through CRUD, which eliminates maintaining both a HTML frontend and a JSON and/or XML interface for your applications -- saving you tons of time and having a leaner code base.
+* Crud also provides built in features for JSON :doc:`API<listeners/api>` for any action you have enabled through Crud, which eliminates maintaining both a HTML frontend and a JSON and/or XML interface for your applications -- saving you tons of time and having a leaner code base.
 
-* CRUD uses the truly open source MIT license, just like CakePHP.
+* Crud uses the truly open source MIT license, just like CakePHP.
 
 Bugs
 ====

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,13 +1,12 @@
+************
 Introduction
-============
+************
 
-CRUD was built to be `scaffolding <http://book.cakephp.org/2.0/en/controllers/scaffolding.html>`_
-on steroids, and allow developers to have enough flexibility to use it for both
-rapid prototyping and production applications, even on the same code base --
-saving you time.
+CRUD was built to be scaffolding on steroids, and allow developers to have enough flexibility to use it for both
+rapid prototyping and production applications, even on the same code base saving you time, and your clients money.
 
 Why Use Crud
-------------
+============
 
 * CRUD is :doc:`very fast to install</installation>`, a few minutes tops.
 
@@ -21,29 +20,30 @@ Why Use Crud
 
 * CRUD will dynamically add the actions to your controller so you don't have to re-implement them over and over again.
 
-* CRUD does not have the same limitations as CakePHP's own scaffolding, which is "my way or the highway." CRUD allows you to hook into all stages of a request, only building the controller code needed specifically for your business logic, outsourcing all the heavy boiler-plating to CRUD.
+* CRUD allows you to hook into all stages of a request, only building the controller code needed specifically for your business logic, outsourcing all the heavy boiler-plating to CRUD.
 
 * CRUD allows you to use your own views, baked or hand-crafted, in addition to adding the code needed to fulfill your application logic, using :doc:`events<events>`. It is by default compatible with CakePHP's baked views.
 
-* CRUD also provides built in features for JSON :doc:`API<listener/api>` for any action you have enabled through CRUD, which eliminates maintaining both a HTML frontend and a JSON and/or XML interface for your applications -- saving you tons of time and having a leaner code base.
+* Optionally there is the `Crud-View plugin <https://github.com/FriendsOfCake/crud-view>`_ for automatic generation of your admin area templates.
 
-* CRUD uses the MIT license, just like CakePHP.
+* CRUD also provides built in features for JSON :doc:`API<listeners/api>` for any action you have enabled through CRUD, which eliminates maintaining both a HTML frontend and a JSON and/or XML interface for your applications -- saving you tons of time and having a leaner code base.
+
+* CRUD uses the truly open source MIT license, just like CakePHP.
 
 Bugs
-----
+====
 
-If you happen to stumble upon a bug, please feel free to create a pull request with a fix
+If you happen to stumble upon a bug, please `feel free to create a pull request or submit an issue <https://github.com/FriendsOfCake/crud/issues>`_ with a fix
 (optionally with a test), and a description of the bug and how it was resolved.
 
-You can also create an issue with a description to raise awareness of the bug.
-
 Features
---------
+========
 
-If you have a good idea for a Crud feature, please join us on IRC and let's discuss it. Pull
-requests are always more than welcome.
+If you have a good idea for a Crud feature, `please join us in #friendsofcake on irc <https://webchat.freenode.net/>`_ and let's discuss it.
+Opening a `pull request <https://github.com/FriendsOfCake/crud/pulls>`_ is always more than welcome, and a great way to start a discussion.
+Please check our `contribution guidelines <https://github.com/FriendsOfCake/crud/blob/master/CONTRIBUTING.md>`_.
 
 Support / Questions
--------------------
+===================
 
-You can join us on IRC in the #FriendsOfCake channel on irc.freenode.net for any support or questions.
+You can `join us in #friendsofcake on irc <https://webchat.freenode.net/>`_ on irc.freenode.net for any support or questions.

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -2,8 +2,6 @@
 Installation
 ************
 
-Installing via composer is quick and simple, and the plugin is `available on Packagist <https://packagist.org/packages/friendsofcake/crud>`_.
-
 Requirements
 ============
 
@@ -18,6 +16,8 @@ The recommended installation method for this plugin is by using composer.
 .. code-block:: sh
 
 	composer require friendsofcake/crud:^4.3
+
+You can also check `Packagist <https://packagist.org/packages/friendsofcake/crud>`_.
 
 Loading the plugin
 ==================

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -1,57 +1,28 @@
+************
 Installation
-============
+************
 
-Installing composer is quick and simple.
+Installing via composer is quick and simple, and the plugin is `available on Packagist <https://packagist.org/packages/friendsofcake/crud>`_.
 
 Requirements
-------------
+============
 
-* CakePHP 3.x
-* PHP 5.4
-
-Getting the source code
------------------------
-
-You can get the Crud source code using either composer or git.
+* CakePHP 3.2+
+* PHP 5.5.9+
 
 Using composer
---------------
+==============
 
 The recommended installation method for this plugin is by using composer.
 
-Using the inline require for composer:
-
 .. code-block:: sh
 
-	composer require friendsofcake/crud:~4.2
-
-Or add this to your composer.json configuration:
-
-.. code-block:: javascript
-
-	{
-		"require" : {
-			"FriendsOfCake/crud": "~4.2"
-		}
-	}
-
-
-Using git submodule
--------------------
-
-Or add it as a git module, this is recommended over ``git clone`` since it's
-easier to keep up to date with development that way:
-
-.. code-block:: sh
-
-		git submodule add git://github.com/FriendsOfCake/crud.git Plugin/Crud
-		cd Plugin/Crud
-
+	composer require friendsofcake/crud:^4.3
 
 Loading the plugin
-------------------
+==================
 
-Add the following to your /App/Config/bootstrap.php
+Add the following to your ``/config/bootstrap.php``
 
 .. code-block:: phpinline
 
@@ -59,28 +30,54 @@ Add the following to your /App/Config/bootstrap.php
 
 
 Configuring the controller
---------------------------
+==========================
 
-In your AppController add the following code:
+The Crud plugin provides a trait which will catch a MissingActionException and then step in to provide scaffold actions
+to the controllers.
+
+To enable Crud across your whole application add the trait to your ``src/Controller/AppController.php``
 
 .. code-block:: php
 
-	<?php
-	namespace App\Controller;
+    <?php
+    namespace App\Controller;
 
-	class AppController extends \Cake\Controller\Controller {
+    class AppController extends \Cake\Controller\Controller {
 
-		use \Crud\Controller\ControllerTrait;
+        use \Crud\Controller\ControllerTrait;
 
-	}
+    }
 
 .. note::
 
-	It's not required to add the ``ControllerTrait`` to ``AppController`` - you can add it to any specific controller
-	as well if you don't want Crud installed application wide
+    To have Crud just scaffold a single controller you can just add the ``ControllerTrait`` to that specific controller.
 
 Adding the ``ControllerTrait`` itself do not enable anything CRUD, but simply installs the code to handle
 the ``\Cake\Error\MissingActionException`` exception so you don't have to implement an action in your controller
-for Crud to work. This will make a lot of sense later.
+for Crud to work.
 
-The :doc:`Configuration page</configuration>` explains how to setup and configure the Crud component.
+The next step is to load the Crud component in your controller. A basic example is as follows, and will enable the Crud
+plugin to scaffold all your controllers index actions.
+
+.. code-block:: phpinline
+
+  class AppController extends \Cake\Controller\Controller
+  {
+
+    use \Crud\Controller\ControllerTrait;
+
+    public function initialize()
+    {
+        parent::initialize();
+
+        $this->loadComponent('Crud.Crud', [
+            'actions' => [
+                'Crud.Index'
+            ]
+        ]);
+
+        // Other application wide controller setup
+
+  }
+
+Further configuration options are detailed on the :doc:`configuration page</configuration>`.

--- a/docs/listeners.rst
+++ b/docs/listeners.rst
@@ -1,56 +1,48 @@
+*********
 Listeners
-=========
+*********
 
 .. tip::
 
-	While CRUD provides many listeners, it's definitely possible and recommended
-	that you add your own reusable listeners for your application needs
+	While CRUD provides many listeners, it's recommended that you add your own reusable
+	listeners for your application needs
 
-Listeners are the foundation for the extreme flexibility CRUD provides you
-as an application developer.
+Listeners are the foundation for the extreme flexibility Crud provides you as an application developer.
 
-The event system allows you to hook into the most important part of the
-:doc:`CRUD action<actions>` flow and customize it to your unique application
-needs.
+The event system allows you to hook into the most important part of the :doc:`Crud actions<actions>` flow and customize
+it to your unique application needs.
 
 The Anatomy Of A Listener
-^^^^^^^^^^^^^^^^^^^^^^^^^
+=========================
 
 The listener system is simply the
 `Events System <http://book.cakephp.org/3.0/en/core-libraries/events.html>`_ from
-CakePHP, and all the official documentation and usage also applies to CRUD.
+CakePHP, and all the official documentation and usage also applies to Crud.
 
-The CRUD event system uses two methods ``trigger()`` and ``on()`` to interface
+The Crud event system uses two methods ``trigger()`` and ``on()`` to interface
 the underlying CakePHP event system.
 
-The only hard requirement for a CRUD listener is that it needs to either implement
+The only hard requirement for a Crud listener is that it needs to either implement
 the ``implementedEvents()`` method or extend ``\Crud\Listener\Base``.
 
-Below is the code for a simple CRUD listener.
-
-In the next few sections we will walk through the code and explain how it works,
-and what every single line of code does.
+Below is the code for a simple Crud listener. In the next few sections we will walk through the code and explain how
+it works, and what every single line of code does.
 
 For each section, the relevant lines of code will be highlighted.
-
-.. literalinclude:: _code/listener_example.php
-	 :language: php
-	 :linenos:
 
 Class And Namespace
 -------------------
 
-All built-in listeners in CRUD live in the ``Crud\Listener`` namespace.
+All built-in listeners in Crud live in the ``Crud\Listener`` namespace.
 
-All listeners in CRUD, even your own, should inherit from the
-``Crud\Listener\Base`` class.
-This class is ``abstract`` and provides numerous auxiliary methods which can be
-useful for you both as a developer and as an action creator.
+All listeners in Crud, including yours, should inherit from the ``Crud\Listener\Base`` class.
+This class is ``abstract`` and provides numerous auxiliary methods which can be useful for you both as a developer and
+as an action creator.
 
 .. literalinclude:: _code/listener_example.php
 	 :language: php
 	 :linenos:
-	 :emphasize-lines: 2-4, 28
+	 :emphasize-lines: 2-4
 
 Implemented Events
 ------------------
@@ -64,7 +56,7 @@ every time a ``Crud.beforeRender`` event is emitted.
 .. literalinclude:: _code/listener_example.php
 	 :language: php
 	 :linenos:
-	 :emphasize-lines: 6-16
+	 :emphasize-lines: 6-18
 
 .. note::
 
@@ -75,21 +67,24 @@ every time a ``Crud.beforeRender`` event is emitted.
 The Callback
 ------------
 
-This method gets executed every time a ``Crud.beforeRender`` event is emitted
-from within CRUD or by you as a developer.
-
-When the event is emitted, we append a header to the client HTTP response named
-``X-Powered-By`` with the value ``CRUD 4.0``.
+This method gets executed every time a ``Crud.beforeRender`` event is emitted from within Crud or by you as a
+developer. When the event is emitted, we append a header to the client HTTP response named ``X-Powered-By`` with
+the value ``CRUD 4.0``.
 
 .. literalinclude:: _code/listener_example.php
 	 :language: php
 	 :linenos:
-	 :emphasize-lines: 18-26
+	 :emphasize-lines: 20-30
 
-More on listeners
-^^^^^^^^^^^^^^^^^
+Included listeners
+==================
+
+Crud comes with a selection of listeners included which cover some of the most common use-cases. These allow you to tap
+into the events within the plugin and change behavior to suit your application, or to provide extra functionality, such
+as an API.
 
 .. toctree::
+	:maxdepth: 1
 
 	listeners/api
 	listeners/api-pagination
@@ -97,5 +92,5 @@ More on listeners
 	listeners/redirect
 	listeners/related-models
 	listeners/search
-	listeners/custom
+	Create your own <listeners/custom>
 	

--- a/docs/listeners.rst
+++ b/docs/listeners.rst
@@ -79,9 +79,8 @@ the value ``CRUD 4.0``.
 Included listeners
 ==================
 
-Crud comes with a selection of listeners included which cover some of the most common use-cases. These allow you to tap
-into the events within the plugin and change behavior to suit your application, or to provide extra functionality, such
-as an API.
+Crud comes with a selection of listeners covering the most common use-cases. These allow you to tap into the events
+within the plugin and change behavior to suit your application, or to provide extra functionality, such as an API.
 
 .. toctree::
 	:maxdepth: 1

--- a/docs/listeners/api-pagination.rst
+++ b/docs/listeners/api-pagination.rst
@@ -1,7 +1,7 @@
 API Pagination
 ==============
 
-.. note::
+.. warning::
 
 	This feature requires the :doc:`API listener<api>` to work.
 
@@ -15,19 +15,20 @@ it available for all your controllers, application wide.
 
 .. code-block:: php
 
-	<?php
-	class AppController extends \Cake\Controller\Controller {
+    <?php
+    class AppController extends \Cake\Controller\Controller {
 
-		public $components = [
-			'RequestHandler',
-			'Crud.Crud' => [
-				'listeners' => [
-					'Crud.Api', // Required
-					'Crud.ApiPagination'
-				]
-			];
-
-	}
+        public function initialize()
+        {
+            $this->loadComponent('RequestHandler');
+            $this->loadComponent('Crud.Crud', [
+                'listeners' => [
+                    'Crud.Api', // Required
+                    'Crud.ApiPagination'
+                ]
+            ]);
+        }
+    }
 
 
 Attach it on the fly in your controller beforeFilter if you want to limit
@@ -35,15 +36,16 @@ availability of the listener to specific controllers and actions.
 
 .. code-block:: php
 
-	<?php
-	class SamplesController extends AppController {
+    <?php
+    class SamplesController extends AppController {
 
-		public function beforeFilter(\Cake\Event\Event $event) {
-			$this->Crud->addListener('Crud.Api'); // Required
-			$this->Crud->addListener('Crud.ApiPagination');
-		}
+        public function beforeFilter(\Cake\Event\Event $event)
+        {
+            $this->Crud->addListener('Crud.Api'); // Required
+            $this->Crud->addListener('Crud.ApiPagination');
+        }
 
-	}
+    }
 
 Output
 ------
@@ -71,20 +73,20 @@ Configuration
 -------------
 
 Configure this listener by setting the
-[CakePHP Pagination](http://book.cakephp.org/3.0/en/controllers/components/pagination.html)
-options directly to the query object.
+`CakePHP Pagination <http://book.cakephp.org/3.0/en/controllers/components/pagination.html>`_ options directly to the
+query object.
 
 .. code-block:: php
 
-	public function index()
-	{
-		$event->subject()->query->contain([
-			'Comments' => function ($q) {
-				return $q
-					->select(['id', 'name', 'description'])
-					->where([
-						'Comments.approved' => true
-					]);
-			}
-		]);
-	}
+    public function index()
+    {
+        $event->subject()->query->contain([
+            'Comments' => function ($q) {
+                return $q
+                    ->select(['id', 'name', 'description'])
+                    ->where([
+                        'Comments.approved' => true
+                    ]);
+            }
+        ]);
+    }

--- a/docs/listeners/api-query-log.rst
+++ b/docs/listeners/api-query-log.rst
@@ -1,13 +1,15 @@
 API Query Log
 =============
 
-.. note::
+.. warning::
 
 	This feature requires the :doc:`API listener<api>` to work.
 
 This listener appends query log information to the API responses
 
-The listener will only append the ``queryLog`` key if ``debug`` is set to true.
+.. note::
+
+    The listener will only append the ``queryLog`` key if ``debug`` is set to true.
 
 Setup
 -----
@@ -17,34 +19,36 @@ you want to attach it only to specific controllers and actions
 
 .. code-block:: php
 
-	<?php
-	class SamplesController extends AppController {
+    <?php
+    class SamplesController extends AppController {
 
-		public function beforeFilter(\Cake\Event\Event $event) {
-			$this->Crud->addListener('Crud.Api'); // Required
-			$this->Crud->addListener('Crud.ApiQueryLog');
-		}
+        public function beforeFilter(\Cake\Event\Event $event) {
+            $this->Crud->addListener('Crud.Api'); // Required
+            $this->Crud->addListener('Crud.ApiQueryLog');
+        }
 
-	}
+    }
 
 Attach it using components array, this is recommended if you want to
 attach it to all controllers, application wide
 
+
 .. code-block:: php
 
-	<?php
-	class SamplesController extends AppController {
+    <?php
+    class AppController extends \Cake\Controller\Controller {
 
-		public $components = [
-			'RequestHandler',
-			'Crud.Crud' => [
-				'listeners' => [
-					'Crud.Api', // Required
-					'Crud.ApiQueryLog'
-				]
-			];
-
-	}
+        public function initialize()
+        {
+            $this->loadComponent('RequestHandler');
+            $this->loadComponent('Crud.Crud', [
+                'listeners' => [
+                    'Crud.Api', // Required
+                    'Crud.ApiQueryLog'
+                ]
+            ]);
+        }
+    }
 
 
 Output
@@ -54,33 +58,33 @@ Paginated results will include a
 
 .. code-block:: json
 
-	{
-		"success": true,
-		"data": [
+    {
+        "success": true,
+        "data": [
 
-		],
-		"queryLog": {
-			"default": {
-				"log": [
-					{
-						"query": "SELECT SOMETHING FROM SOMEWHERE",
-						"took": 2,
-						"params": [
+        ],
+        "queryLog": {
+            "default": {
+                "log": [
+                    {
+                        "query": "SELECT SOMETHING FROM SOMEWHERE",
+                        "took": 2,
+                        "params": [
 
-						],
-						"affected": 25,
-						"numRows": 25
-					},
-					{
-						"query": "SELECT SOMETHING FROM SOMEWHERE'",
-						"params": [
+                        ],
+                        "affected": 25,
+                        "numRows": 25
+                    },
+                    {
+                        "query": "SELECT SOMETHING FROM SOMEWHERE'",
+                        "params": [
 
-						],
-						"affected": 1,
-						"numRows": 1,
-						"took": 0
-					}
-				]
-			}
-		}
-	}
+                        ],
+                        "affected": 1,
+                        "numRows": 1,
+                        "took": 0
+                    }
+                ]
+            }
+        }
+    }

--- a/docs/listeners/api.rst
+++ b/docs/listeners/api.rst
@@ -7,7 +7,7 @@ Introduction
 ------------
 .. note::
 
-  The ``API listener`` depends on the ``RequestHandler`` to be loaded **before** ``Crud``
+  The ``API listener`` depends on the ``RequestHandler`` to be loaded **before** ``Crud``.
 
 `Please also see the CakePHP documentation on JSON and XML views <http://book.cakephp.org/3.0/en/views/json-and-xml-views.html>`_
 
@@ -17,8 +17,8 @@ Setup
 Routing
 ^^^^^^^
 
-You need to tell the ``Router`` to parse extensions else it won't be able to
-process and render ``json`` and ``xml`` URL extension
+You need to tell the ``Router`` to parse extensions else it won't be able toprocess and render ``json`` and ``xml``
+URL extension.
 
 .. code-block:: phpinline
 
@@ -30,8 +30,8 @@ Ensure this statement is used before connecting any routes, and is in the routin
 Controller
 ^^^^^^^^^^
 
-Attach it on the fly in your controllers ``beforeFilter``, this is recommended if
-you want to attach it only to specific controllers and actions
+Attach it on the fly in your controllers ``beforeFilter``, this is recommended if you want to attach it only to
+specific controllers and actions.
 
 .. code-block:: php
 
@@ -44,8 +44,7 @@ you want to attach it only to specific controllers and actions
     }
   }
 
-Attach it using components array, this is recommended if you want to
-attach it to all controllers, application wide
+Attach it using components array, this is recommended if you want to attach it to all controllers, application wide.
 
 .. code-block:: php
 
@@ -72,19 +71,19 @@ The Api Listener creates 3 new detectors in your ``CakeRequest`` object.
 is('json')
 ^^^^^^^^^^
 
-Checks if the extension of the request is ``.json`` or if the requester accepts
-json as part of the ``HTTP accepts`` header
+Checks if the extension of the request is ``.json`` or if the requester accepts json as part of the
+``HTTP accepts`` header.
 
 is('xml')
 ^^^^^^^^^
 
-Checks if the extension of the request is ``.xml`` or if the requester accepts
-XML as part of the ``HTTP accepts`` header
+Checks if the extension of the request is ``.xml`` or if the requester accepts XML as part of the ``HTTP accepts``
+header.
 
 is('api')
 ^^^^^^^^^
 
-Checking if the request is either ``is('json')`` or ``is('xml')``
+Checking if the request is either ``is('json')`` or ``is('xml')``.
 
 Default behavior
 ----------------

--- a/docs/listeners/api.rst
+++ b/docs/listeners/api.rst
@@ -4,18 +4,18 @@ API
 This listener allows you to easily create a JSON or XML Api built on top of Crud.
 
 Introduction
-^^^^^^^^^^^^
+------------
+.. note::
 
-The ``API listener`` depends on the ``RequestHandler`` to be loaded **before** ``Crud``
+  The ``API listener`` depends on the ``RequestHandler`` to be loaded **before** ``Crud``
 
-[Please also see the CakePHP documentation on JSON and XML views]
-(http://book.cakephp.org/2.0/en/views/json-and-xml-views.html#enabling-data-views-in-your-application)
+`Please also see the CakePHP documentation on JSON and XML views <http://book.cakephp.org/3.0/en/views/json-and-xml-views.html>`_
 
 Setup
-^^^^^
+-----
 
 Routing
--------
+^^^^^^^
 
 You need to tell the ``Router`` to parse extensions else it won't be able to
 process and render ``json`` and ``xml`` URL extension
@@ -25,12 +25,12 @@ process and render ``json`` and ``xml`` URL extension
   // config/routes.php
   Router::extensions(['json', 'xml']);
 
-Ensure this statement is used before connecting any routes.
+Ensure this statement is used before connecting any routes, and is in the routing global scope.
 
 Controller
-----------
+^^^^^^^^^^
 
-Attach it on the fly in your controller beforeFilter, this is recommended if
+Attach it on the fly in your controllers ``beforeFilter``, this is recommended if
 you want to attach it only to specific controllers and actions
 
 .. code-block:: php
@@ -52,40 +52,42 @@ attach it to all controllers, application wide
   <?php
   class AppController extends Controller {
 
-    public $components = [
-      'RequestHandler',
-      'Crud.Crud' => [
-        'actions' => ['Crud.Index', 'Crud.View'],
-        'listeners' => ['Crud.Api']
-      ]
-    ];
-
+    public function initialize()
+    {
+        $this->loadComponent('RequestHandler');
+        $this->loadComponent('Crud.Crud', [
+          'actions' => [
+            'Crud.Index',
+            'Crud.View'
+          ],
+          'listeners' => ['Crud.Api']
+        ]);
   }
 
-New CakeRequest detectors
-^^^^^^^^^^^^^^^^^^^^^^^^^
+CakeRequest detectors
+---------------------
 
 The Api Listener creates 3 new detectors in your ``CakeRequest`` object.
 
 is('json')
-----------
+^^^^^^^^^^
 
 Checks if the extension of the request is ``.json`` or if the requester accepts
 json as part of the ``HTTP accepts`` header
 
 is('xml')
----------
+^^^^^^^^^
 
 Checks if the extension of the request is ``.xml`` or if the requester accepts
 XML as part of the ``HTTP accepts`` header
 
 is('api')
----------
+^^^^^^^^^
 
 Checking if the request is either ``is('json')`` or ``is('xml')``
 
 Default behavior
-^^^^^^^^^^^^^^^^
+----------------
 
 If the current request doesn't evaluate ``is('api')`` to true, the listener
 won't do anything at all.
@@ -93,14 +95,14 @@ won't do anything at all.
 All it's callbacks will simply return ``NULL`` and don't get in your way.
 
 Exception handler
-^^^^^^^^^^^^^^^^^
+-----------------
 
 The Api listener overrides the ``Exception.renderer`` for ``api`` requests,
 so in case of an error, a standardized error will be returned, in either
 ``json`` or ``xml`` - according to the API request type.
 
 Request type enforcing
-^^^^^^^^^^^^^^^^^^^^^^
+----------------------
 
 The API listener will try to enforce some best practices on how an API
 should behave.
@@ -117,16 +119,16 @@ else an ``MethodNotAllowed`` exception will be raised.
 For a request to ``delete`` the HTTP request type **must** be ``HTTP DELETE`` -
 else an ``MethodNotAllowed`` exception will be raised.
 
+You can `find out more about RESTful on Wikipedia <https://en.wikipedia.org/wiki/Representational_state_transfer#Applied_to_web_services>`_.
+
 Response format
-^^^^^^^^^^^^^^^
+---------------
 
-The default response format for both XML and JSON is two root keys,
-``success`` and ``data``.
+The default response format for both XML and JSON has two root keys, ``success`` and ``data``. It's possible to add
+your own root keys simply by using ``_serialize`` on the view var.
 
-It's possible to add your own root keys simply by ``_serialize`` view var.
-
-JSON
-----
+JSON response
+^^^^^^^^^^^^^
 
 .. code-block:: json
 
@@ -138,8 +140,8 @@ JSON
   }
 
 
-XML
----
+XML response
+^^^^^^^^^^^^
 
 .. code-block:: xml
 
@@ -150,12 +152,12 @@ XML
 
 
 Exception response format
-^^^^^^^^^^^^^^^^^^^^^^^^^
+-------------------------
 
 The ``data.exception`` key is only returned if ``debug`` is > 0
 
-JSON
-----
+JSON exception
+^^^^^^^^^^^^^^
 
 .. code-block:: json
 
@@ -175,8 +177,8 @@ JSON
   }
 
 
-XML
----
+XML exception
+^^^^^^^^^^^^^
 
 .. code-block:: xml
 
@@ -199,7 +201,7 @@ XML
 
 
 HTTP POST (add)
-^^^^^^^^^^^^^^^
+---------------
 
 ``success`` is based on the ``event->subject->success`` parameter from the
 ``Add`` action.
@@ -213,7 +215,7 @@ along with the id of the created record in the ``data`` property of the
 response body.
 
 HTTP PUT (edit)
-^^^^^^^^^^^^^^^
+---------------
 
 ``success`` is based on the ``event->subject->success`` parameter from the
 ``Edit`` action.
@@ -226,7 +228,7 @@ If ``success`` is ``true`` a HTTP response code of ``200`` will be returned
 (even when the resource has not been updated).
 
 HTTP DELETE (delete)
-^^^^^^^^^^^^^^^^^^^^
+--------------------
 
 ``success`` is based on the ``event->subject->success`` parameter from
 the ``Delete`` action.
@@ -237,13 +239,13 @@ If ``success`` is ``true`` a HTTP response code of ``200`` will be returned,
 along with empty ``data`` property in the response body.
 
 Not Found (view / edit / delete)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+--------------------------------
 
 In case an ``id`` is provided to a crud action and the id does not exist in
 the database, a ``404`` NotFoundException` will be thrown.
 
 Invalid id (view / edit / delete)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+---------------------------------
 
 In case a ``ìd`` is provided to a crud action and the id is not valid
 according to the database type a ``500 BadRequestException`` will be thrown

--- a/docs/listeners/custom.rst
+++ b/docs/listeners/custom.rst
@@ -1,29 +1,59 @@
 Custom
 ======
 
-Any class can be used as a CRUD Listener, even the controller.
+Any class can be used as a Crud Listener, even the controller.
 
-Example Controller
-------------------
+Using a controller as a listener
+--------------------------------
 
 We override the ``implementedEvents()`` method in the controller, and bind
 the ``Crud.beforeFind`` event to the ``_beforeFind()`` method in the controller.
 
-.. code-block:: php
+.. code-block:: phpinline
 
   <?php
-  namespace app\Controller;
+  namespace App\Controller;
 
   class BlogsController extends AppController {
 
-    public function implementedEvents() {
-      return parent::implementedEvents() + [
-        'Crud.beforeFind' => '_beforeFind'
-      ];
+    public function implementedEvents()
+    {
+        return parent::implementedEvents() + [
+            'Crud.beforeFind' => '_beforeFind'
+        ];
     }
 
-    public function _beforeFind(\Cake\Event\Event $event) {
+    public function _beforeFind(\Cake\Event\Event $event, \Cake\ORM\Query $query)
+    {
 
     }
 
+  }
+
+Creating a listener class
+-------------------------
+
+Creating your own listener class is very similar to enabling the controller to be a listener.
+
+.. code-block:: phpinline
+
+  <?php
+  namespace App\Lib\Listeners;
+
+  use Cake\Event\EventListenerInterface;
+  use Cake\Event\Event;
+
+  class MyListener implements EventListenerInterface
+  {
+      public function implementedEvents()
+      {
+          return [
+              'Crud.beforeFind' => '_beforeFind'
+          ];
+      }
+
+      public function _beforeFind(Event $event)
+      {
+          Log::debug('Inside the listener!');
+      }
   }

--- a/docs/listeners/custom.rst
+++ b/docs/listeners/custom.rst
@@ -33,7 +33,7 @@ the ``Crud.beforeFind`` event to the ``_beforeFind()`` method in the controller.
 Creating a listener class
 -------------------------
 
-Creating your own listener class is very similar to enabling the controller to be a listener.
+Creating your own listener class is very similar to using a controller as a listener.
 
 .. code-block:: phpinline
 

--- a/docs/listeners/redirect.rst
+++ b/docs/listeners/redirect.rst
@@ -14,13 +14,12 @@ you want to attach it only to specific controllers and actions:
   <?php
   class SamplesController extends AppController {
 
-    public function beforeFilter(\Cake\Event\Event $event) {
-      $this->Crud->addListener('Crud.Redirect');
+      public function beforeFilter(\Cake\Event\Event $event) {
+          $this->Crud->addListener('Crud.Redirect');
 
-      parent::beforeFilter();
-    }
+          parent::beforeFilter();
+      }
   }
-  ?>
 
 
 Attach it using components array, this is recommended if you want to
@@ -31,14 +30,19 @@ attach it to all controllers, application wide:
   <?php
   class SamplesController extends AppController {
 
-    public $components = [
-      'Crud.Crud' => [
-        'actions' => ['index', 'view'],
-        'listeners' => ['Crud.Redirect']
-      ];
-
+    public function initialize()
+    {
+        $this->loadComponent('Crud.Crud', [
+            'actions' => [
+                'index',
+                'view'
+            ],
+            'listeners' => [
+                'Crud.Redirect'
+            ]
+        ]);
+    }
   }
-  ?>
 
 Configuration
 -------------
@@ -117,7 +121,7 @@ Name            Reader             Key         Result                           
 ============== ================== =========== ==================================== =================================================================================================================================
 
 Edit action
-^^^^^^^^^^
+^^^^^^^^^^^
 
 By default Edit Crud Action always redirect to ``array('action' => 'index')`` on ``afterSave``
 
@@ -137,9 +141,11 @@ It's very simple to modify existing or add your own redirect rules:
 .. code-block:: php
 
   <?php
-  class SamplesController extends AppController {
+  class SamplesController extends AppController
+  {
 
-    public function beforeFilter(\Cake\Event\Event $event) {
+    public function beforeFilter(\Cake\Event\Event $event)
+    {
       // Get all the redirect rules
       $rules = $this->Crud->action()->redirectConfig();
 
@@ -151,17 +157,16 @@ It's very simple to modify existing or add your own redirect rules:
       // if $_POST['_view'] is set then redirect to
       // 'view' action with the value of '$subject->id'
       $this->Crud->action()->redirectConfig('view',
-        [
-          'reader' => 'request.data',  // Any reader from the list above
-          'key'    => '_view',         // The key to check for, passed to the reader
-          'url'    => [                // The url to redirect to
-            'action' => 'view',        // The final url will be '/view/$id'
-            ['subject.key', 'id']      // If an array is encountered, it will be expanded the same was as 'reader'+'key'
+          [
+              'reader' => 'request.data',    // Any reader from the list above
+              'key' => '_view',              // The key to check for, passed to the reader
+              'url' => [                     // The url to redirect to
+                  'action' => 'view',        // The final url will be '/view/$id'
+                  ['subject.key', 'id']      // If an array is encountered, it will be expanded the same was as 'reader'+'key'
+              ]
           ]
-        ]
       );
 
       parent::beforeFilter();
     }
   }
-  ?>

--- a/docs/listeners/related-models.rst
+++ b/docs/listeners/related-models.rst
@@ -1,26 +1,21 @@
 Related Models
 ==============
 
-If you are used to bake or CakePHP scaffolding you might want to have some
-control over the data it is sent to the view for filling select boxes for
-associated models.
+If you are used to bake or CakePHP scaffolding you might want to have some control over the data it sends to the view
+for filling select boxes for associated models.
 
 Introduction
 ------------
 
-CRUD can be configured to return the list of record for all
-related models or just those you want to in a per-action basis.
+Crud can be configured to return the list of records for all related models or just those you want to on a per-action
+basis. By default all related model lists for the main Crud table instance will be fetched, but only for add, edit and
+corresponding admin actions.
 
-By default all related model lists for main CRUD table instance
-will be fetched, but only for add, edit and corresponding admin actions.
-
-For instance if your ``Posts`` table in associated to ``Tags`` and ``Authors``,
-then for the aforementioned actions you will have in your view the ``$authors``
-and ``$tags`` variable containing the result of calling ``find(‘list’)`` on
+For instance if your ``Posts`` table is associated with ``Tags`` and ``Authors``, then for those actions
+you will have in your view the ``$authors`` and ``$tags`` variables containing the result of calling ``find(‘list’)`` on
 each table.
 
-Should you need more fine grain control over the lists fetched, you can
-configure statically or use dynamic methods.
+Should you need more fine grain control over the lists fetched, you can configure it statically or use dynamic methods.
 
 Configuring
 -----------
@@ -34,62 +29,56 @@ Before you're able to configure your ``relatedModels`` you need to load the list
 
     public function initialize()
     {
-      parent::initialize();
-      $this->Crud->addListener('relatedModels', 'Crud.RelatedModels');
+        parent::initialize();
+        $this->Crud->addListener('relatedModels', 'Crud.RelatedModels');
     }
 
-.. code-block:: php
+You can enable and disable which model relations you want to have automatically fetched very easily, as shown below.
 
-You can enable and disable which model relations you want to have automatically
-fetched very easily, as shown below.
-
-If you set ``relatedModels`` to ``true`` all model relations will be fetched
-automatically.
-
-If you set ``relatedModels`` to an ``array``, only the related models in that
-array will be fetched automatically.
-
-If you set ``relatedModels`` to ``false`` no model relations will be fetched
-automatically.
+* If you set ``relatedModels`` to ``true`` all model relations will be fetched automatically.
+* If you set ``relatedModels`` to an ``array``, only the related models in that array will be fetched automatically.
+* If you set ``relatedModels`` to ``false`` no model relations will be fetched automatically.
 
 .. code-block:: php
 
-	<?php
-	class DemoController extends AppController {
+    <?php
+    class DemoController extends AppController {
 
-		public $components = [
-			'Crud.Crud' => [
-				'actions' => [
-					'add' => ['relatedModels' => ['Author']],
-					'edit' => ['relatedModels' => ['Tag', 'Cms.Page']]
-				]
-			]
-		];
-
-	}
+        public function initialize()
+        {
+            $this->loadComponent('Crud.Crud', [
+                'actions' => [
+                    'add' => ['relatedModels' => ['Authors']],
+                    'edit' => ['relatedModels' => ['Tags', 'Cms.Pages']]
+                ]
+            ]);
+        }
+    }
 
 It’s possible to dynamically reconfigure the relatedModels listener
 
 .. code-block:: php
 
-	<?php
-	// This can be changed in beforeFilter and the controller action
-	public function beforeFilter(\Cake\Event\Event $event) {
-		// Automatically executes find('list') on the User ($users) and Tag ($tags) tables
-		$this->Crud->listener('relatedModels')->relatedModels(['User', 'Tag'], 'your_action');
+    <?php
+    // This can be changed in beforeFilter and the controller action
 
-		// Automatically executes find('list') on the User ($users) table
-		$this->Crud->listener('relatedModels')->relatedModels(['User'], 'your_action');
+    public function beforeFilter(\Cake\Event\Event $event)
+    {
+        // Automatically executes find('list') on the Users ($users) and Tags ($tags) tables
+        $this->Crud->listener('relatedModels')->relatedModels(['Users', 'Tags'], 'your_action');
 
-		// Fetch related data from all table relations (default)
-		$this->Crud->listener('relatedModels')->relatedModels(true);
+        // Automatically executes find('list') on the Users ($users) table
+        $this->Crud->listener('relatedModels')->relatedModels(['Users'], 'your_action');
 
-		// Don't fetch any related data
-		$this->Crud->listener('relatedModels')->relatedModels(false);
+        // Fetch related data from all table relations (default)
+        $this->Crud->listener('relatedModels')->relatedModels(true);
 
-		// Get the current configuration
-		$config = $this->Crud->listener('relatedModels')->relatedModels();
-	}
+        // Don't fetch any related data
+        $this->Crud->listener('relatedModels')->relatedModels(false);
+
+        // Get the current configuration
+        $config = $this->Crud->listener('relatedModels')->relatedModels();
+    }
 
 Events
 ------
@@ -110,19 +99,18 @@ Example
 
 .. code-block:: php
 
-	<?php
-	class DemoController extends AppController {
+    <?php
+    class DemoController extends AppController {
 
-		public function beforeFilter(\Cake\Event\Event $event) {
-			parent::beforeFilter();
+        public function beforeFilter(\Cake\Event\Event $event) {
+            parent::beforeFilter();
 
-			$this->Crud->on('relatedModel', function(\Cake\Event\Event $event) {
-				if ($event->subject->association->name() === 'Authors') {
-					$event->subject->query->limit(3);
-					$event->subject->query->where(['is_active' => true]);
-				}
-			});
+            $this->Crud->on('relatedModel', function(\Cake\Event\Event $event) {
+                if ($event->subject()->association->name() === 'Authors') {
+                    $event->subject()->query->limit(3);
+                    $event->subject()->query->where(['is_active' => true]);
+                }
+            });
 
-		}
-
-	}
+        }
+    }

--- a/docs/listeners/related-models.rst
+++ b/docs/listeners/related-models.rst
@@ -8,8 +8,12 @@ Introduction
 ------------
 
 Crud can be configured to return the list of records for all related models or just those you want to on a per-action
-basis. By default all related model lists for the main Crud table instance will be fetched, but only for add, edit and
-corresponding admin actions.
+basis. By default all related model lists for the main Crud table instance will be fetched, but only for ``add``,
+``edit`` and corresponding admin actions.
+
+.. note::
+
+  Please note that the RelatedModels listener does not work on ``index`` actions.
 
 For instance if your ``Posts`` table is associated with ``Tags`` and ``Authors``, then for those actions
 you will have in your view the ``$authors`` and ``$tags`` variables containing the result of calling ``find(‘list’)`` on

--- a/docs/listeners/search.rst
+++ b/docs/listeners/search.rst
@@ -1,28 +1,28 @@
-Search 
-=======
+Search
+======
 
 This listener provides search capabilities for the Crud plugin.
 
 Introduction
-^^^^^^^^^^^^
-The ``Search listener`` depends on the ``FriendsOfCake`` repo ``search``.
+------------
 
-[Please also see the repo]
-(https://github.com/FriendsOfCake/search)
+The Search listener depends on the `friendsofcake/search <https://packagist.org/packages/friendsofcake/search>`_ package.
 
 Setup
-^^^^^
+-----
 
 Installation
--------------
+^^^^^^^^^^^^
 
-You need to install `FriendsOfCake/Search <https://github.com/FriendsOfCake/search>`_ first.
+.. code-block:: sh
+
+  composer require friendsofcake/search
 
 Controller
-----------
+^^^^^^^^^^
 
-Attach it on the fly in your controller beforeFilter, this is recommended if
-you want to attach it only to specific controllers and actions:
+Attach it on the fly in your controllers beforeFilter, this is recommended if
+you want to attach it only to specific controllers and actions.
 
 .. code-block:: php
 
@@ -30,27 +30,29 @@ you want to attach it only to specific controllers and actions:
   class SamplesController extends AppController {
 
     public function beforeFilter(\Cake\Event\Event $event) {
-      $this->Crud->addListener('Crud.Search');
+        $this->Crud->addListener('Crud.Search');
 
-      parent::beforeFilter();
+        parent::beforeFilter();
     }
   }
-  ?>
-
 
 Attach it using components array, this is recommended if you want to
-attach it to all controllers, application wide:
+attach it to all controllers, application wide.
 
 .. code-block:: php
 
   <?php
-  class SamplesController extends AppController {
+  class DemoController extends AppController {
 
-    public $components = [
-      'Crud.Crud' => [
-        'actions' => ['index', 'view'],
-        'listeners' => ['Crud.Search']
-      ];
-
+      public function initialize()
+      {
+          $this->loadComponent('Crud.Crud', [
+              'actions' => [
+                  'index'
+              ],
+              'listeners' => [
+                  'Crud.Search'
+              ]
+          ]);
+      }
   }
-  ?>

--- a/docs/quick-start.rst
+++ b/docs/quick-start.rst
@@ -1,22 +1,21 @@
+***********
 Quick Start
-===========
+***********
 
-You are busy, and you just want to ``get things done™``, so let's get going.
+You are busy, and you just want to "get things done™", so let's get going.
 
 After :doc:`installation<installation>`, you are ready to CRUD-ify your app.
 
 The application
---------------
+===============
 
 So the application our `pointy-haired boss <https://www.google.com/search?q=pointy+haired+boss>`_ has tasked us to create today is a Blog.
 
 App Controller
---------------
-
-Since CRUD is awesome, and you already started to kinda love it, we want to enable CRUD for our entire application.
+==============
 
 Let's setup CRUD to handle all ``index()``, ``add()``, ``edit()``, ``view()`` and ``delete()`` actions automatically,
-we do this by enabling Crud in the ``AppController`` with the correct ``actions`` configuration.
+we do this by enabling Crud in the ``AppController`` with the ``actions`` options configuration.
 
 .. code-block:: php
 
@@ -27,25 +26,28 @@ we do this by enabling Crud in the ``AppController`` with the correct ``actions`
 
       use \Crud\Controller\ControllerTrait;
 
-      public $components = [
-        'Crud.Crud' => [
-          'actions' => [
-            'Crud.Index',
-            'Crud.Add',
-            'Crud.Edit',
-            'Crud.View',
-            'Crud.Delete'
-          ]
-        ]
-      ];
+        public function initialize()
+        {
+            parent::initialize();
+
+            $this->loadComponent('Crud.Crud', [
+                'actions' => [
+                    'Crud.Index',
+                    'Crud.Add',
+                    'Crud.Edit',
+                    'Crud.View',
+                    'Crud.Delete'
+                ]
+            ]);
+        }
     }
 
 There we go, that was easy.
 
 Posts Controller
-----------------
+================
 
-So, our new shiny Blog needs a ``Posts Controller`` to, well, manage the posts.
+So, our new Blog needs a Posts controller to allow us to create, read, update and delete posts.
 
 .. code-block:: php
 
@@ -57,20 +59,22 @@ So, our new shiny Blog needs a ``Posts Controller`` to, well, manage the posts.
 
   }
 
-(...) and that's it! we don't really need any logic there for now, since we have configured CRUD to take care of all actions
+This is all the code we need in the ``PostsController`` as Crud will scaffold the controller actions for us.
 
-But... since CRUD doesn't provide any views (yet), you will have to bake the views for now
+If you are not using `Crud-View <https://github.com/FriendsOfCake/crud-view>`_ then you will have
+to `bake your templates <http://book.cakephp.org/3.0/en/bake/usage.html>`_.
 
-.. code-block:: text
+.. code-block:: sh
 
-  Console/cake bake template posts
+  bin/cake bake template posts
 
 Let's check out our new application, go to ``/posts`` and behold, a nice paginated ``ìndex()`` template, all without any code
 in your controller.
 
-You should now be able to navigate to ``/posts/add`` as well and create your first post.
+You should now be able to navigate to ``/posts/add`` as well and create your first post, as well as being able to edit it.
 
-Creating an API
----------------
+Reference application
+=====================
 
-This section is WIP.
+If you'd rather look through a completed application, José from the CakePHP core team has created an application using Crud.
+`You can find it on Github <https://github.com/lorenzo/cakephp3-bookmarkr>`_.

--- a/docs/unit-testing.rst
+++ b/docs/unit-testing.rst
@@ -1,5 +1,6 @@
+************
 Unit Testing
-============
+************
 
 To ease with unit testing of Crud Listeners and Crud Actions, it's recommended
 to use the proxy methods found in [CrudBaseObject]({{site.url}}/api/develop/class-CrudBaseObject.html).
@@ -10,7 +11,7 @@ They also allow you to just mock the methods you need for your specific test, ra
 CrudComponent can be in some cases.
 
 Proxy methods
-^^^^^^^^^^^^^^
+=============
 
 These methods are available in all `CrudAction` and `CrudListener` objects.
 
@@ -91,7 +92,7 @@ Get the current ``Cake\Network\Request`` for this HTTP Request
 	$this->_request()
 
 _response()
-----------
+-----------
 
 Get the current ``Cake\Network\Response`` for this HTTP Request
 
@@ -109,7 +110,7 @@ Get the entity instance that is created from ``Controller::$modelClass``
 	$this->_entity()
 
 _table()
----------
+--------
 
 Get the table instance that is created from ``Controller::$modelClass``
 


### PR DESCRIPTION
# Changes made
* Updated all code formatting to be 4 space indents so it looks more visually appealing in Sphinx
* Fixed all the headings so they no longer throw a severe warning during build for `Title level inconsistent`
* Removed the unused `secure-delete` partial
* Created and populated the missing `related_models` partial
* Created and populated the missing `crud-subject` page and matching document label
* Reworked some of the copy to fix grammar and minor typos
* Re-ordered the contents to make more sense, so it's Actions, Events, Subject, Listener
* Added links to `Crud-View` in relevant places
* Added relevant links to `foc/search`
* Added links to Packagist where appropriate
* Changed all the code samples to use `initialize()` and `loadComponent()` instead of `$components`
* Changed all code samples to match PSR2/CakePHP, such as opening class and function braces
* Removed many code highlighted words which were proper nouns, such as `Component` -> Component
* Changed all instances of CRUD to Crud where Crud is referring to the name of the plugin, rather than the acronym for create, read, update, delete
* Changed the depth of table of contents on pages with sub-pages so it's not huge
* Added an example of creating a standalone listener, alongside using a controller as a listener
* Added a new Api page with a link to @bravo-kernel blog post
* I have, where appropriate, cross linked sections to more verbose pages to avoid repetition and aid navigation
* Updated the requirements to match the `composer.json` which is Cake 3.2 and PHP 5.5.9
* Removed the section about installing using Git submodules
* Added a link to @lorenzo demo of Bookmarkr using Crud
* Updated the links to the Cake 2 book, with matching Cake 3 links
* Updated the console commands to be `bin/cake` instead of `Console/cake`

## Feedback
Any changes, let me know and I can push some more commits up.