### PR TITLE
remove unnecessary renderAs()

### DIFF
--- a/src/Listener/ApiListener.php
+++ b/src/Listener/ApiListener.php
@@ -193,13 +193,7 @@ class ApiListener extends BaseListener
         $this->_ensureData($subject);
         $this->_ensureSerialize();
 
-        $controller = $this->_controller();
-
-        if (!empty($controller->RequestHandler->ext)) {
-            $controller->RequestHandler->renderAs($controller, $controller->RequestHandler->ext);
-        }
-
-        return $controller->render();
+        return $this->_controller()->render();
     }
 
     /**


### PR DESCRIPTION
I need to render templates for specific API actions. Therefore I set `_serialize` to false in `Crud.beforeRender`. If I keep the deleted lines, it will search for templates inside `Posts/json/json/view.ctp` instead of `Posts/json/view.ctp`.