### PR TITLE
Dasherize JSON API relationships node

### DIFF
--- a/docs/listeners/jsonapi.rst
+++ b/docs/listeners/jsonapi.rst
@@ -511,7 +511,7 @@ might request ``/countries/2?include=cultures,currencies`` to achieve the
 same response. If the include parameter is provided, then only requested
 relationships will be included in the ``included`` schema.
 
-It is possible blacklist, or whitelist what the client is allowed to include.
+It is possible to blacklist, or whitelist what the client is allowed to include.
 This is done using the listener configuration:
 
 .. code-block:: php
@@ -788,7 +788,7 @@ and then simply use search aliases named ``filter`` like shown below:
   }
 
 Please note that not
-`all filtering options <https://github.com/FriendsOfCake/crud/issues/524`_
+`all filtering options <https://github.com/FriendsOfCake/crud/issues/524>`_
 have been implemented yet.
 
 Schemas

--- a/src/Listener/JsonApiListener.php
+++ b/src/Listener/JsonApiListener.php
@@ -209,6 +209,7 @@ class JsonApiListener extends ApiListener
      * @param array|bool $blacklist Blacklisted includes
      * @param array|bool $whitelist Whitelisted options
      * @param \Cake\ORM\Table|null $repository The repository
+     * @param array $path Include path
      * @return string
      * @throws \Cake\Network\Exception\BadRequestException
      */
@@ -658,6 +659,7 @@ class JsonApiListener extends ApiListener
      * config option 'include'.
      *
      * @param \Cake\ORM\AssociationCollection $associations AssociationCollection
+     * @param bool $last What does this do?
      * @return array
      * @throws \InvalidArgumentException
      */

--- a/src/Schema/JsonApi/DynamicEntitySchema.php
+++ b/src/Schema/JsonApi/DynamicEntitySchema.php
@@ -140,6 +140,17 @@ class DynamicEntitySchema extends SchemaProvider
                 continue;
             }
 
+            // change related  data in entity to dasherized if need be
+            if ($this->_view->viewVars['_inflect'] === 'dasherize') {
+                $dasherizedProperty = Inflector::dasherize($property);
+
+                if (empty($entity->$dasherizedProperty)) {
+                    $entity->$dasherizedProperty = $entity->$property;
+                    unset($entity->$property);
+                    $property = $dasherizedProperty;
+                }
+            }
+
             $relations[$property] = [
                 self::DATA => $data,
                 self::SHOW_SELF => true,
@@ -181,6 +192,10 @@ class DynamicEntitySchema extends SchemaProvider
      */
     public function getRelationshipSelfLink($entity, $name, $meta = null, $treatAsHref = false)
     {
+        if ($this->_view->viewVars['_inflect'] === 'dasherize') {
+            $name = Inflector::underscore($name);
+        }
+
         $association = $this->_repository->associations()->getByProperty($name);
         $relatedRepository = $association->target();
 
@@ -198,6 +213,7 @@ class DynamicEntitySchema extends SchemaProvider
                     'type' => $name,
                 ], $this->_view->viewVars['_absoluteLinks']);
             } else {
+                $name = Inflector::dasherize($name);
                 $relatedEntity = $entity[$name];
 
                 $url = Router::url($this->_getRepositoryRoutingParameters($relatedRepository) + [

--- a/src/View/JsonApiView.php
+++ b/src/View/JsonApiView.php
@@ -7,6 +7,7 @@ use Cake\Datasource\RepositoryInterface;
 use Cake\Event\EventManager;
 use Cake\Network\Request;
 use Cake\Network\Response;
+use Cake\Utility\Inflector;
 use Cake\View\View;
 use Crud\Error\Exception\CrudException;
 use Neomerx\JsonApi\Document\Link;
@@ -117,6 +118,10 @@ class JsonApiView extends View
      */
     protected function _encodeWithSchemas()
     {
+        if ($this->viewVars['_inflect'] === 'dasherize') {
+            $this->_dasherizeIncludesViewVar();
+        }
+
         $schemas = $this->_entitiesToNeoMerxSchema($this->viewVars['_repositories']);
 
         // Please note that a third NeoMerx EncoderOptions argument `depth`
@@ -352,5 +357,17 @@ class JsonApiView extends View
         }
 
         return $jsonOptions;
+    }
+
+    /**
+     * Dasherizes all values in the '_includes` viewVar array.
+     *
+     * @return void
+     */
+    protected function _dasherizeIncludesViewVar()
+    {
+        foreach ($this->viewVars['_include'] as $key => $value) {
+            $this->viewVars['_include'][$key] = Inflector::dasherize($value);
+        }
     }
 }

--- a/tests/App/Model/Entity/NationalCapital.php
+++ b/tests/App/Model/Entity/NationalCapital.php
@@ -1,0 +1,7 @@
+<?php
+namespace Crud\Test\App\Model\Entity;
+
+class NationalCapital extends \Cake\ORM\Entity
+{
+
+}

--- a/tests/App/Model/Entity/NationalCity.php
+++ b/tests/App/Model/Entity/NationalCity.php
@@ -1,0 +1,7 @@
+<?php
+namespace Crud\Test\App\Model\Entity;
+
+class NationalCity extends \Cake\ORM\Entity
+{
+
+}

--- a/tests/App/Model/Table/CountriesTable.php
+++ b/tests/App/Model/Table/CountriesTable.php
@@ -9,8 +9,10 @@ class CountriesTable extends Table
     public function initialize(array $config)
     {
         $this->belongsTo('Currencies');
+        $this->belongsTo('NationalCapitals');
 
         $this->hasMany('Cultures');
+        $this->hasMany('NationalCities');
     }
 
     public function validationDefault(Validator $validator)

--- a/tests/App/Model/Table/NationalCapitalsTable.php
+++ b/tests/App/Model/Table/NationalCapitalsTable.php
@@ -1,0 +1,10 @@
+<?php
+namespace Crud\Test\App\Model\Table;
+
+class NationalCapitalsTable extends \Cake\ORM\Table
+{
+    public function initialize(array $config)
+    {
+        $this->belongsTo('Countries');
+    }
+}

--- a/tests/App/Model/Table/NationalCitiesTable.php
+++ b/tests/App/Model/Table/NationalCitiesTable.php
@@ -1,0 +1,10 @@
+<?php
+namespace Crud\Test\App\Model\Table;
+
+class NationalCitiesTable extends \Cake\ORM\Table
+{
+    public function initialize(array $config)
+    {
+        $this->belongsTo('Countries');
+    }
+}

--- a/tests/Fixture/CountriesFixture.php
+++ b/tests/Fixture/CountriesFixture.php
@@ -11,11 +11,12 @@ class CountriesFixture extends TestFixture
         'code' => ['type' => 'string', 'length' => 2, 'null' => false],
         'name' => ['type' => 'string', 'length' => 255, 'null' => false],
         'currency_id' => ['type' => 'integer', 'null' => false],
+        'national_capital_id' => ['type' => 'integer', 'null' => false],
         '_constraints' => ['primary' => ['type' => 'primary', 'columns' => ['id']]],
     ];
 
     public $records = [
-        ['code' => 'NL', 'name' => 'The Netherlands', 'currency_id' => 1],
-        ['code' => 'BE', 'name' => 'Belgium', 'currency_id' => 1],
+        ['code' => 'NL', 'name' => 'The Netherlands', 'currency_id' => 1, 'national_capital_id' => 1],
+        ['code' => 'BE', 'name' => 'Belgium', 'currency_id' => 1, 'national_capital_id' => 2]
     ];
 }

--- a/tests/Fixture/CulturesFixture.php
+++ b/tests/Fixture/CulturesFixture.php
@@ -9,7 +9,7 @@ class CulturesFixture extends TestFixture
     public $fields = [
         'id' => ['type' => 'integer'],
         'code' => ['type' => 'string', 'length' => 5, 'null' => false],
-        'name' => ['type' => 'string', 'length' => 255, 'null' => false],
+        'name' => ['type' => 'string', 'length' => 100, 'null' => false],
         'country_id' => ['type' => 'integer', 'null' => false],
         '_constraints' => ['primary' => ['type' => 'primary', 'columns' => ['id']]],
     ];

--- a/tests/Fixture/JsonApi/get_country_include_all_supported_associations.json
+++ b/tests/Fixture/JsonApi/get_country_include_all_supported_associations.json
@@ -1,0 +1,114 @@
+{
+    "data": {
+        "type": "countries",
+        "id": "1",
+        "attributes": {
+            "code": "NL",
+            "name": "The Netherlands"
+        },
+        "relationships": {
+            "currency": {
+                "data": {
+                    "type": "currencies",
+                    "id": "1"
+                },
+                "links": {
+                    "self": "\/currencies\/1"
+                }
+            },
+            "national-capital": {
+                "data": {
+                    "type": "national-capitals",
+                    "id": "1"
+                },
+                "links": {
+                    "self": "\/national-capitals\/1"
+                }
+            },
+            "cultures": {
+                "data": [
+                    {
+                        "type": "cultures",
+                        "id": "1"
+                    }
+                ],
+                "links": {
+                    "self": "\/cultures?country_id=1"
+                }
+            },
+            "national-cities": {
+                "data": [
+                    {
+                        "type": "national-cities",
+                        "id": "1"
+                    },
+                    {
+                        "type": "national-cities",
+                        "id": "2"
+                    }
+                ],
+                "links": {
+                    "self": "\/national-cities?country_id=1"
+                }
+            }
+        },
+        "links": {
+            "self": "\/countries\/1"
+        }
+    },
+    "included": [
+        {
+            "type": "currencies",
+            "id": "1",
+            "attributes": {
+                "code": "EUR",
+                "name": "Euro"
+            },
+            "links": {
+                "self": "\/currencies\/1"
+            }
+        },
+        {
+            "type": "national-capitals",
+            "id": "1",
+            "attributes": {
+                "name": "Amsterdam",
+                "description": "National capital of the Netherlands"
+            },
+            "links": {
+                "self": "\/national-capitals\/1"
+            }
+        },
+        {
+            "type": "cultures",
+            "id": "1",
+            "attributes": {
+                "code": "nl-NL",
+                "name": "Dutch"
+            },
+            "links": {
+                "self": "\/cultures\/1"
+            }
+        },
+        {
+            "type": "national-cities",
+            "id": "1",
+            "attributes": {
+                "name": "Amsterdam"
+            },
+            "links": {
+                "self": "\/national-cities\/1"
+            }
+        },
+        {
+            "type": "national-cities",
+            "id": "2",
+            "attributes": {
+                "name": "Rotterdam"
+            },
+            "links": {
+                "self": "\/national-cities\/2"
+            }
+        }
+    ]
+}

--- a/tests/Fixture/JsonApi/get_country_include_national-capital.json
+++ b/tests/Fixture/JsonApi/get_country_include_national-capital.json
@@ -1,0 +1,37 @@
+{
+    "data": {
+        "type": "countries",
+        "id": "1",
+        "attributes": {
+            "code": "NL",
+            "name": "The Netherlands"
+        },
+        "relationships": {
+            "national-capital": {
+                "data": {
+                    "type": "national-capitals",
+                    "id": "1"
+                },
+                "links": {
+                    "self": "\/national-capitals\/1"
+                }
+            }
+        },
+        "links": {
+            "self": "\/countries\/1"
+        }
+    },
+    "included": [
+        {
+            "type": "national-capitals",
+            "id": "1",
+            "attributes": {
+                "name": "Amsterdam",
+                "description": "National capital of the Netherlands"
+            },
+            "links": {
+                "self": "\/national-capitals\/1"
+            }
+        }
+    ]
+}

--- a/tests/Fixture/JsonApi/get_country_include_national-capital_and_national-cities.json
+++ b/tests/Fixture/JsonApi/get_country_include_national-capital_and_national-cities.json
@@ -1,0 +1,72 @@
+{
+    "data": {
+        "type": "countries",
+        "id": "1",
+        "attributes": {
+            "code": "NL",
+            "name": "The Netherlands"
+        },
+        "relationships": {
+            "national-capital": {
+                "data": {
+                    "type": "national-capitals",
+                    "id": "1"
+                },
+                "links": {
+                    "self": "\/national-capitals\/1"
+                }
+            },
+            "national-cities": {
+                "data": [
+                    {
+                        "type": "national-cities",
+                        "id": "1"
+                    },
+                    {
+                        "type": "national-cities",
+                        "id": "2"
+                    }
+                ],
+                "links": {
+                    "self": "\/national-cities?country_id=1"
+                }
+            }
+        },
+        "links": {
+            "self": "\/countries\/1"
+        }
+    },
+    "included": [
+        {
+            "type": "national-capitals",
+            "id": "1",
+            "attributes": {
+                "name": "Amsterdam",
+                "description": "National capital of the Netherlands"
+            },
+            "links": {
+                "self": "\/national-capitals\/1"
+            }
+        },
+        {
+            "type": "national-cities",
+            "id": "1",
+            "attributes": {
+                "name": "Amsterdam"
+            },
+            "links": {
+                "self": "\/national-cities\/1"
+            }
+        },
+        {
+            "type": "national-cities",
+            "id": "2",
+            "attributes": {
+                "name": "Rotterdam"
+            },
+            "links": {
+                "self": "\/national-cities\/2"
+            }
+        }
+    ]
+}

--- a/tests/Fixture/JsonApi/get_country_include_national-cities.json
+++ b/tests/Fixture/JsonApi/get_country_include_national-cities.json
@@ -1,0 +1,52 @@
+{
+    "data": {
+        "type": "countries",
+        "id": "1",
+        "attributes": {
+            "code": "NL",
+            "name": "The Netherlands"
+        },
+        "relationships": {
+            "national-cities": {
+                "data": [
+                    {
+                        "type": "national-cities",
+                        "id": "1"
+                    },
+                    {
+                        "type": "national-cities",
+                        "id": "2"
+                    }
+                ],
+                "links": {
+                    "self": "\/national-cities?country_id=1"
+                }
+            }
+        },
+        "links": {
+            "self": "\/countries\/1"
+        }
+    },
+    "included": [
+        {
+            "type": "national-cities",
+            "id": "1",
+            "attributes": {
+                "name": "Amsterdam"
+            },
+            "links": {
+                "self": "\/national-cities\/1"
+            }
+        },
+        {
+            "type": "national-cities",
+            "id": "2",
+            "attributes": {
+                "name": "Rotterdam"
+            },
+            "links": {
+                "self": "\/national-cities\/2"
+            }
+        }
+    ]
+}

--- a/tests/Fixture/NationalCapitalsFixture.php
+++ b/tests/Fixture/NationalCapitalsFixture.php
@@ -1,0 +1,21 @@
+<?php
+namespace Crud\Test\Fixture;
+
+use Cake\TestSuite\Fixture\TestFixture;
+
+class NationalCapitalsFixture extends TestFixture
+{
+
+    public $fields = [
+        'id' => ['type' => 'integer'],
+        'name' => ['type' => 'string', 'length' => 3, 'null' => false],
+        'description' => ['type' => 'string', 'length' => 255, 'null' => false],
+        '_constraints' => ['primary' => ['type' => 'primary', 'columns' => ['id']]],
+    ];
+
+    public $records = [
+        ['name' => 'Amsterdam', 'description' => 'National capital of the Netherlands'],
+        ['name' => 'Brussels', 'description' => 'National capital of Belgium'],
+        ['name' => 'Wellington', 'description' => 'National capital of New Zealand'],
+    ];
+}

--- a/tests/Fixture/NationalCapitalsFixture.php
+++ b/tests/Fixture/NationalCapitalsFixture.php
@@ -8,7 +8,7 @@ class NationalCapitalsFixture extends TestFixture
 
     public $fields = [
         'id' => ['type' => 'integer'],
-        'name' => ['type' => 'string', 'length' => 3, 'null' => false],
+        'name' => ['type' => 'string', 'length' => 100, 'null' => false],
         'description' => ['type' => 'string', 'length' => 255, 'null' => false],
         '_constraints' => ['primary' => ['type' => 'primary', 'columns' => ['id']]],
     ];

--- a/tests/Fixture/NationalCitiesFixture.php
+++ b/tests/Fixture/NationalCitiesFixture.php
@@ -3,18 +3,20 @@ namespace Crud\Test\Fixture;
 
 use Cake\TestSuite\Fixture\TestFixture;
 
-class CurrenciesFixture extends TestFixture
+class NationalCitiesFixture extends TestFixture
 {
 
     public $fields = [
         'id' => ['type' => 'integer'],
-        'code' => ['type' => 'string', 'length' => 3, 'null' => false],
         'name' => ['type' => 'string', 'length' => 100, 'null' => false],
+        'country_id' => ['type' => 'integer', 'null' => false],
         '_constraints' => ['primary' => ['type' => 'primary', 'columns' => ['id']]],
     ];
 
     public $records = [
-        ['code' => 'EUR', 'name' => 'Euro'],
-        ['code' => 'USD', 'name' => 'US Dollar'],
+        ['name' => 'Amsterdam', 'country_id' => 1],
+        ['name' => 'Rotterdam', 'country_id' => 1],
+        ['name' => 'Brussels', 'country_id' => 2],
+        ['name' => 'Antwerp', 'country_id' => 2]
     ];
 }

--- a/tests/TestCase/Integration/JsonApi/DefaultAddActionIntegrationTest.php
+++ b/tests/TestCase/Integration/JsonApi/DefaultAddActionIntegrationTest.php
@@ -20,7 +20,8 @@ class DefaultAddActionIntegrationTest extends JsonApiBaseTestCase
                 'attributes' => [
                     'code' => 'NZ',
                     'name' => 'New Zealand',
-                    'currency_id' => 1
+                    'currency_id' => 1,
+                    'national_capital_id' => 3
                 ]
             ]
         ];

--- a/tests/TestCase/Integration/JsonApi/IncludeQueryIntegrationTest.php
+++ b/tests/TestCase/Integration/JsonApi/IncludeQueryIntegrationTest.php
@@ -17,17 +17,18 @@ class IncludeQueryIntegrationTest extends JsonApiBaseTestCase
                 '/countries/1',
                 'get_country_no_relationships.json',
             ],
-            'include culture' => [
-                '/countries/1?include=cultures',
-                'get_country_include_culture.json'
-            ],
-            'include currency plural' => [
+            // assert single-word associations
+            'include currency belongsTo plural' => [
                 '/countries/1?include=currencies',
                 'get_country_include_currency.json'
             ],
-            'include currency singular' => [
+            'include currency belongsTo singular' => [
                 '/countries/1?include=currency',
                 'get_country_include_currency.json'
+            ],
+            'include culture hasMany' => [
+                '/countries/1?include=cultures',
+                'get_country_include_culture.json'
             ],
             'include currency and culture' => [
                 '/countries/1?include=currencies,cultures',
@@ -36,6 +37,28 @@ class IncludeQueryIntegrationTest extends JsonApiBaseTestCase
             'include currency and deep countries' => [
                 '/countries/1?include=currencies.countries',
                 'get_country_include_currency_and_countries.json'
+            ],
+            // assert multi-word associations
+            'include national-capital belongsTo singular' => [
+                '/countries/1?include=national-capital',
+                'get_country_include_national-capital.json'
+            ],
+            'include national-capital belongsTo plural' => [
+                '/countries/1?include=national-capitals',
+                'get_country_include_national-capital.json'
+            ],
+            'include national-cities hasMany' => [
+                '/countries/1?include=national-cities',
+                'get_country_include_national-cities.json'
+            ],
+            // assert all of the above in a single request
+            'include all supported associations (singular belongsTo)' => [
+                '/countries/1?include=currency,cultures,national-capital,national-cities',
+                'get_country_include_all_supported_associations.json'
+            ],
+            'include all supported associations (plural belongsTo)' => [
+                '/countries/1?include=currencies,cultures,national-capitals,national-cities',
+                'get_country_include_all_supported_associations.json'
             ],
         ];
     }
@@ -52,7 +75,6 @@ class IncludeQueryIntegrationTest extends JsonApiBaseTestCase
 
         $this->assertResponseSuccess();
         $this->_assertJsonApiResponseHeaders();
-
         $this->assertResponseEquals($this->_getExpected($expectedFile));
     }
 

--- a/tests/TestCase/Integration/JsonApiBaseTestCase.php
+++ b/tests/TestCase/Integration/JsonApiBaseTestCase.php
@@ -19,6 +19,8 @@ abstract class JsonApiBaseTestCase extends IntegrationTestCase
         'plugin.crud.countries',
         'plugin.crud.currencies',
         'plugin.crud.cultures',
+        'plugin.crud.national_capitals',
+        'plugin.crud.national_cities',
     ];
 
     /**
@@ -39,10 +41,16 @@ abstract class JsonApiBaseTestCase extends IntegrationTestCase
             $routes->resources('Countries', [
                 'inflect' => 'dasherize'
             ]);
-            $routes->resources('Currencies', [
+            $routes->resources('Currencies', [ // single word belongsTo association
                 'inflect' => 'dasherize'
             ]);
-            $routes->resources('Cultures', [
+            $routes->resources('Cultures', [ // single word hasMany association
+                'inflect' => 'dasherize'
+            ]);
+            $routes->resources('NationalCapitals', [ // multi-word belongsTo association
+                'inflect' => 'dasherize'
+            ]);
+            $routes->resources('NationalCities', [ // multi-word hasMany association
                 'inflect' => 'dasherize'
             ]);
         });

--- a/tests/TestCase/Listener/JsonApiListenerTest.php
+++ b/tests/TestCase/Listener/JsonApiListenerTest.php
@@ -30,6 +30,8 @@ class JsonApiListenerTest extends TestCase
         'plugin.crud.countries',
         'plugin.crud.cultures',
         'plugin.crud.currencies',
+        'plugin.crud.national_capitals',
+        'plugin.crud.national_cities',
     ];
 
     /**
@@ -1006,7 +1008,9 @@ class JsonApiListenerTest extends TestCase
     {
         $table = TableRegistry::get('Countries');
         $table->belongsTo('Currencies');
+        $table->belongsTo('NationalCapitals');
         $table->hasMany('Cultures');
+        $table->hasMany('NationalCities');
 
         $associations = [];
         foreach ($table->associations() as $association) {
@@ -1032,7 +1036,9 @@ class JsonApiListenerTest extends TestCase
         $expected = [
             'Countries' => $table,
             'Currencies' => $table->Currencies->target(),
+            'NationalCapitals' => $table->NationalCapitals->target(),
             'Cultures' => $table->Cultures->target(),
+            'NationalCities' => $table->NationalCities->target(),
         ];
 
         $this->assertSame($expected, $result);
@@ -1074,26 +1080,26 @@ class JsonApiListenerTest extends TestCase
 
         $expected = [
             'currency.countries',
-            'cultures'
+            'national_capital',
+            'cultures',
+            'national_cities',
         ];
-
         $result = $this->callProtectedMethod('_getIncludeList', [$associations], $listener);
-
         $this->assertSame($expected, $result);
 
         unset($associations['currencies']['children']['countries']);
-        $this->assertSame(['currencies', 'cultures'], array_keys($associations));
-        $result = $this->callProtectedMethod('_getIncludeList', [$associations], $listener);
+        $this->assertSame(['currencies', 'nationalcapitals', 'cultures', 'nationalcities'], array_keys($associations));
 
-        $this->assertSame(['currency', 'cultures'], $result);
+        $result = $this->callProtectedMethod('_getIncludeList', [$associations], $listener);
+        $this->assertSame(['currency', 'national_capital', 'cultures', 'national_cities'], $result);
 
         // assert the include list is still auto-generated if an association is
         // removed from the AssociationsCollection
         unset($associations['cultures']);
-        $this->assertSame(['currencies'], array_keys($associations));
-        $result = $this->callProtectedMethod('_getIncludeList', [$associations], $listener);
+        $this->assertSame(['currencies', 'nationalcapitals', 'nationalcities'], array_keys($associations));
 
-        $this->assertSame(['currency'], $result);
+        $result = $this->callProtectedMethod('_getIncludeList', [$associations], $listener);
+        $this->assertSame(['currency', 'national_capital', 'national_cities'], $result);
 
         // assert user specified listener config option is returned as-is (no magic)
         $userSpecifiedIncludes = [

--- a/tests/TestCase/Schema/DynamicEntitySchemaTest.php
+++ b/tests/TestCase/Schema/DynamicEntitySchemaTest.php
@@ -149,6 +149,7 @@ class DynamicEntitySchemaTest extends TestCase
 
         $view->set('_repositories', $repositories);
         $view->set('_absoluteLinks', false); // test relative links (listener default)
+        $view->set('_inflect', 'dasherize');
 
         // setup the schema
         $schema = $this

--- a/tests/TestCase/View/JsonApiViewTest.php
+++ b/tests/TestCase/View/JsonApiViewTest.php
@@ -191,28 +191,6 @@ class JsonApiViewTest extends TestCase
     }
 
     /**
-     * Make sure that an exception is thrown for generic entity classes
-     *
-     * @return void
-     */
-    public function DISABLEDtestEncodeWithGenericEntity()
-    {
-        TableRegistry::get('Countries')->entityClass(Entity::class);
-
-        // test collection of entities without relationships
-        $countries = TableRegistry::get('Countries')
-            ->find()
-            ->all();
-        $view = $this->_getView('Countries', [
-            'countries' => $countries
-        ]);
-
-        $this->expectException(CrudException::class);
-        $this->expectExceptionMessage('Entity classes must be the generic "Cake\ORM\Entity" class for repository "Countries"');
-        $view->render();
-    }
-
-    /**
      * Make sure expected JSON API strings are generated as expected when
      * using Crud's DynamicEntitySchema.
      *

--- a/tests/TestCase/View/JsonApiViewTest.php
+++ b/tests/TestCase/View/JsonApiViewTest.php
@@ -8,9 +8,11 @@ use Cake\Event\Event;
 use Cake\Filesystem\File;
 use Cake\Network\Request;
 use Cake\Network\Response;
+use Cake\ORM\Entity;
 use Cake\ORM\Query;
 use Cake\ORM\TableRegistry;
 use Cake\Utility\Inflector;
+use Crud\Error\Exception\CrudException;
 use Crud\Event\Subject;
 use Crud\Listener\JsonApiListener;
 use Crud\TestSuite\TestCase;
@@ -68,6 +70,7 @@ class JsonApiViewTest extends TestCase
             '_fieldSets' => $listener->config('fieldSets'),
             '_jsonOptions' => $listener->config('jsonOptions'),
             '_debugPrettyPrint' => $listener->config('debugPrettyPrint'),
+            '_inflect' => $listener->config('inflect')
         ];
 
         // override some defaults to create more DRY tests
@@ -95,6 +98,7 @@ class JsonApiViewTest extends TestCase
                 JSON_PRETTY_PRINT
             ],
             '_debugPrettyPrint' => true,
+            '_inflect' => 'dasherize',
             '_serialize' => true
         ];
         $this->assertSame($expected, $this->_defaultViewVars);
@@ -184,6 +188,28 @@ class JsonApiViewTest extends TestCase
 
         $this->assertNotContains('non_underscored_should_not_be_in_special_vars', $result);
         $this->assertContains('_underscored_should_be_in_special_vars', $result);
+    }
+
+    /**
+     * Make sure that an exception is thrown for generic entity classes
+     *
+     * @return void
+     */
+    public function DISABLEDtestEncodeWithGenericEntity()
+    {
+        TableRegistry::get('Countries')->entityClass(Entity::class);
+
+        // test collection of entities without relationships
+        $countries = TableRegistry::get('Countries')
+            ->find()
+            ->all();
+        $view = $this->_getView('Countries', [
+            'countries' => $countries
+        ]);
+
+        $this->expectException(CrudException::class);
+        $this->expectExceptionMessage('Entity classes must be the generic "Cake\ORM\Entity" class for repository "Countries"');
+        $view->render();
     }
 
     /**


### PR DESCRIPTION
This dasherizes associations inside the `relationship` node. Closes #528.

~Not ready for merging, needs tests.~