### PR TITLE
Remove Bad Apostrophe

### DIFF
--- a/docs/crud-subject.rst
+++ b/docs/crud-subject.rst
@@ -3,7 +3,7 @@ Crud Subject
 ************
 .. _crud-subject:
 
-The Crud Subject is the class which is passed as the subject of all the events that the Crud plugin emits during it's
+The Crud Subject is the class which is passed as the subject of all the events that the Crud plugin emits during its
 execution. Depending on the action being scaffolded, and what it's working on the contents of the subject can be
 different.
 


### PR DESCRIPTION
A possessive belonging to an "it" doesn't need an apostrophe. Don't believe me? Ask [the Oatmeal](http://theoatmeal.com/comics/apostrophe) (look for the velociraptor)!