### PR TITLE
Cake 3.4 returns false for _ext if not there

### DIFF
--- a/src/Listener/ApiListener.php
+++ b/src/Listener/ApiListener.php
@@ -415,7 +415,7 @@ class ApiListener extends BaseListener
 
         foreach ($detectors as $name => $config) {
             $request->addDetector($name, function (Request $request) use ($config) {
-                if ($request->param('_ext') === $config['ext']) {
+                if ($config['ext'] !== false && $request->param('_ext') === $config['ext']) {
                     return true;
                 }
 

--- a/tests/TestCase/Listener/ApiListenerTest.php
+++ b/tests/TestCase/Listener/ApiListenerTest.php
@@ -993,7 +993,8 @@ class ApiListenerTest extends TestCase
     {
         $detectors = [
             'json' => ['ext' => 'json', 'accepts' => 'application/json'],
-            'xml' => ['ext' => 'xml', 'accepts' => 'text/xml']
+            'xml' => ['ext' => 'xml', 'accepts' => 'text/xml'],
+            'jsonapi' => ['ext' => false, 'accepts' => 'application/vnd.api+json']
         ];
 
         $listener = $this
@@ -1025,7 +1026,9 @@ class ApiListenerTest extends TestCase
         foreach ($detectors as $name => $configuration) {
             $request->params['_ext'] = $configuration['ext'];
             $request->clearDetectorCache();
-            $this->assertTrue($request->is($name));
+            if ($configuration['ext'] !== false) {
+                $this->assertTrue($request->is($name));
+            }
         }
 
         $request->params['_ext'] = null;
@@ -1061,6 +1064,15 @@ class ApiListenerTest extends TestCase
             $request->is('api'),
             "A request with no extensions should not be considered an api request"
         );
+
+        //Ensure that no set extension will not result in a true
+        unset($request->params['_ext']);
+        $request->clearDetectorCache();
+        $request->expects($this->any())
+            ->method('accepts')
+            ->will($this->returnValue(false));
+
+        $this->assertFalse($request->is('jsonapi'), "A request with no extensions should not be considered an jsonapi request");
     }
 
     /**


### PR DESCRIPTION
Since CakePHP 3.4 returns false for `_ext` as soon as `JsonApiListener` is loaded, all requests are treated as a JsonAPI request