### PR TITLE
Remove unneeded apostrophe

### DIFF
--- a/docs/actions/bulk.rst
+++ b/docs/actions/bulk.rst
@@ -11,7 +11,7 @@ Three BulkAction classes exist in the core:
 - :doc:`Toggle</actions/bulk-toggle>`: Toggles the value of a boolean field for a set of entities
 
 To create your own BulkAction, simply create a new action class with a ``_bulk``
-method. This method takes a CakePHP ``Query`` object as it's first argument
+method. This method takes a CakePHP ``Query`` object as its first argument
 
 .. code-block:: phpinline
 


### PR DESCRIPTION
A possessive belonging to an "it" doesn't need an apostrophe. Don't believe me? Ask [the Oatmeal](http://theoatmeal.com/comics/apostrophe) (look for the velociraptor)!