### PR TITLE
ApiPaginationListener should use setConfig in beforeRender

### DIFF
--- a/src/Listener/ApiPaginationListener.php
+++ b/src/Listener/ApiPaginationListener.php
@@ -68,6 +68,6 @@ class ApiPaginationListener extends BaseListener
         ];
 
         $controller->set('pagination', $paginationResponse);
-        $this->_action()->getConfig('serialize.pagination', 'pagination');
+        $this->_action()->setConfig('serialize.pagination', 'pagination');
     }
 }

--- a/tests/TestCase/Listener/ApiPaginationListenerTest.php
+++ b/tests/TestCase/Listener/ApiPaginationListenerTest.php
@@ -150,11 +150,11 @@ class ApiPaginationListenerTest extends TestCase
         $Action = $this
             ->getMockBuilder('\Crud\Action\BaseAction')
             ->disableOriginalConstructor()
-            ->setMethods(['getConfig'])
+            ->setMethods(['setConfig'])
             ->getMock();
         $Action
             ->expects($this->once())
-            ->method('getConfig')
+            ->method('setConfig')
             ->with('serialize.pagination', 'pagination');
 
         $Instance = $this
@@ -224,11 +224,11 @@ class ApiPaginationListenerTest extends TestCase
         $Action = $this
             ->getMockBuilder('\Crud\Action\BaseAction')
             ->disableOriginalConstructor()
-            ->setMethods(['getConfig'])
+            ->setMethods(['setConfig'])
             ->getMock();
         $Action
             ->expects($this->once())
-            ->method('getConfig')
+            ->method('setConfig')
             ->with('serialize.pagination', 'pagination');
 
         $Instance = $this

--- a/tests/TestCase/Listener/ApiPaginationListenerTest.php
+++ b/tests/TestCase/Listener/ApiPaginationListenerTest.php
@@ -2,6 +2,8 @@
 namespace Crud\Test\TestCase\Listener;
 
 use Cake\Http\ServerRequest;
+use Crud\Action\BaseAction;
+use Crud\Listener\ApiPaginationListener;
 use Crud\TestSuite\TestCase;
 
 /**
@@ -252,5 +254,77 @@ class ApiPaginationListenerTest extends TestCase
         $Controller->modelClass = 'MyPlugin.MyModel';
 
         $Instance->beforeRender(new \Cake\Event\Event('something'));
+    }
+
+    /**
+     * Test if the pagination is set to be serialized in the beforeRender event
+     *
+     * @return void
+     */
+    public function testBeforeRenderMakeSurePaginationDataIsSetToBeSerialized()
+    {
+        $Request = $this
+            ->getMockBuilder(ServerRequest::class)
+            ->setMethods(null)
+            ->getMock();
+        $Request->paging = [
+            'MyModel' => [
+                'pageCount' => 10,
+                'page' => 2,
+                'nextPage' => true,
+                'prevPage' => true,
+                'count' => 100,
+                'limit' => 10
+            ]
+        ];
+
+        $expected = [
+            'page_count' => 10,
+            'current_page' => 2,
+            'has_next_page' => true,
+            'has_prev_page' => true,
+            'count' => 100,
+            'limit' => 10
+        ];
+
+        $Controller = $this
+            ->getMockBuilder('\Cake\Controller\Controller')
+            ->disableOriginalConstructor()
+            ->setMethods(['set'])
+            ->getMock();
+        $Controller
+            ->expects($this->once())
+            ->method('set')
+            ->with('pagination', $expected);
+
+        $Action = $this
+            ->getMockBuilder('\Crud\Action\BaseAction')
+            ->disableOriginalConstructor()
+            ->setMethods(null)
+            ->getMock();
+
+        $Instance = $this
+            ->getMockBuilder('\Crud\Listener\ApiPaginationListener')
+            ->disableOriginalConstructor()
+            ->setMethods(['_request', '_controller', '_action'])
+            ->getMock();
+        $Instance
+            ->expects($this->once())
+            ->method('_request')
+            ->will($this->returnValue($Request));
+        $Instance
+            ->expects($this->once())
+            ->method('_controller')
+            ->will($this->returnValue($Controller));
+        $Instance
+            ->expects($this->once())
+            ->method('_action')
+            ->will($this->returnValue($Action));
+
+        $Controller->modelClass = 'MyModel';
+
+        $Instance->beforeRender(new \Cake\Event\Event('something'));
+
+        $this->assertSame('pagination', $Action->getConfig('serialize.pagination'));
     }
 }


### PR DESCRIPTION
After updating to crud tag 5.3.x the pagination failed due to a faulty replacement of the deprecated method InstanceConfigTrait::config(). 
At Crud\Listener\ApiPaginationListener line 71 the deprecated config method was used as a setter, but it was replaced as a getter.