### PR TITLE
Fix related-models.md example code

### DIFF
--- a/docs/listeners/related-models.rst
+++ b/docs/listeners/related-models.rst
@@ -132,7 +132,7 @@ Example
     class DemoController extends AppController {
 
         public function beforeFilter(\Cake\Event\Event $event) {
-            parent::beforeFilter();
+            parent::beforeFilter($event);
 
             $this->Crud->on('relatedModel', function(\Cake\Event\Event $event) {
                 if ($event->getSubject()->association->name() === 'Authors') {


### PR DESCRIPTION
Current example code breaks with an error. This fixes it.