### PR TITLE
RelatedModelsListener - missing oneToMany relation

### DIFF
--- a/src/Listener/RelatedModelsListener.php
+++ b/src/Listener/RelatedModelsListener.php
@@ -147,7 +147,7 @@ class RelatedModelsListener extends BaseListener
         $settings = $this->relatedModels(null, $action);
 
         if ($settings === true) {
-            return $this->getAssociatedByType(['oneToOne', 'manyToMany', 'manyToOne']);
+            return $this->getAssociatedByType(['oneToOne', 'manyToMany', 'manyToOne', 'oneToMany']);
         }
 
         if (empty($settings)) {

--- a/tests/TestCase/Listener/RelatedModelsListenerTest.php
+++ b/tests/TestCase/Listener/RelatedModelsListenerTest.php
@@ -117,7 +117,7 @@ class RelatedModelListenerTest extends TestCase
         $listener
             ->expects($this->once())
             ->method('getAssociatedByType')
-            ->with(['oneToOne', 'manyToMany', 'manyToOne']);
+            ->with(['oneToOne', 'manyToMany', 'manyToOne', 'oneToMany']);
 
         $result = $listener->models();
     }
@@ -180,7 +180,7 @@ class RelatedModelListenerTest extends TestCase
             ->will($this->returnValue('oneToOne'));
 
         $expected = ['Posts' => $association];
-        $result = $listener->getAssociatedByType(['oneToOne', 'manyToMany', 'manyToOne']);
+        $result = $listener->getAssociatedByType(['oneToOne', 'manyToMany', 'manyToOne', 'oneToMany']);
 
         $this->assertEquals($expected, $result);
     }


### PR DESCRIPTION
Added oneToMany to the RelatedModelsListeners as without it, our hasMany() relations were not showing up when using Crud