### PR TITLE
Require CakePHP 3.6 since we use 3.6-only features

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         }
     ],
     "require": {
-        "cakephp/cakephp": "^3.5"
+        "cakephp/cakephp": "^3.6"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7.14|^6.0",


### PR DESCRIPTION
https://github.com/FriendsOfCake/crud/releases/tag/5.4.2 Includes 3.6 exceptions - so I guess we should also require 3.6 as the minimum.