### PR TITLE
Adds beforeFind to RelatedModelsListener, for View

### DIFF
--- a/src/Listener/RelatedModelsListener.php
+++ b/src/Listener/RelatedModelsListener.php
@@ -25,6 +25,7 @@ class RelatedModelsListener extends BaseListener
     {
         return [
             'Crud.beforePaginate' => 'beforePaginate',
+            'Crud.beforeFind' => 'beforeFind',
             'Crud.beforeRender' => 'beforeRender',
         ];
     }
@@ -36,6 +37,27 @@ class RelatedModelsListener extends BaseListener
      * @return void
      */
     public function beforePaginate(Event $event)
+    {
+        $contained = $event->subject()->query->contain();
+        if (!empty($contained)) {
+            return;
+        }
+
+        $models = $this->models();
+        if (empty($models)) {
+            return;
+        }
+
+        $event->subject()->query->contain(array_keys($models));
+    }
+
+    /**
+     * Automatically parse and contain related table classes
+     *
+     * @param \Cake\Event\Event $event Before find event
+     * @return void
+     */
+    public function beforeFind(Event $event)
     {
         $contained = $event->subject()->query->contain();
         if (!empty($contained)) {

--- a/src/Listener/RelatedModelsListener.php
+++ b/src/Listener/RelatedModelsListener.php
@@ -31,33 +31,32 @@ class RelatedModelsListener extends BaseListener
     }
 
     /**
-     * Automatically parse and contain related table classes
+     * Handle beforePaginate
      *
-     * @param \Cake\Event\Event $event Before paginate event
-     * @return void
+     * @param Event $event Before paginate event
      */
     public function beforePaginate(Event $event)
     {
-        $contained = $event->subject()->query->contain();
-        if (!empty($contained)) {
-            return;
-        }
+        $this->_eventHandler($event);
+    }
 
-        $models = $this->models();
-        if (empty($models)) {
-            return;
-        }
-
-        $event->subject()->query->contain(array_keys($models));
+    /**
+     * Handle beforeFind
+     *
+     * @param Event $event Before find event
+     */
+    public function beforeFind(Event $event)
+    {
+        $this->_eventHandler($event);
     }
 
     /**
      * Automatically parse and contain related table classes
      *
-     * @param \Cake\Event\Event $event Before find event
+     * @param \Cake\Event\Event $event Before paginate or Before find event
      * @return void
      */
-    public function beforeFind(Event $event)
+    protected function _eventHandler(Event $event)
     {
         $contained = $event->subject()->query->contain();
         if (!empty($contained)) {

--- a/tests/TestCase/Listener/RelatedModelsListenerTest.php
+++ b/tests/TestCase/Listener/RelatedModelsListenerTest.php
@@ -308,4 +308,42 @@ class RelatedModelListenerTest extends TestCase
 
         $this->assertEquals(['Users' => []], $result);
     }
+
+    /**
+     * testbeforeFind
+     *
+     * @return void
+     */
+    public function testbeforeFind()
+    {
+        $listener = $this
+            ->getMockBuilder('\Crud\Listener\RelatedModelsListener')
+            ->disableOriginalConstructor()
+            ->setMethods(['models'])
+            ->getMock();
+        $table = $this
+            ->getMockBuilder('\Cake\ORM\Table')
+            ->disableOriginalConstructor()
+            ->setMethods(['associations', 'association'])
+            ->getMock();
+
+        $listener
+            ->expects($this->once())
+            ->method('models')
+            ->will($this->returnValue(['Users' => 'manyToOne']));
+
+        $db = $this->getMockBuilder('\Cake\Database\Connection')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $query = new Query($db, null);
+        $query->repository($table);
+        $subject = new Subject(['query' => $query]);
+        $event = new Event('beforeFind', $subject);
+
+        $listener->beforeFind($event);
+        $result = $event->subject()->query->contain();
+
+        $this->assertEquals(['Users' => []], $result);
+    }
 }


### PR DESCRIPTION
Change makes it possible to get related models for Crud.View, just like we have with Crud.Index, making it more streamlined.

refs #402
