### PR TITLE
Fixed name of custom action in documentation

### DIFF
--- a/docs/actions/custom.rst
+++ b/docs/actions/custom.rst
@@ -16,7 +16,7 @@ A default custom index action might be as simple as the following:
     <?php
     namespace App\Crud\Action;
 
-    class MyIndex extends \Crud\Action\BaseAction
+    class MyIndexAction extends \Crud\Action\BaseAction
     {
         /**
          * Default settings


### PR DESCRIPTION
The name of the action was different to the `className` used in the example usage further down the page.