### PR TITLE
Return 201 for successfully created JSON API records

### DIFF
--- a/src/Listener/JsonApiListener.php
+++ b/src/Listener/JsonApiListener.php
@@ -109,9 +109,9 @@ class JsonApiListener extends ApiListener
     }
 
     /**
-     * afterSave() event used to respond with `Location` header pointing to
-     * the newly created resources. Only applied to `add` actions as described
-     * at http://jsonapi.org/format/#crud-creating-responses-201.
+     * afterSave() event used to respond with Status Code 201 for newly
+     * created resources. Only applied to `add` actions as described at
+     * http://jsonapi.org/format/#crud-creating-responses-201.
      *
      * @param \Cake\Event\Event $event Event
      * @return false|null
@@ -125,6 +125,10 @@ class JsonApiListener extends ApiListener
         // `created` will be set for add actions, `id` for edit actions
         if (!$event->subject()->created && !$event->subject()->id) {
             return false;
+        }
+
+        if ($event->subject()->created) {
+            $this->_controller()->response->statusCode(201);
         }
 
         $this->_insertBelongsToDataIntoEventFindResult($event);

--- a/tests/App/Controller/CountriesController.php
+++ b/tests/App/Controller/CountriesController.php
@@ -1,0 +1,34 @@
+<?php
+namespace Crud\Test\App\Controller;
+
+use Cake\Controller\Controller;
+use Crud\Controller\ControllerTrait;
+
+/**
+ * Test controller for JsonApiListener integration tests.
+ */
+class CountriesController extends Controller
+{
+
+    use ControllerTrait;
+
+    public $paginate = [
+        'limit' => 3
+    ];
+
+    public $components = [
+        'RequestHandler',
+        'Crud.Crud' => [
+            'actions' => [
+                'Crud.Index',
+                'Crud.View',
+                'Crud.Add',
+                'Crud.Edit',
+                'Crud.Delete',
+            ],
+            'listeners' => [
+                'Crud.JsonApi'
+            ]
+        ]
+    ];
+}

--- a/tests/Fixture/CountriesFixture.php
+++ b/tests/Fixture/CountriesFixture.php
@@ -15,7 +15,7 @@ class CountriesFixture extends TestFixture
     ];
 
     public $records = [
-        ['id' => 1, 'code' => 'NL', 'name' => 'The Netherlands', 'currency_id' => 1],
-        ['id' => 2, 'code' => 'BE', 'name' => 'Belgium', 'currency_id' => 1],
+        ['code' => 'NL', 'name' => 'The Netherlands', 'currency_id' => 1],
+        ['code' => 'BE', 'name' => 'Belgium', 'currency_id' => 1],
     ];
 }

--- a/tests/Fixture/CulturesFixture.php
+++ b/tests/Fixture/CulturesFixture.php
@@ -15,8 +15,8 @@ class CulturesFixture extends TestFixture
     ];
 
     public $records = [
-        ['id' => 1, 'code' => 'nl-NL', 'name' => 'Dutch', 'country_id' => 1],
-        ['id' => 2, 'code' => 'nl-BE', 'name' => 'Dutch (Belgium)', 'country_id' => 2],
-        ['id' => 3, 'code' => 'fr-BE', 'name' => 'French (Belgium)', 'country_id' => 2],
+        ['code' => 'nl-NL', 'name' => 'Dutch', 'country_id' => 1],
+        ['code' => 'nl-BE', 'name' => 'Dutch (Belgium)', 'country_id' => 2],
+        ['code' => 'fr-BE', 'name' => 'French (Belgium)', 'country_id' => 2],
     ];
 }

--- a/tests/Fixture/CurrenciesFixture.php
+++ b/tests/Fixture/CurrenciesFixture.php
@@ -14,7 +14,7 @@ class CurrenciesFixture extends TestFixture
     ];
 
     public $records = [
-        ['id' => 1, 'code' => 'EUR', 'name' => 'Euro'],
-        ['id' => 2, 'code' => 'USD', 'name' => 'US Dollar'],
+        ['code' => 'EUR', 'name' => 'Euro'],
+        ['code' => 'USD', 'name' => 'US Dollar'],
     ];
 }

--- a/tests/TestCase/Controller/JsonApiIntegrationTest.php
+++ b/tests/TestCase/Controller/JsonApiIntegrationTest.php
@@ -1,0 +1,92 @@
+<?php
+namespace Crud\TestCase\Controller;
+
+use Cake\Routing\Router;
+use Crud\TestSuite\IntegrationTestCase;
+
+class JsonApiIntegrationTest extends IntegrationTestCase
+{
+
+    public $fixtures = [
+        'plugin.crud.countries',
+        'plugin.crud.currencies'
+    ];
+
+    /**
+     * Set up required RESTful resource routes.
+     */
+    public function setUp()
+    {
+        Router::scope('/', function ($routes) {
+            $routes->resources('Countries', [
+                'inflect' => 'dasherize'
+            ]);
+        });
+    }
+
+    /**
+     * Test most basic `index` action
+     *
+     * @return void
+     */
+    public function testGet()
+    {
+        $this->configRequest([
+            'headers' => ['Accept' => 'application/vnd.api+json']
+        ]);
+
+        $this->get('/countries');
+
+        $this->assertResponseOk();
+        $this->_assertJsonApiResponse();
+        $this->assertResponseCode(200);
+        $this->assertResponseNotEmpty();
+    }
+
+    /**
+     * Make sure HTTP Status Code 201 is returned after successfully
+     * creating a new record using POST method.
+     *
+     * @link http://jsonapi.org/format/#crud-creating-responses-201
+     * @link https://github.com/FriendsOfCake/crud/issues/496
+     * @return void
+     */
+    public function testSuccessfulPostReturnsStatusCode201()
+    {
+        $postData = [
+            'data' => [
+                'type' => 'countries',
+                'attributes' => [
+                    'code' => 'NZ',
+                    'name' => 'New Zealand',
+                    'currency_id' => 1
+                ]
+            ]
+        ];
+
+        $this->configRequest([
+            'headers' => [
+                'Accept' => 'application/vnd.api+json',
+                'Content-Type' => 'application/vnd.api+json'
+            ],
+            'input' => json_encode($postData)
+        ]);
+
+        $this->post('/countries');
+
+        $this->assertResponseOk();
+        $this->_assertJsonApiResponse();
+        $this->assertResponseCode(201);
+        $this->assertResponseNotEmpty();
+    }
+
+    /**
+     * Helper method to prevent repetition since all JSON API responses
+     * must pass this test.
+     */
+    protected function _assertJsonApiResponse()
+    {
+        $this->assertHeader('Content-Type', 'application/vnd.api+json');
+        $this->assertContentType('application/vnd.api+json');
+    }
+}


### PR DESCRIPTION
Status code after successfully created JSON API record should return 201 (now 200). http://jsonapi.org/format/#crud-creating-responses-201.

Closes #496 