### PR TITLE
Properly handle ids during bulk actions

### DIFF
--- a/src/Action/Bulk/BaseAction.php
+++ b/src/Action/Bulk/BaseAction.php
@@ -90,7 +90,7 @@ abstract class BaseAction extends CrudBaseAction
         }
 
         $ids = array_filter($ids);
-        return array_keys($ids);
+        return array_values($ids);
     }
 
     /**

--- a/tests/TestCase/Action/Bulk/SetValueActionTest.php
+++ b/tests/TestCase/Action/Bulk/SetValueActionTest.php
@@ -77,8 +77,8 @@ class SetValueActionTest extends IntegrationTestCase
 
         $this->{$method}('/blogs/deactivateAll', [
             'id' => [
-                1 => 1,
-                2 => 2,
+                1,
+                2,
             ],
         ]);
 
@@ -125,8 +125,8 @@ class SetValueActionTest extends IntegrationTestCase
 
         $this->post('/blogs/deactivateAll', [
             'id' => [
-                1 => 1,
-                2 => 2,
+                1,
+                2,
             ],
         ]);
 
@@ -169,8 +169,8 @@ class SetValueActionTest extends IntegrationTestCase
 
         $this->post('/users/deactivateAll', [
             'id' => [
-                '0acad6f2-b47e-4fc1-9086-cbc906dc45fd' => '0acad6f2-b47e-4fc1-9086-cbc906dc45fd',
-                '968ad2b3-f41d-4de3-909a-74a3ce85e826' => '968ad2b3-f41d-4de3-909a-74a3ce85e826',
+                '0acad6f2-b47e-4fc1-9086-cbc906dc45fd',
+                '968ad2b3-f41d-4de3-909a-74a3ce85e826',
             ],
         ]);
 

--- a/tests/TestCase/Listener/ApiListenerTest.php
+++ b/tests/TestCase/Listener/ApiListenerTest.php
@@ -339,7 +339,6 @@ class ApiListenerTest extends TestCase
                 ->expects($this->any())
                 ->method('errors')
                 ->will($this->returnValue($validationErrors));
-
         } else {
             $listener->expects($this->never())->method('_validationErrors');
         }


### PR DESCRIPTION
I noticed that when executing bulk actions, they were being performed on the wrong entries since _processIds() was using array_keys() to extract the ids from the array's keys, when it should be using the array's values.

Example:
> POST /network-objects/bulk/updating '{"id":[3,4]}'

This would update the object with id 1, instead of objects 3 and 4.