### PR TITLE
Updated Sphinx config to include pygments for phpinline

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -53,7 +53,7 @@ master_doc = 'contents'
 
 # General information about the project.
 project = u'crud'
-copyright = u'2016, Christian Winther'
+copyright = u'2016, Friends of Cake'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -213,7 +213,7 @@ latex_elements = {
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
   ('index', 'crud.tex', u'crud',
-   u'Christian Winther', 'manual'),
+   u'Friends of Cake', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
@@ -243,7 +243,7 @@ latex_documents = [
 # (source start file, name, description, authors, manual section).
 man_pages = [
     ('index', 'crud', u'crud Documentation',
-     [u'Christian Winther'], 1)
+     [u'Friends of Cake'], 1)
 ]
 
 # If true, show URL addresses after external links.
@@ -257,7 +257,7 @@ man_pages = [
 #  dir menu entry, description, category)
 texinfo_documents = [
   ('index', 'crud', u'crud Documentation',
-   u'Christian Winther', 'crud', 'CakePHP scaffolding on steroids!',
+   u'Friends of Cake', 'crud', 'CakePHP scaffolding on steroids!',
    'Miscellaneous'),
 ]
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -36,6 +36,7 @@ from _config import *
 extensions = [
 #	'_config.cakephpbranch',
 #  'sphinx.ext.todo'
+    'sphinxcontrib.phpdomain'
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -52,7 +53,7 @@ master_doc = 'contents'
 
 # General information about the project.
 project = u'crud'
-copyright = u'2014, Christian Winther'
+copyright = u'2016, Christian Winther'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -77,7 +78,8 @@ release = '4.0'
 # directories to ignore when looking for source files.
 exclude_patterns = [
 	'_build',
-	'_themes'
+	'_themes',
+	'_partials'
 ]
 
 # The reST default role (used for this markup: `text`) to use for all
@@ -255,7 +257,7 @@ man_pages = [
 #  dir menu entry, description, category)
 texinfo_documents = [
   ('index', 'crud', u'crud Documentation',
-   u'Christian Winther', 'crud', 'One line description of project.',
+   u'Christian Winther', 'crud', 'CakePHP scaffolding on steroids!',
    'Miscellaneous'),
 ]
 
@@ -277,3 +279,11 @@ texinfo_documents = [
 #lexers['phpinline'] = PhpLexer(startinline=True)
 
 branch = 'master'
+
+# -- Import Pygment lexers for PHP -----------------------
+from sphinx.highlighting import lexers
+from pygments.lexers.web import PhpLexer
+lexers['php'] = PhpLexer(startinline=True)
+lexers['phpinline'] = PhpLexer(startinline=True)
+lexers['php-annotations'] = PhpLexer(startinline=True)
+primary_domain = "php"


### PR DESCRIPTION
# Changes made
* Updated the copyright year, pending #395 
* Include the `sphinxcontrib.phpdomain` to make local highlighting easier `sudo easy_install -U sphinxcontrib-phpdomain`
* Added a description for the plugin
* Added the relevant lexers for PHP
* Excluded all the partials, so you don't get a warning about them not being in the toctree when building the docs