### PR TITLE
Use CakePHP Router to generate JSONAPI links

### DIFF
--- a/src/Traits/JsonApiTrait.php
+++ b/src/Traits/JsonApiTrait.php
@@ -1,0 +1,86 @@
+<?php
+namespace Crud\Traits;
+
+use Cake\ORM\Entity;
+use Cake\Routing\Router;
+use Cake\Utility\Inflector;
+
+trait JsonApiTrait
+{
+
+    /**
+     * Use Cake's router to generate all (prefix) URL parts used in the
+     * NeoMerx Link objects to ensure proper handling of prefixes, base, etc.
+     *
+     * @param \Cake\ORM\Entity $entity Entity
+     * @param bool $absolute True for absolute links, false for relative links
+     * @return string
+     */
+    protected function _getCakeSubUrl(Entity $entity, $absolute = true)
+    {
+        $controller = $this->_getControllerNameFromEntity($entity);
+
+        if ($absolute === true) {
+            return Router::url([
+                'controller' => $controller,
+                '_method' => 'GET',
+            ], true);
+        }
+
+        return Router::normalize([
+            'controller' => $controller,
+            '_method' => 'GET',
+        ], true);
+    }
+
+    /**
+     * Parses the name of an Entity class to build a lowercase plural
+     * controller name to be used in links.
+     *
+     * @param \Cake\ORM\Entity $entity Entity
+     * @return string Lowercase controller name
+     */
+    protected function _getControllerNameFromEntity($entity)
+    {
+        $className = $this->_getClassName($entity);
+        $className = Inflector::pluralize($className);
+
+        return Inflector::tableize($className);
+    }
+
+    /**
+     * Helper function to return the class name of an object without namespace.
+     *
+     * @param mixed $class Any php class object
+     * @return bool|string False if the classname could not be derived
+     */
+    protected function _getClassName($class)
+    {
+        if (!is_object($class)) {
+            return false;
+        }
+
+        $className = get_class($class);
+
+        if ($pos = strrpos($className, '\\')) {
+            return substr($className, $pos + 1);
+        }
+
+        return $className;
+    }
+
+    /**
+     * Helper function to determine if string is singular or plural.
+     *
+     * @param string $string Preferably a CakePHP generated name.
+     * @return bool
+     */
+    protected function _stringIsSingular($string)
+    {
+        if (Inflector::singularize($string) === $string) {
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/src/View/JsonApiView.php
+++ b/src/View/JsonApiView.php
@@ -103,8 +103,7 @@ class JsonApiView extends View
         $encoder = Encoder::instance(
             [],
             new EncoderOptions(
-                $this->_jsonOptions(),
-                $this->viewVars['_urlPrefix']
+                $this->_jsonOptions()
             )
         );
 
@@ -125,8 +124,7 @@ class JsonApiView extends View
         $encoder = Encoder::instance(
             $schemas,
             new EncoderOptions(
-                $this->_jsonOptions(),
-                $this->viewVars['_urlPrefix']
+                $this->_jsonOptions()
             )
         );
 

--- a/tests/TestCase/Listener/JsonApiListenerTest.php
+++ b/tests/TestCase/Listener/JsonApiListenerTest.php
@@ -8,7 +8,6 @@ use Cake\Filesystem\File;
 use Cake\Network\Request;
 use Cake\Network\Response;
 use Cake\ORM\TableRegistry;
-use Cake\Routing\Router;
 use Crud\Event\Subject;
 use Crud\Listener\JsonApiListener;
 use Crud\TestSuite\TestCase;
@@ -53,7 +52,8 @@ class JsonApiListenerTest extends TestCase
             'setFlash' => false,
             'withJsonApiVersion' => false,
             'meta' => false,
-            'urlPrefix' => null,
+            'absoluteLinks' => false,
+            'jsonApiBelongsToLinks' => false,
             'jsonOptions' => [],
             'debugPrettyPrint' => true,
             'include' => [],
@@ -531,53 +531,6 @@ class JsonApiListenerTest extends TestCase
     }
 
     /**
-     * _getNewResourceUrl()
-     *
-     * @return void
-     */
-    public function testGetNewResourceUrl()
-    {
-        $controller = $this
-            ->getMockBuilder('\Cake\Controller\Controller')
-            ->setMethods(null)
-            ->enableOriginalConstructor()
-            ->getMock();
-        $controller->name = 'Countries';
-
-        $listener = $this
-            ->getMockBuilder('\Crud\Listener\JsonApiListener')
-            ->disableOriginalConstructor()
-            ->setMethods(['_controller', '_action'])
-            ->getMock();
-
-        $listener
-            ->expects($this->any())
-            ->method('_controller')
-            ->will($this->returnValue($controller));
-
-        $listener
-            ->expects($this->any())
-            ->method('_action')
-            ->will($this->returnValue('add'));
-
-        $this->setReflectionClassInstance($listener);
-
-        $routerParameters = [
-            'controller' => 'monkeys',
-            'action' => 'view',
-            123
-        ];
-
-        // assert Router defaults (to test against)
-        $result = Router::url($routerParameters, true);
-        $this->assertEquals('/monkeys/view/123', $result);
-
-        // assert success
-        $result = $this->callProtectedMethod('_getNewResourceUrl', ['monkeys', 123], $listener);
-        $this->assertEquals('/monkeys/123', $result);
-    }
-
-    /**
      * Make sure render() works with find data
      *
      * @return void
@@ -672,28 +625,6 @@ class JsonApiListenerTest extends TestCase
         $this->markTestIncomplete(
             'Implement this test to bump coverage to 100%. Requires mocking system/php functions'
         );
-    }
-
-    /**
-     * Make sure config option `urlPrefix` does not accept an array
-     *
-     * @expectedException \Crud\Error\Exception\CrudException
-     * @expectedExceptionMessage JsonApiListener configuration option `urlPrefix` only accepts a string
-     */
-    public function testValidateConfigOptionUrlPrefixFailWithArray()
-    {
-        $listener = $this
-            ->getMockBuilder('\Crud\Listener\JsonApiListener')
-            ->disableOriginalConstructor()
-            ->setMethods(null)
-            ->getMock();
-
-        $listener->config([
-            'urlPrefix' => ['array', 'not-accepted']
-        ]);
-
-        $this->setReflectionClassInstance($listener);
-        $this->callProtectedMethod('_validateConfigOptions', [], $listener);
     }
 
     /**
@@ -803,6 +734,91 @@ class JsonApiListenerTest extends TestCase
         $this->callProtectedMethod('_validateConfigOptions', [], $listener);
     }
 
+    /**
+     * Make sure config option `absoluteLinks` accepts a boolean
+     *
+     * @return void
+     */
+    public function testValidateConfigOptionAbsoluteLinksSuccessWithBoolean()
+    {
+        $listener = $this
+            ->getMockBuilder('\Crud\Listener\JsonApiListener')
+            ->disableOriginalConstructor()
+            ->setMethods(null)
+            ->getMock();
+
+        $listener->config([
+            'absoluteLinks' => true
+        ]);
+
+        $this->setReflectionClassInstance($listener);
+        $this->callProtectedMethod('_validateConfigOptions', [], $listener);
+    }
+
+    /**
+     * Make sure config option `absoluteLinks` does not accept a string
+     *
+     * @expectedException \Crud\Error\Exception\CrudException
+     * @expectedExceptionMessage JsonApiListener configuration option `absoluteLinks` only accepts a boolean
+     */
+    public function testValidateConfigOptionAbsoluteLinksFailsWithString()
+    {
+        $listener = $this
+            ->getMockBuilder('\Crud\Listener\JsonApiListener')
+            ->disableOriginalConstructor()
+            ->setMethods(null)
+            ->getMock();
+
+        $listener->config([
+            'absoluteLinks' => 'string-not-accepted'
+        ]);
+
+        $this->setReflectionClassInstance($listener);
+        $this->callProtectedMethod('_validateConfigOptions', [], $listener);
+    }
+
+    /**
+     * Make sure config option `jsonApiBelongsToLinks` accepts a boolean
+     *
+     * @return void
+     */
+    public function testValidateConfigOptionJsonApiBelongsToLinksSuccessWithBoolean()
+    {
+        $listener = $this
+            ->getMockBuilder('\Crud\Listener\JsonApiListener')
+            ->disableOriginalConstructor()
+            ->setMethods(null)
+            ->getMock();
+
+        $listener->config([
+            'jsonApiBelongsToLinks' => true
+        ]);
+
+        $this->setReflectionClassInstance($listener);
+        $this->callProtectedMethod('_validateConfigOptions', [], $listener);
+    }
+
+    /**
+     * Make sure config option `jsonApiBelongsToLinks` does not accept a string
+     *
+     * @expectedException \Crud\Error\Exception\CrudException
+     * @expectedExceptionMessage JsonApiListener configuration option `jsonApiBelongsToLinks` only accepts a boolean
+     */
+    public function testValidateConfigOptionJsonApiBelongsToLinksFailsWithString()
+    {
+        $listener = $this
+            ->getMockBuilder('\Crud\Listener\JsonApiListener')
+            ->disableOriginalConstructor()
+            ->setMethods(null)
+            ->getMock();
+
+        $listener->config([
+            'jsonApiBelongsToLinks' => 'string-not-accepted'
+        ]);
+
+        $this->setReflectionClassInstance($listener);
+        $this->callProtectedMethod('_validateConfigOptions', [], $listener);
+    }
 
     /**
      * Make sure config option `include` does not accept a string

--- a/tests/TestCase/Traits/JsonApiTraitTest.php
+++ b/tests/TestCase/Traits/JsonApiTraitTest.php
@@ -1,0 +1,73 @@
+<?php
+namespace Crud\Test\TestCase\Traits;
+
+use Crud\TestSuite\TestCase;
+use Crud\Test\App\Model\Entity\Country;
+use Crud\Traits\JsonApiTrait;
+use stdClass;
+
+/**
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ */
+class JsonApiTraitTest extends TestCase
+{
+    use JsonApiTrait;
+
+    /**
+     * _getCakeSubUrl()
+     *
+     * @return void
+     */
+    public function testGetCakeSubUrl()
+    {
+        $entity = new Country();
+
+        // assert success for absolute links
+        $expected = '/countries';
+        $this->assertSame($expected, $this->_getCakeSubUrl($entity, true));
+
+        // assert success for relative links
+        $expected = '/countries';
+        $this->assertSame($expected, $this->_getCakeSubUrl($entity, false));
+    }
+
+    /**
+     * _getClassName()
+     *
+     * @return void
+     */
+    public function testGetClassName()
+    {
+        // assert false for arguments that are not a class
+        $this->assertFalse($this->_getClassName('string'));
+        $this->assertFalse($this->_getClassName(123));
+        $this->assertFalse($this->_getClassName(true));
+        $this->assertFalse($this->_getClassName(['dummy' => 'array']));
+
+        // assert success
+        $object = new stdClass();
+        $expected = 'stdClass';
+        $this->assertSame($expected, $this->_getClassName($object));
+
+        $object = new Country();
+        $expected = 'Country';
+        $this->assertSame($expected, $this->_getClassName($object));
+    }
+
+    /**
+     * _stringIsSingular()
+     *
+     * @return void
+     */
+    public function testStringIsSingular()
+    {
+        //assert success
+        $this->assertTrue($this->_stringIsSingular('country'));
+        $this->assertTrue($this->_stringIsSingular('Country'));
+
+        // assert fails
+        $this->assertFalse($this->_stringIsSingular('countries'));
+        $this->assertFalse($this->_stringIsSingular('Countries'));
+    }
+}

--- a/tests/TestCase/View/JsonApiViewTest.php
+++ b/tests/TestCase/View/JsonApiViewTest.php
@@ -61,6 +61,8 @@ class JsonApiViewTest extends TestCase
             '_urlPrefix' => $listener->config('urlPrefix'),
             '_withJsonApiVersion' => $listener->config('withJsonApiVersion'),
             '_meta' => $listener->config('meta'),
+            '_absoluteLinks' => $listener->config('absoluteLinks'),
+            '_jsonApiBelongsToLinks' => $listener->config('jsonApiBelongsToLinks'),
             '_include' => $listener->config('include'),
             '_fieldSets' => $listener->config('fieldSets'),
             '_jsonOptions' => $listener->config('jsonOptions'),
@@ -84,6 +86,8 @@ class JsonApiViewTest extends TestCase
             '_urlPrefix' => null,
             '_withJsonApiVersion' => false,
             '_meta' => false,
+            '_absoluteLinks' => false,
+            '_jsonApiBelongsToLinks' => false,
             '_include' => [],
             '_fieldSets' => [],
             '_jsonOptions' => [


### PR DESCRIPTION
This replaces the seriously flawed link generating logic (previously breaking a lot of things) with CakePHP Router generated links. This PR solves most of the concerns I had before. Now:

- respects prefixes
- respects dasherized routes, etc
- respects CakePHP `base` configuration option

Added an option to switch between absolute and relative links as a new year's bonus.