### PR TITLE
Move logic for dispatchComponents to ::initialize to comply with Cake 3.3 AuthComponent

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -121,6 +121,7 @@ If you've loaded an action in eg. your ``AppController`` - but don't want it inc
 Example of disable a loaded action:
 
 ..code-block:: phpinline
+
   class AppController extends \Cake\Controller\Controller {
 
     public $components = [
@@ -132,6 +133,7 @@ Example of disable a loaded action:
   }
 
 ..code-block:: phpinline
+
   class PostsController extends AppController {
 
     public function beforeFilter(\Cake\Event\Event $event) {

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -121,7 +121,6 @@ If you've loaded an action in eg. your ``AppController`` - but don't want it inc
 Example of disable a loaded action:
 
 ..code-block:: phpinline
-
   class AppController extends \Cake\Controller\Controller {
 
     public $components = [
@@ -133,7 +132,6 @@ Example of disable a loaded action:
   }
 
 ..code-block:: phpinline
-
   class PostsController extends AppController {
 
     public function beforeFilter(\Cake\Event\Event $event) {

--- a/src/Controller/Component/CrudComponent.php
+++ b/src/Controller/Component/CrudComponent.php
@@ -173,10 +173,9 @@ class CrudComponent extends Component
     /**
      * Add self to list of components capable of dispatching an action.
      *
-     * @param \Cake\Event\Event $event Event instance
-     * @return void
+     * @param array $config
      */
-    public function beforeFilter(Event $event)
+    public function initialize(array $config)
     {
         $this->_action = $this->_controller->request->action;
         $this->_request = $this->_controller->request;
@@ -186,7 +185,16 @@ class CrudComponent extends Component
         }
 
         $this->_controller->dispatchComponents['Crud'] = true;
+    }
 
+    /**
+     * Loads listeners
+     *
+     * @param \Cake\Event\Event $event Event instance
+     * @return void
+     */
+    public function beforeFilter(Event $event)
+    {
         $this->_loadListeners();
         $this->trigger('beforeFilter');
     }

--- a/src/Controller/Component/CrudComponent.php
+++ b/src/Controller/Component/CrudComponent.php
@@ -173,10 +173,12 @@ class CrudComponent extends Component
     /**
      * Add self to list of components capable of dispatching an action.
      *
-     * @param array $config
+     * @param array $config Configuration values for component
      */
     public function initialize(array $config)
     {
+        parent::initialize($config);
+
         $this->_action = $this->_controller->request->action;
         $this->_request = $this->_controller->request;
 

--- a/tests/TestCase/Controller/Component/CrudComponentTest.php
+++ b/tests/TestCase/Controller/Component/CrudComponentTest.php
@@ -375,7 +375,7 @@ class CrudComponentTest extends TestCase
         $this->assertTrue($result);
 
         $this->controller->request->action = 'edit';
-        $this->Crud->beforeFilter(new Event('Controller.beforeFilter'));
+        $this->Crud->initialize([]);
         $result = $this->Crud->isActionMapped();
         $this->assertTrue($result);
     }


### PR DESCRIPTION
With this change: https://github.com/cakephp/cakephp/pull/6906 one can have the AuthComponent working in `Controller::initialize` rather than `Controller::beforeFilter` - but if one does that with crud, the `dispatchComponents`property is not yet filled, and because of that the code in the ControllerTrait doesn't work. (https://github.com/FriendsOfCake/crud/blob/master/src/Controller/ControllerTrait.php#L96).

This makes the AuthComponent *skip* both authentication and authorization, unless there is boilerplate code as follows for each action (because of: https://github.com/cakephp/cakephp/blob/master/src/Controller/Component/AuthComponent.php#L291)

```
<?php
namespace Controller;

use Cake\Event\Event;

class PostsController extends AppController
{
    public function index()
    {
        return $this->Crud->execute();
    }

    public function add()
    {
        return $this->Crud->execute();
    }

    public function edit($id)
    {
        return $this->Crud->execute();
    }

    public function delete($id)
    {
        return $this->Crud->execute();
    }

    public function view($id)
    {
        return $this->Crud->execute();
    }
}

```