### PR TITLE
JsonApi updates http code 422 and 409 cannot send correct headers.

### DIFF
--- a/src/Error/JsonApiExceptionRenderer.php
+++ b/src/Error/JsonApiExceptionRenderer.php
@@ -97,6 +97,10 @@ class JsonApiExceptionRenderer extends \Cake\Error\ExceptionRenderer
         // set data and send response
         $this->controller->response->type('jsonapi');
         $this->controller->response->body($json);
+        $this->controller->response->cors($this->controller->request)
+            ->allowOrigin('*')
+            ->allowCredentials()
+            ->build();
 
         return $this->controller->response;
     }


### PR DESCRIPTION
When validation errors appear, headers cannot send correct, and data is blocked because not have anyone header.