### PR TITLE
Check for each class individually.

### DIFF
--- a/aliases.php
+++ b/aliases.php
@@ -4,14 +4,23 @@ if (!class_exists('Cake\Http\Exception\MethodNotAllowedException')) {
         'Cake\Network\Exception\MethodNotAllowedException',
         'Cake\Http\Exception\MethodNotAllowedException'
     );
+}
+
+if (!class_exists('Cake\Http\Exception\NotImplementedException')) {
     class_alias(
         'Cake\Network\Exception\NotImplementedException',
         'Cake\Http\Exception\NotImplementedException'
     );
+}
+
+if (!class_exists('Cake\Http\Exception\BadRequestException')) {
     class_alias(
         'Cake\Network\Exception\BadRequestException',
         'Cake\Http\Exception\BadRequestException'
     );
+}
+
+if (!class_exists('Cake\Http\Exception\NotFoundException')) {
     class_alias(
         'Cake\Network\Exception\NotFoundException',
         'Cake\Http\Exception\NotFoundException'


### PR DESCRIPTION
One of more could have been already aliased by other plugins like ADmad/Glide.