### PR TITLE
relatedModel improvements

### DIFF
--- a/docs/listeners/related-models.rst
+++ b/docs/listeners/related-models.rst
@@ -117,6 +117,7 @@ subject, which can be altered on the fly before any result is fetched
 * ``viewVar`` The name of the variable when set to the view
 * ``query`` The ``\Cake\ORM\Query`` object used for the ``find('list')``
 * ``association`` The ``\Cake\ORM\Association`` object
+* ``entity`` The ``Cake\ORM\Entity`` you are finding relations for
 
 Example
 

--- a/docs/listeners/related-models.rst
+++ b/docs/listeners/related-models.rst
@@ -75,6 +75,11 @@ The above example will add a contain to your query for all related models in you
   The Related Models listener performs differently for the ``index`` method, than it does for ``add``
   and ``edit``.
 
+.. note::
+
+  The Related Models listener are aware of custom binding keys for your relations, and will use them
+  over the primary key (which is CakePHP default behavior)
+
 If you need to contain extra data in your ``add`` and ``edit`` methods, then you can hook the ``beforeFind`` event and
 adjust the queries contain as you need. You can find out how in the :ref:`crud-beforefind`.
 

--- a/src/Listener/RelatedModelsListener.php
+++ b/src/Listener/RelatedModelsListener.php
@@ -59,7 +59,11 @@ class RelatedModelsListener extends BaseListener
      */
     public function beforeRender(Event $event)
     {
-        $this->publishRelatedModels(null, $event->subject->entity);
+        $entity = null;
+        if (isset($event->subject->entity)) {
+            $entity = $event->subject->entity;
+        }
+        $this->publishRelatedModels(null, $entity);
     }
 
     /**
@@ -88,12 +92,28 @@ class RelatedModelsListener extends BaseListener
             }
 
             $finder = $this->finder($association);
-            $query = $association->find()->find($finder);
+            $query = $association->find()->find($finder, $this->_findOptions($association));
             $subject = $this->_subject(compact('name', 'viewVar', 'query', 'association', 'entity'));
             $event = $this->_trigger('relatedModel', $subject);
 
-            $controller->set($event->subject->viewVar, $event->subject->query->toArray());
+            $controller->set($event->subject->viewVar, $event->subject->query);
         }
+    }
+
+    /**
+     * Find keyField and valueField for find('list')
+     *
+     * This is useful for cases where the relation has a different binding key
+     * than the primary key in the associated table (e.g. NOT 'id')
+     *
+     * @param  Association $association
+     * @return array
+     */
+    protected function _findOptions(Association $association)
+    {
+        return [
+            'keyField' => $association->bindingKey()
+        ];
     }
 
     /**

--- a/src/Listener/RelatedModelsListener.php
+++ b/src/Listener/RelatedModelsListener.php
@@ -106,7 +106,7 @@ class RelatedModelsListener extends BaseListener
      * This is useful for cases where the relation has a different binding key
      * than the primary key in the associated table (e.g. NOT 'id')
      *
-     * @param  Association $association
+     * @param Association $association The association that we process
      * @return array
      */
     protected function _findOptions(Association $association)

--- a/src/Listener/RelatedModelsListener.php
+++ b/src/Listener/RelatedModelsListener.php
@@ -59,7 +59,7 @@ class RelatedModelsListener extends BaseListener
      */
     public function beforeRender(Event $event)
     {
-        $this->publishRelatedModels();
+        $this->publishRelatedModels(null, $event->subject->entity);
     }
 
     /**
@@ -67,9 +67,10 @@ class RelatedModelsListener extends BaseListener
      * for an action
      *
      * @param NULL|string $action If NULL the current action will be used
+     * @param NULL|Entity $entity The optional entity for which we we trying to find related
      * @return void
      */
-    public function publishRelatedModels($action = null)
+    public function publishRelatedModels($action = null, $entity = null)
     {
         $models = $this->models($action);
 
@@ -88,7 +89,7 @@ class RelatedModelsListener extends BaseListener
 
             $finder = $this->finder($association);
             $query = $association->find()->find($finder);
-            $subject = $this->_subject(compact('name', 'viewVar', 'query', 'association'));
+            $subject = $this->_subject(compact('name', 'viewVar', 'query', 'association', 'entity'));
             $event = $this->_trigger('relatedModel', $subject);
 
             $controller->set($event->subject->viewVar, $event->subject->query->toArray());


### PR DESCRIPTION
- `keyField` will now using the relation `bindingKey` instead of the `primaryKey` by default in `find('list')`
- `entity` are a new `subject` key for `view` and `edit` - and will contain the current `entity` you are finding relations for - this allow for injection of related model conditions based on the `entity` properties ( e.g. an `entity` with `country_id = 1` - you can now easily limit relations to known good relations for that country id