### PR TITLE
documentation update: fix name of Exception Renderer class for use in Cake 3.3+

### DIFF
--- a/docs/listeners/api.rst
+++ b/docs/listeners/api.rst
@@ -123,7 +123,7 @@ config in ``config/app.php`` to ``'Crud\Error\ExceptionRenderer'`` as following:
 
     'Error' => [
         'errorLevel' => E_ALL,
-        'exceptionRenderer' => 'Crud\Error\JsonApiExceptionRenderer',
+        'exceptionRenderer' => 'Crud\Error\ExceptionRenderer',
         'skipLog' => [],
         'log' => true,
         'trace' => true,


### PR DESCRIPTION
this looks like a typo or perhaps a leftover from an older version of this plugin? There doesn't seem to be a JsonApiExceptionRenderer, and changing the reference to 'Crud\Error\ExceptionRenderer' produces the correct behavior as far as i can see.