### PR TITLE
Fixed bulk action example code

### DIFF
--- a/docs/actions/bulk.rst
+++ b/docs/actions/bulk.rst
@@ -30,7 +30,7 @@ method. This method takes a CakePHP ``Query`` object as it's first argument
      * @param \Cake\ORM\Query $query The query to act upon
      * @return boolean
      */
-    protected function _handle(Query $query)
+    protected function _bulk(Query $query)
     {
       $query->update()->set(['approved' => true]);
       $statement = $query->execute();


### PR DESCRIPTION
The example code shows the `_execute()` method rather than the `bulk()` one (I assume this is incorrect based on the plugin's code and the paragraph before the example.