### PR TITLE
ApiQueryLogListener eats disk space even when debug=false

### DIFF
--- a/src/Listener/ApiQueryLogListener.php
+++ b/src/Listener/ApiQueryLogListener.php
@@ -49,6 +49,10 @@ class ApiQueryLogListener extends BaseListener
      */
     public function setupLogging(Event $event)
     {
+        if (!Configure::read('debug')) {
+            return;
+        }
+
         foreach ($this->_getSources() as $connectionName) {
             try {
                 $connection = $this->_getSource($connectionName);


### PR DESCRIPTION
ApiQueryLogListener::setupLogging() event should not enable query logging if debugging is not enabled. Please note that enabling query logging causes dumping those logs into queries.log file