### PR TITLE
Fix #572 added api key to defaultconfig in view and lookup actions

### DIFF
--- a/src/Action/LookupAction.php
+++ b/src/Action/LookupAction.php
@@ -28,7 +28,15 @@ class LookupAction extends BaseAction
     protected $_defaultConfig = [
         'enabled' => true,
         'scope' => 'table',
-        'findMethod' => 'list'
+        'findMethod' => 'list',
+        'api' => [
+            'success' => [
+                'code' => 200
+            ],
+            'error' => [
+                'code' => 400
+            ]
+        ]
     ];
 
     /**

--- a/src/Action/ViewAction.php
+++ b/src/Action/ViewAction.php
@@ -36,7 +36,15 @@ class ViewAction extends BaseAction
         'findMethod' => 'all',
         'view' => null,
         'viewVar' => null,
-        'serialize' => []
+        'serialize' => [],
+        'api' => [
+            'success' => [
+                'code' => 200
+            ],
+            'error' => [
+                'code' => 400
+            ]
+        ]
     ];
 
     /**


### PR DESCRIPTION
See issue https://github.com/FriendsOfCake/crud/issues/572.
This will add the `api` key to the $_defaultConfig in the ViewAction and the LookupAction.