### PR TITLE
Added haders from older controller

### DIFF
--- a/src/Error/JsonApiExceptionRenderer.php
+++ b/src/Error/JsonApiExceptionRenderer.php
@@ -95,6 +95,7 @@ class JsonApiExceptionRenderer extends \Cake\Error\ExceptionRenderer
         }
 
         // set data and send response
+        $this->controller->response->header($this->error->responseHeader());
         $this->controller->response->type('jsonapi');
         $this->controller->response->body($json);
 

--- a/src/Listener/ApiListener.php
+++ b/src/Listener/ApiListener.php
@@ -179,6 +179,7 @@ class ApiListener extends BaseListener
 
         if ($exceptionConfig['type'] === 'validate') {
             $exception = new $class($Event->subject->entity);
+            $exception->responseHeader($this->_controller()->response->getHeaders());
             throw $exception;
         }
 


### PR DESCRIPTION
When have exception, all headers are destroyed and new Response instance created, with this, new Response set olders headers.