### PR TITLE
Adds JsonApiListener to index and Api section

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -11,3 +11,9 @@ Implementing the API Listener
 
 If you'd like to get started right away with the :doc:`api listener </listeners/api>`, please check the
 :doc:`Listeners chapter </listeners>`.
+
+Implementing the JSON API Listener
+==================================
+
+To get started with the :doc:`jsonapi Listener </listeners/api>`, please check the
+:doc:`Listeners chapter </listeners>`.

--- a/docs/listeners.rst
+++ b/docs/listeners.rst
@@ -88,8 +88,8 @@ within the plugin and change behavior to suit your application, or to provide ex
 	listeners/api
 	listeners/api-pagination
 	listeners/api-query-log
+	listeners/jsonapi
 	listeners/redirect
 	listeners/related-models
 	listeners/search
 	Create your own <listeners/custom>
-	


### PR DESCRIPTION
This makes the JsonApiListener documentation find'able, there's no entry point atm.