### PR TITLE
Search listener skip if behavior not loaded on purpose.

### DIFF
--- a/src/Listener/SearchListener.php
+++ b/src/Listener/SearchListener.php
@@ -53,7 +53,7 @@ class SearchListener extends BaseListener
         }
 
         $table = $this->_table();
-        if (!$table->behaviors()->loaded('Search')) {
+        if (!$table->behaviors()->has('Search')) {
             return;
         }
 

--- a/src/Listener/SearchListener.php
+++ b/src/Listener/SearchListener.php
@@ -53,6 +53,10 @@ class SearchListener extends BaseListener
         }
 
         $table = $this->_table();
+        if (!$table->behaviors()->loaded('Search')) {
+            return;
+        }
+
         if (!$table->behaviors()->hasMethod('filterParams')) {
             throw new RuntimeException(sprintf(
                 'Missing Search.Search behavior on %s',


### PR DESCRIPTION
The main controller has
```php
			'listeners' => [
				...
				'Crud.Search',
```
because 90% of the controllers need it.
But if one Table does not have the Search behavior loaded, this means here in this controller we do not need/want the search functionality. Currently it fails with "Missing Search.Search behavior" error.

The exception should only be thrown if the behavior is loaded and something is missing then.