### PR TITLE
Fix resolving ambiguous field names in SQL searches.

### DIFF
--- a/src/Listener/SearchListener.php
+++ b/src/Listener/SearchListener.php
@@ -3,6 +3,7 @@ namespace Crud\Listener;
 
 use Cake\Core\Plugin;
 use Cake\Event\Event;
+use Cake\Utility\Hash;
 use RuntimeException;
 
 class SearchListener extends BaseListener
@@ -60,7 +61,7 @@ class SearchListener extends BaseListener
             ));
         }
 
-        $filterParams = $table->filterParams($this->_request()->query);
+        $filterParams = $table->filterParams(Hash::flatten($this->_request()->query));
         $event->subject->query->find('search', $filterParams);
     }
 }


### PR DESCRIPTION
I ran into a problem where my table had an association which had a duplicate column name from the parent. Which raises a MySQL error that the column in the where clause was ambiguous.

In my `DocumentsTable` class I had to use the full name for the field.

```
   $this->searchManager()->value('Documents.active');
```

This produced a query string like this `documents?Documents[active]=0` which gets resolved as a nested array in the `$this->request->query`

So I modified `SearchListener` to flatten the query parameters back to dot notation.

This PR includes that change.