### PR TITLE
Fixed incorrect class inheritance

### DIFF
--- a/docs/listeners/custom.rst
+++ b/docs/listeners/custom.rst
@@ -41,6 +41,7 @@ Creating your own listener class is very similar to using a controller as a list
   namespace App\Lib\Listeners;
 
   use Cake\Event\Event;
+  use Crud\Listener\BaseListener;
 
   class MyListener extends BaseListener
   {

--- a/docs/listeners/custom.rst
+++ b/docs/listeners/custom.rst
@@ -40,10 +40,9 @@ Creating your own listener class is very similar to using a controller as a list
   <?php
   namespace App\Lib\Listeners;
 
-  use Cake\Event\EventListenerInterface;
   use Cake\Event\Event;
 
-  class MyListener implements EventListenerInterface
+  class MyListener extends BaseListener
   {
       public function implementedEvents()
       {


### PR DESCRIPTION
Seems this example was implementing the Cake Event Interface, whereas elsewhere in the docs it says to extend the BaseListener, which is an abstract class with the `implementedEvents` method already in there.