### PR TITLE
remove Bad Apostrophe

### DIFF
--- a/docs/listeners/api.rst
+++ b/docs/listeners/api.rst
@@ -91,7 +91,7 @@ Default behavior
 If the current request doesn't evaluate ``is('api')`` to true, the listener
 won't do anything at all.
 
-All it's callbacks will simply return ``NULL`` and don't get in your way.
+All its callbacks will simply return ``NULL`` and don't get in your way.
 
 Exception handler
 -----------------


### PR DESCRIPTION
A possessive belonging to an "it" doesn't need an apostrophe. Don't believe me? Ask [the Oatmeal](http://theoatmeal.com/comics/apostrophe) (look for the velociraptor)!