### PR TITLE
Redirect to last page if requested page number doesn't exist.

### DIFF
--- a/src/Action/IndexAction.php
+++ b/src/Action/IndexAction.php
@@ -3,6 +3,9 @@ declare(strict_types=1);
 
 namespace Crud\Action;
 
+use Cake\Http\Exception\NotFoundException;
+use Cake\Http\Response;
+use Cake\Routing\Router;
 use Crud\Traits\FindMethodTrait;
 use Crud\Traits\SerializeTrait;
 use Crud\Traits\ViewTrait;
@@ -46,19 +49,29 @@ class IndexAction extends BaseAction
     /**
      * Generic handler for all HTTP verbs
      *
-     * @return void
+     * @return \Cake\Http\Response|null
      */
-    protected function _handle(): void
+    protected function _handle(): ?Response
     {
         [$finder, $options] = $this->_extractFinder();
         $query = $this->_table()->find($finder, $options);
         $subject = $this->_subject(['success' => true, 'query' => $query]);
 
         $this->_trigger('beforePaginate', $subject);
-        $items = $this->_controller()->paginate($subject->query);
+        try {
+            $items = $this->_controller()->paginate($subject->query);
+        } catch (NotFoundException $e) {
+            $url = Router::reverseToArray($this->_request());
+            unset($url['?']['page']);
+
+            return $this->_controller()->redirect($url);
+        }
+
         $subject->set(['entities' => $items]);
 
         $this->_trigger('afterPaginate', $subject);
         $this->_trigger('beforeRender', $subject);
+
+        return null;
     }
 }

--- a/src/Action/IndexAction.php
+++ b/src/Action/IndexAction.php
@@ -61,8 +61,10 @@ class IndexAction extends BaseAction
         try {
             $items = $this->_controller()->paginate($subject->query);
         } catch (NotFoundException $e) {
+            $pagingParams = $this->_request()->getAttribute('paging');
+
             $url = Router::reverseToArray($this->_request());
-            unset($url['?']['page']);
+            $url['?']['page'] = $pagingParams[$this->_table()->getAlias()]['pageCount'];
 
             return $this->_controller()->redirect($url);
         }

--- a/tests/TestCase/Action/IndexActionTest.php
+++ b/tests/TestCase/Action/IndexActionTest.php
@@ -132,4 +132,24 @@ class IndexActionTest extends IntegrationTestCase
         $this->get('/blogs');
         $this->assertSame(['foo' => 'bar'], $this->_controller->Blogs->customOptions);
     }
+
+    /**
+     * Test that trying to access a non existent page number redirects to 1st page.
+     *
+     * @return void
+     */
+    public function testForPageOutOfBounds()
+    {
+        $this->_eventManager->on(
+            'Controller.initialize',
+            ['priority' => 11],
+            function ($event) {
+                $this->_subscribeToEvents($this->_controller);
+            }
+        );
+
+        $this->get('/blogs?page=999&foo=bar');
+        $this->assertSame(302, $this->_response->getStatusCode());
+        $this->assertSame('http://localhost/blogs?foo=bar', $this->_response->getHeaderLine('Location'));
+    }
 }

--- a/tests/TestCase/Action/IndexActionTest.php
+++ b/tests/TestCase/Action/IndexActionTest.php
@@ -150,6 +150,6 @@ class IndexActionTest extends IntegrationTestCase
 
         $this->get('/blogs?page=999&foo=bar');
         $this->assertSame(302, $this->_response->getStatusCode());
-        $this->assertSame('http://localhost/blogs?foo=bar', $this->_response->getHeaderLine('Location'));
+        $this->assertSame('http://localhost/blogs?page=2&foo=bar', $this->_response->getHeaderLine('Location'));
     }
 }


### PR DESCRIPTION
FriendsOfCake/crud-view#268 would retain the query string including page number. So if you were on last page with single record, redirecting back to same URL after record is deleted would cause paginator to throw `NotFoundException`.