### PR TITLE
Handles composite primary keys in _findRecord.

### DIFF
--- a/src/Controller/Component/CrudComponent.php
+++ b/src/Controller/Component/CrudComponent.php
@@ -218,7 +218,9 @@ class CrudComponent extends Component
         $this->_action = $controllerAction ?: $this->_action;
 
         $action = $this->_action;
-        $args = (!empty($args)) ? [$args] : $this->_request->params['pass'];
+        if (empty($args)) {
+            $args = $this->_request->params['pass'];
+        }
 
         try {
             $event = $this->trigger('beforeHandle', $this->getSubject(compact('args', 'action')));

--- a/src/Controller/Component/CrudComponent.php
+++ b/src/Controller/Component/CrudComponent.php
@@ -218,9 +218,7 @@ class CrudComponent extends Component
         $this->_action = $controllerAction ?: $this->_action;
 
         $action = $this->_action;
-        if (empty($args)) {
-            $args = $this->_request->params['pass'];
-        }
+        $args = (!empty($args)) ? [$args] : $this->_request->params['pass'];
 
         try {
             $event = $this->trigger('beforeHandle', $this->getSubject(compact('args', 'action')));

--- a/src/Traits/FindMethodTrait.php
+++ b/src/Traits/FindMethodTrait.php
@@ -1,8 +1,8 @@
 <?php
 namespace Crud\Traits;
 
-use Crud\Event\Subject;
 use Cake\Datasource\Exception\InvalidPrimaryKeyException;
+use Crud\Event\Subject;
 
 trait FindMethodTrait
 {

--- a/src/Traits/FindMethodTrait.php
+++ b/src/Traits/FindMethodTrait.php
@@ -2,6 +2,7 @@
 namespace Crud\Traits;
 
 use Crud\Event\Subject;
+use Cake\Datasource\Exception\InvalidPrimaryKeyException;
 
 trait FindMethodTrait
 {
@@ -30,13 +31,34 @@ trait FindMethodTrait
      * @param string $id Record id
      * @param \Crud\Event\Subject $subject Event subject
      * @return \Cake\ORM\Entity
+     * @throws \Cake\Datasource\Exception\InvalidPrimaryKeyException When $primaryKey has an
+     *      incorrect number of elements.
      */
     protected function _findRecord($id, Subject $subject)
     {
         $repository = $this->_table();
 
+        $key = (array)$repository->primaryKey();
+        $alias = $repository->alias();
+        foreach ($key as $index => $keyname) {
+            $key[$index] = $alias . '.' . $keyname;
+        }
+        $primaryKey = (array)$id;
+        if (count($key) !== count($primaryKey)) {
+            $primaryKey = $primaryKey ?: [null];
+            $primaryKey = array_map(function ($key) {
+                return var_export($key, true);
+            }, $primaryKey);
+            throw new InvalidPrimaryKeyException(sprintf(
+                'Record not found in table "%s" with primary key [%s]',
+                $repository,
+                implode($primaryKey, ', ')
+            ));
+        }
+        $conditions = array_combine($key, $primaryKey);
+
         $query = $repository->find($this->findMethod());
-        $query->where([current($query->aliasField($repository->primaryKey())) => $id]);
+        $query->where($conditions);
 
         $subject->set([
             'repository' => $repository,


### PR DESCRIPTION
With this change, when we have a table with composite primary keys, all we need to do is pass the keys to the execute method.

``` php
public function view($id)
{
    $primaryKeys = explode(';',$id);
    return $this->Crud->execute(null, $primaryKeys);
}
```

Refs: #431.
