### PR TITLE
Fix non-loaded listeners being detected as loaded

### DIFF
--- a/src/Controller/Component/CrudComponent.php
+++ b/src/Controller/Component/CrudComponent.php
@@ -188,6 +188,7 @@ class CrudComponent extends Component
         $this->_controller->dispatchComponents['Crud'] = true;
 
         $this->_loadListeners();
+
         $this->trigger('beforeFilter');
     }
 
@@ -636,7 +637,7 @@ class CrudComponent extends Component
      * Load a single event class attached to Crud.
      *
      * @param string $name Name
-     * @return \Crud\Listener\BaseListener
+     * @return mixed void|\Crud\Listener\BaseListener
      * @throws \Crud\Error\Exception\ListenerNotConfiguredException
      * @throws \Crud\Error\Exception\MissingListenerException
      */
@@ -649,7 +650,12 @@ class CrudComponent extends Component
                 throw new ListenerNotConfiguredException(sprintf('Listener "%s" is not configured', $name));
             }
 
+            if (!isset($config['className'])) {
+                return;
+            }
+
             $className = App::classname($config['className'], 'Listener', 'Listener');
+
             if (empty($className)) {
                 throw new MissingListenerException('Could not find listener class: ' . $config['className']);
             }

--- a/tests/TestCase/Controller/Component/CrudComponentTest.php
+++ b/tests/TestCase/Controller/Component/CrudComponentTest.php
@@ -1014,5 +1014,11 @@ class CrudComponentTest extends TestCase
         $this->setReflectionClassInstance($this->Crud);
         $listener = $this->callProtectedMethod('_loadListener', ['HasSetup'], $this->Crud);
         $this->assertSame(1, $listener->callCount, 'Setup should be called');
+
+        // assert non-loaded Listener with config setting in user application is skipped
+        $this->Crud->config('listeners.someListener', [
+            'someOption' => 'butNotClassName'
+        ]);
+        $this->assertNull($this->callProtectedMethod('_loadListener', ['someListener'], $this->Crud));
     }
 }


### PR DESCRIPTION
This change prevents false positives during Listener detection and thus allows users to now easily switch between listeners (even when config settings for a non-enabled Listener are present in the user application).

Before:
- in my app switch from JsonApiListener to ApiListener
- config setting still present in my app `$this->Crud->config(['listeners.jsonApi.jsonOptions' => [128]]);`
- caused cake error CrudComponent L657, undefined index 'className'
