### PR TITLE
Fixes JSON API prev/next pagination

### DIFF
--- a/src/Listener/ApiPaginationListener.php
+++ b/src/Listener/ApiPaginationListener.php
@@ -116,7 +116,7 @@ class ApiPaginationListener extends BaseListener
             $prev = Router::$routerMethod([
                 'controller' => $this->_controller()->name,
                 'action' => 'index',
-                'page' => $pagination['prevPage']
+                'page' => $pagination['page'] - 1
             ], true);
         }
 
@@ -125,7 +125,7 @@ class ApiPaginationListener extends BaseListener
             $next = Router::$routerMethod([
                 'controller' => $this->_controller()->name,
                 'action' => 'index',
-                'page' => $pagination['nextPage']
+                'page' => $pagination['page'] + 1
             ], true);
         }
 

--- a/tests/TestCase/Listener/ApiPaginationListenerTest.php
+++ b/tests/TestCase/Listener/ApiPaginationListenerTest.php
@@ -444,8 +444,8 @@ class ApiPaginationListenerTest extends TestCase
         $pagination = [
             'page' => 1, // self
             'pageCount' => 1, // last
-            'prevPage' => null, // prev
-            'nextPage' => null, // next
+            'prevPage' => false,
+            'nextPage' => false,
             'count' => 8, // record_count
             'limit' => 10 // page_limit
         ];
@@ -468,8 +468,8 @@ class ApiPaginationListenerTest extends TestCase
         $pagination = [
             'page' => 1,
             'pageCount' => 3,
-            'prevPage' => null,
-            'nextPage' => 2,
+            'prevPage' => false,
+            'nextPage' => true,
             'count' => 28,
             'limit' => 10
         ];
@@ -492,8 +492,8 @@ class ApiPaginationListenerTest extends TestCase
         $pagination = [
             'page' => 2,
             'pageCount' => 3,
-            'prevPage' => null,
-            'nextPage' => 3,
+            'prevPage' => true,
+            'nextPage' => true,
             'count' => 28,
             'limit' => 10
         ];
@@ -502,7 +502,7 @@ class ApiPaginationListenerTest extends TestCase
             'self' => '/countries?page=2',
             'first' => '/countries?page=1',
             'last' => '/countries?page=3',
-            'prev' => null,
+            'prev' => '/countries?page=1',
             'next' => '/countries?page=3',
             'record_count' => 28,
             'page_count' => 3,
@@ -516,8 +516,8 @@ class ApiPaginationListenerTest extends TestCase
         $pagination = [
             'page' => 3,
             'pageCount' => 3,
-            'prevPage' => 2,
-            'nextPage' => null,
+            'prevPage' => true,
+            'nextPage' => false,
             'count' => 28,
             'limit' => 10
         ];


### PR DESCRIPTION
Incorporates #499 + corrects a bad test using incorrect previous page. All jsonapi pagination tested successfully (1-of-3, 2-of-3, 3-of-3)