### PR TITLE
Remove deprecated calls from RelatedModelsListener

### DIFF
--- a/src/Listener/RelatedModelsListener.php
+++ b/src/Listener/RelatedModelsListener.php
@@ -90,7 +90,7 @@ class RelatedModelsListener extends BaseListener
         $controller = $this->_controller();
 
         foreach ($models as $name => $association) {
-            list(, $associationName) = pluginSplit($association->name());
+            list(, $associationName) = pluginSplit($association->getName());
             $viewVar = Inflector::variable($associationName);
             if (array_key_exists($viewVar, $controller->viewVars)) {
                 continue;
@@ -196,7 +196,7 @@ class RelatedModelsListener extends BaseListener
                 continue;
             }
 
-            $return[$associationClass->name()] = $associationClass;
+            $return[$associationClass->getName()] = $associationClass;
         }
 
         return $return;
@@ -224,7 +224,7 @@ class RelatedModelsListener extends BaseListener
                     $association
                 ));
             }
-            $return[$associationClass->name()] = $associationClass;
+            $return[$associationClass->getName()] = $associationClass;
         }
 
         return $return;

--- a/tests/TestCase/Listener/RelatedModelsListenerTest.php
+++ b/tests/TestCase/Listener/RelatedModelsListenerTest.php
@@ -149,7 +149,7 @@ class RelatedModelListenerTest extends TestCase
         $association = $this
             ->getMockBuilder('\Cake\ORM\Association')
             ->disableOriginalConstructor()
-            ->setMethods(['type', 'name', 'eagerLoader', 'cascadeDelete', 'isOwningSide', 'saveAssociated'])
+            ->setMethods(['type', 'getName', 'eagerLoader', 'cascadeDelete', 'isOwningSide', 'saveAssociated'])
             ->getMock();
 
         $listener
@@ -172,7 +172,7 @@ class RelatedModelListenerTest extends TestCase
             ->will($this->returnValue($association));
         $association
             ->expects($this->once())
-            ->method('name')
+            ->method('getName')
             ->will($this->returnValue('Posts'));
         $association
             ->expects($this->once())
@@ -212,7 +212,7 @@ class RelatedModelListenerTest extends TestCase
         $association = $this
             ->getMockBuilder('\Cake\ORM\Association')
             ->disableOriginalConstructor()
-            ->setMethods(['type', 'name', 'eagerLoader', 'cascadeDelete', 'isOwningSide', 'saveAssociated'])
+            ->setMethods(['type', 'getName', 'eagerLoader', 'cascadeDelete', 'isOwningSide', 'saveAssociated'])
             ->getMock();
 
         $listener
@@ -231,8 +231,7 @@ class RelatedModelListenerTest extends TestCase
             ->will($this->returnValue($association));
         $association
             ->expects($this->once())
-            ->method('name')
-            ->with(null)
+            ->method('getName')
             ->will($this->returnValue('Posts'));
 
         $expected = ['Posts' => $association];


### PR DESCRIPTION
Noticed this deprecated calls when updating one of my apps