### PR TITLE
CakePHP 3.4: Replace call_user_func* with modern syntax

### DIFF
--- a/src/Action/AddAction.php
+++ b/src/Action/AddAction.php
@@ -118,8 +118,7 @@ class AddAction extends BaseAction
 
         $this->_trigger('beforeSave', $subject);
 
-        $saveCallback = [$this->_table(), $subject->saveMethod];
-        if (call_user_func($saveCallback, $subject->entity, $subject->saveOptions)) {
+        if ($this->_table()->{$subject->saveMethod}($subject->entity, $subject->saveOptions)) {
             return $this->_success($subject);
         }
 

--- a/src/Action/BaseAction.php
+++ b/src/Action/BaseAction.php
@@ -61,14 +61,14 @@ abstract class BaseAction extends Object
             $this->_responding = true;
             $this->_controller()->eventManager()->on($this);
 
-            return call_user_func_array([$this, $method], $args);
+            return $this->{$method}(...$args);
         }
 
         if (method_exists($this, '_handle')) {
             $this->_responding = true;
             $this->_controller()->eventManager()->on($this);
 
-            return call_user_func_array([$this, '_handle'], $args);
+            return $this->{'_handle'}(...$args);
         }
 
         throw new NotImplementedException(sprintf(

--- a/src/Action/EditAction.php
+++ b/src/Action/EditAction.php
@@ -119,7 +119,7 @@ class EditAction extends BaseAction
         );
 
         $this->_trigger('beforeSave', $subject);
-        if (call_user_func([$this->_table(), $this->saveMethod()], $entity, $this->saveOptions())) {
+        if ($this->_table()->{$this->saveMethod()}($entity, $this->saveOptions())) {
             return $this->_success($subject);
         }
 

--- a/src/Controller/ControllerTrait.php
+++ b/src/Controller/ControllerTrait.php
@@ -48,7 +48,7 @@ trait ControllerTrait
 
         $callable = [$this, $request->params['action']];
         if (is_callable($callable)) {
-            return call_user_func_array($callable, $request->params['pass']);
+            return $callable(...$request->params['pass']);
         }
 
         $component = $this->_isActionMapped();

--- a/src/Listener/ApiListener.php
+++ b/src/Listener/ApiListener.php
@@ -298,7 +298,7 @@ class ApiListener extends BaseListener
                 }
 
                 if (method_exists($subject->entity, $valuePath)) {
-                    $data = Hash::insert($data, $keyPath, call_user_func([$subject->entity, $valuePath]));
+                    $data = Hash::insert($data, $keyPath, $subject->entity->{$valuePath});
                 } elseif (isset($subject->entity->{$valuePath})) {
                     $data = Hash::insert($data, $keyPath, $subject->entity->{$valuePath});
                 }


### PR DESCRIPTION
Ref: https://github.com/cakephp/cakephp/wiki/3.4-Roadmap#php-56-minimum
Ref: http://php.net/manual/en/functions.arguments.php#functions.variable-arg-list