### PR TITLE
Adds neomerx dev dependency required for running unit tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,3 +57,4 @@ script:
 
 notifications:
   email: false
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,4 +57,3 @@ script:
 
 notifications:
   email: false
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,8 +40,6 @@ before_script:
   - composer self-update
   - composer install --prefer-dist
 
-  - sh -c "if [ '$DEFAULT' = '1' ] || [ '$CODECOVERAGE' = '1' ]; then composer require 'neomerx/json-api:^0.8.10'; fi"
-
   - sh -c "if [ '$DB' = 'mysql' ]; then mysql -e 'CREATE DATABASE cakephp_test;'; fi"
 
   - sh -c "if [ '$DB' = 'pgsql' ]; then psql -c 'CREATE DATABASE cakephp_test;' -U postgres; fi"

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,8 @@
     "require-dev": {
         "phpunit/phpunit": "<6.0",
         "friendsofcake/cakephp-test-utilities": "dev-master",
-        "friendsofcake/search": "dev-master"
+        "friendsofcake/search": "dev-master",
+        "neomerx/json-api": "^0.8.10"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This should resolve the following error produced when running the unit tests locally. Not an issue on Travis because neomerx is composer installed there.

    PHP Fatal error:  Class 'Neomerx\JsonApi\Schema\SchemaProvider' not found in /home/vagrant/projects/alt3-api/vendor/friendsofcake/crud/src/Schema/JsonApi/DynamicEntitySchema.php on line 19
