### PR TITLE
Fix builds on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ php:
 
 services:
   - mysql
-  -postgresql
+  - postgresql
 
 env:
   matrix:

--- a/src/Action/AddAction.php
+++ b/src/Action/AddAction.php
@@ -17,7 +17,6 @@ use Crud\Traits\ViewVarTrait;
  */
 class AddAction extends BaseAction
 {
-
     use RedirectTrait;
     use SaveMethodTrait;
     use SerializeTrait;
@@ -56,37 +55,37 @@ class AddAction extends BaseAction
             'success' => [
                 'code' => 201,
                 'data' => [
-                    'entity' => ['id']
-                ]
+                    'entity' => ['id'],
+                ],
             ],
             'error' => [
                 'exception' => [
                     'type' => 'validate',
-                    'class' => ValidationException::class
-                ]
-            ]
+                    'class' => ValidationException::class,
+                ],
+            ],
         ],
         'redirect' => [
             'post_add' => [
                 'reader' => 'request.data',
                 'key' => '_add',
-                'url' => ['action' => 'add']
+                'url' => ['action' => 'add'],
             ],
             'post_edit' => [
                 'reader' => 'request.data',
                 'key' => '_edit',
-                'url' => ['action' => 'edit', ['entity.field', 'id']]
-            ]
+                'url' => ['action' => 'edit', ['entity.field', 'id']],
+            ],
         ],
         'messages' => [
             'success' => [
-                'text' => 'Successfully created {name}'
+                'text' => 'Successfully created {name}',
             ],
             'error' => [
-                'text' => 'Could not create {name}'
-            ]
+                'text' => 'Could not create {name}',
+            ],
         ],
-        'serialize' => []
+        'serialize' => [],
     ];
 
     /**
@@ -98,7 +97,7 @@ class AddAction extends BaseAction
     {
         $subject = $this->_subject([
             'success' => true,
-            'entity' => $this->_entity($this->_request()->getQuery() ?: null, ['validate' => false] + $this->saveOptions())
+            'entity' => $this->_entity($this->_request()->getQuery() ?: null, ['validate' => false] + $this->saveOptions()),
         ]);
 
         $this->_trigger('beforeRender', $subject);
@@ -114,7 +113,7 @@ class AddAction extends BaseAction
         $subject = $this->_subject([
             'entity' => $this->_entity($this->_request()->getData(), $this->saveOptions()),
             'saveMethod' => $this->saveMethod(),
-            'saveOptions' => $this->saveOptions()
+            'saveOptions' => $this->saveOptions(),
         ]);
 
         $event = $this->_trigger('beforeSave', $subject);

--- a/src/Action/BaseAction.php
+++ b/src/Action/BaseAction.php
@@ -151,7 +151,7 @@ abstract class BaseAction extends BaseObject
             'params' => ['class' => 'message'],
             'key' => 'flash',
             'type' => $this->getConfig('action') . '.' . $type,
-            'name' => $this->resourceName()
+            'name' => $this->resourceName(),
         ], $config);
 
         if (!isset($config['text'])) {
@@ -197,7 +197,7 @@ abstract class BaseAction extends BaseObject
         $this->_controller()->Flash->set($subject->text, [
             'element' => $subject->element,
             'params' => $subject->params,
-            'key' => $subject->key
+            'key' => $subject->key,
         ]);
     }
 

--- a/src/Action/Bulk/BaseAction.php
+++ b/src/Action/Bulk/BaseAction.php
@@ -32,11 +32,11 @@ abstract class BaseAction extends CrudBaseAction
         'findConfig' => [],
         'messages' => [
             'success' => [
-                'text' => 'Bulk action successfully completed'
+                'text' => 'Bulk action successfully completed',
             ],
             'error' => [
-                'text' => 'Could not complete bulk action'
-            ]
+                'text' => 'Could not complete bulk action',
+            ],
         ],
     ];
 

--- a/src/Action/Bulk/DeleteAction.php
+++ b/src/Action/Bulk/DeleteAction.php
@@ -23,11 +23,11 @@ class DeleteAction extends BaseAction
     {
         $this->_defaultConfig['messages'] = [
             'success' => [
-                'text' => 'Delete completed successfully'
+                'text' => 'Delete completed successfully',
             ],
             'error' => [
-                'text' => 'Could not complete deletion'
-            ]
+                'text' => 'Could not complete deletion',
+            ],
         ];
 
         parent::__construct($Controller, $config);

--- a/src/Action/Bulk/SetValueAction.php
+++ b/src/Action/Bulk/SetValueAction.php
@@ -24,11 +24,11 @@ class SetValueAction extends BaseAction
     {
         $this->_defaultConfig['messages'] = [
             'success' => [
-                'text' => 'Set value successfully'
+                'text' => 'Set value successfully',
             ],
             'error' => [
-                'text' => 'Could not set value'
-            ]
+                'text' => 'Could not set value',
+            ],
         ];
         $this->_defaultConfig['value'] = null;
 

--- a/src/Action/Bulk/ToggleAction.php
+++ b/src/Action/Bulk/ToggleAction.php
@@ -25,11 +25,11 @@ class ToggleAction extends BaseAction
     {
         $this->_defaultConfig['messages'] = [
             'success' => [
-                'text' => 'Value toggled successfully'
+                'text' => 'Value toggled successfully',
             ],
             'error' => [
-                'text' => 'Could not toggle value'
-            ]
+                'text' => 'Could not toggle value',
+            ],
         ];
 
         parent::__construct($Controller, $config);

--- a/src/Action/DeleteAction.php
+++ b/src/Action/DeleteAction.php
@@ -13,7 +13,6 @@ use Crud\Traits\RedirectTrait;
  */
 class DeleteAction extends BaseAction
 {
-
     use FindMethodTrait;
     use RedirectTrait;
 
@@ -33,20 +32,20 @@ class DeleteAction extends BaseAction
         'deleteMethod' => 'delete',
         'messages' => [
             'success' => [
-                'text' => 'Successfully deleted {name}'
+                'text' => 'Successfully deleted {name}',
             ],
             'error' => [
-                'text' => 'Could not delete {name}'
-            ]
+                'text' => 'Could not delete {name}',
+            ],
         ],
         'api' => [
             'success' => [
-                'code' => 200
+                'code' => 200,
             ],
             'error' => [
-                'code' => 400
-            ]
-        ]
+                'code' => 400,
+            ],
+        ],
     ];
 
     /**

--- a/src/Action/EditAction.php
+++ b/src/Action/EditAction.php
@@ -18,7 +18,6 @@ use Crud\Traits\ViewVarTrait;
  */
 class EditAction extends BaseAction
 {
-
     use FindMethodTrait;
     use RedirectTrait;
     use SaveMethodTrait;
@@ -55,37 +54,37 @@ class EditAction extends BaseAction
         'saveOptions' => [],
         'messages' => [
             'success' => [
-                'text' => 'Successfully updated {name}'
+                'text' => 'Successfully updated {name}',
             ],
             'error' => [
-                'text' => 'Could not update {name}'
-            ]
+                'text' => 'Could not update {name}',
+            ],
         ],
         'redirect' => [
             'post_add' => [
                 'reader' => 'request.data',
                 'key' => '_add',
-                'url' => ['action' => 'add']
+                'url' => ['action' => 'add'],
             ],
             'post_edit' => [
                 'reader' => 'request.data',
                 'key' => '_edit',
-                'url' => ['action' => 'edit', ['subject.key', 'id']]
-            ]
+                'url' => ['action' => 'edit', ['subject.key', 'id']],
+            ],
         ],
         'api' => [
             'methods' => ['put', 'post', 'patch'],
             'success' => [
-                'code' => 200
+                'code' => 200,
             ],
             'error' => [
                 'exception' => [
                     'type' => 'validate',
-                    'class' => ValidationException::class
-                ]
-            ]
+                    'class' => ValidationException::class,
+                ],
+            ],
         ],
-        'serialize' => []
+        'serialize' => [],
     ];
 
     /**

--- a/src/Action/IndexAction.php
+++ b/src/Action/IndexAction.php
@@ -14,7 +14,6 @@ use Crud\Traits\ViewVarTrait;
  */
 class IndexAction extends BaseAction
 {
-
     use FindMethodTrait;
     use SerializeTrait;
     use ViewTrait;
@@ -34,12 +33,12 @@ class IndexAction extends BaseAction
         'serialize' => [],
         'api' => [
             'success' => [
-                'code' => 200
+                'code' => 200,
             ],
             'error' => [
-                'code' => 400
-            ]
-        ]
+                'code' => 400,
+            ],
+        ],
     ];
 
     /**

--- a/src/Action/LookupAction.php
+++ b/src/Action/LookupAction.php
@@ -14,7 +14,6 @@ use Crud\Traits\ViewVarTrait;
  */
 class LookupAction extends BaseAction
 {
-
     use FindMethodTrait;
     use SerializeTrait;
     use ViewTrait;
@@ -28,7 +27,7 @@ class LookupAction extends BaseAction
     protected $_defaultConfig = [
         'enabled' => true,
         'scope' => 'table',
-        'findMethod' => 'list'
+        'findMethod' => 'list',
     ];
 
     /**

--- a/src/Action/ViewAction.php
+++ b/src/Action/ViewAction.php
@@ -14,7 +14,6 @@ use Crud\Traits\ViewVarTrait;
  */
 class ViewAction extends BaseAction
 {
-
     use FindMethodTrait;
     use SerializeTrait;
     use ViewTrait;
@@ -38,7 +37,7 @@ class ViewAction extends BaseAction
         'findMethod' => 'all',
         'view' => null,
         'viewVar' => null,
-        'serialize' => []
+        'serialize' => [],
     ];
 
     /**

--- a/src/Controller/Component/CrudComponent.php
+++ b/src/Controller/Component/CrudComponent.php
@@ -112,20 +112,20 @@ class CrudComponent extends Component
             'invalidId' => [
                 'code' => 400,
                 'class' => BadRequestException::class,
-                'text' => 'Invalid id'
+                'text' => 'Invalid id',
             ],
             'recordNotFound' => [
                 'code' => 404,
                 'class' => NotFoundException::class,
-                'text' => 'Not found'
+                'text' => 'Not found',
             ],
             'badRequestMethod' => [
                 'code' => 405,
                 'class' => MethodNotAllowedException::class,
-                'text' => 'Method not allowed. This action permits only {methods}'
-            ]
+                'text' => 'Method not allowed. This action permits only {methods}',
+            ],
         ],
-        'eventLogging' => false
+        'eventLogging' => false,
     ];
 
     /**

--- a/src/Core/BaseObject.php
+++ b/src/Core/BaseObject.php
@@ -15,7 +15,6 @@ use Cake\Event\EventListenerInterface;
  */
 abstract class BaseObject implements EventListenerInterface
 {
-
     use InstanceConfigTrait;
     use ProxyTrait;
 

--- a/src/Error/ExceptionRenderer.php
+++ b/src/Error/ExceptionRenderer.php
@@ -39,7 +39,7 @@ class ExceptionRenderer extends \Cake\Error\ExceptionRenderer
             'error' => $error,
             'errorCount' => $error->getValidationErrorCount(),
             'errors' => $error->getValidationErrors(),
-            '_serialize' => ['code', 'url', 'message', 'errorCount', 'errors']
+            '_serialize' => ['code', 'url', 'message', 'errorCount', 'errors'],
         ];
         $this->controller->set($sets);
 
@@ -100,7 +100,7 @@ class ExceptionRenderer extends \Cake\Error\ExceptionRenderer
             if (!isset($data['trace'])) {
                 $data['trace'] = Debugger::formatTrace($viewVars['error']->getTrace(), [
                     'format' => 'array',
-                    'args' => false
+                    'args' => false,
                 ]);
             }
         }

--- a/src/Listener/ApiListener.php
+++ b/src/Listener/ApiListener.php
@@ -32,20 +32,20 @@ class ApiListener extends BaseListener
     protected $_defaultConfig = [
         'viewClasses' => [
             'json' => 'Json',
-            'xml' => 'Xml'
+            'xml' => 'Xml',
         ],
         'detectors' => [
             'json' => ['ext' => 'json', 'accepts' => 'application/json'],
-            'xml' => ['ext' => 'xml', 'accepts' => 'text/xml']
+            'xml' => ['ext' => 'xml', 'accepts' => 'text/xml'],
         ],
         'exception' => [
             'type' => 'default',
             'class' => BadRequestException::class,
             'message' => 'Unknown error',
-            'code' => 0
+            'code' => 0,
         ],
         'exceptionRenderer' => ExceptionRenderer::class,
-        'setFlash' => false
+        'setFlash' => false,
     ];
 
     /**
@@ -69,7 +69,7 @@ class ApiListener extends BaseListener
             'Crud.setFlash' => ['callable' => [$this, 'setFlash'], 'priority' => 5],
 
             'Crud.beforeRender' => ['callable' => [$this, 'respond'], 'priority' => 100],
-            'Crud.beforeRedirect' => ['callable' => [$this, 'respond'], 'priority' => 100]
+            'Crud.beforeRedirect' => ['callable' => [$this, 'respond'], 'priority' => 100],
         ];
     }
 

--- a/src/Listener/ApiPaginationListener.php
+++ b/src/Listener/ApiPaginationListener.php
@@ -28,7 +28,7 @@ class ApiPaginationListener extends BaseListener
         }
 
         return [
-            'Crud.beforeRender' => ['callable' => 'beforeRender', 'priority' => 75]
+            'Crud.beforeRender' => ['callable' => 'beforeRender', 'priority' => 75],
         ];
     }
 
@@ -64,7 +64,7 @@ class ApiPaginationListener extends BaseListener
             'has_next_page' => $pagination['nextPage'],
             'has_prev_page' => $pagination['prevPage'],
             'count' => $pagination['count'],
-            'limit' => $pagination['limit']
+            'limit' => $pagination['limit'],
         ];
 
         $controller->set('pagination', $paginationResponse);

--- a/src/Listener/ApiQueryLogListener.php
+++ b/src/Listener/ApiQueryLogListener.php
@@ -37,7 +37,7 @@ class ApiQueryLogListener extends BaseListener
 
         return [
             'Crud.beforeFilter' => ['callable' => [$this, 'setupLogging'], 'priority' => 1],
-            'Crud.beforeRender' => ['callable' => [$this, 'beforeRender'], 'priority' => 75]
+            'Crud.beforeRender' => ['callable' => [$this, 'beforeRender'], 'priority' => 75],
         ];
     }
 

--- a/src/Listener/RedirectListener.php
+++ b/src/Listener/RedirectListener.php
@@ -22,7 +22,7 @@ class RedirectListener extends BaseListener
      * @var array
      */
     protected $_defaultConfig = [
-        'readers' => []
+        'readers' => [],
     ];
 
     /**
@@ -34,7 +34,7 @@ class RedirectListener extends BaseListener
     public function implementedEvents()
     {
         return [
-            'Crud.beforeRedirect' => ['callable' => 'beforeRedirect', 'priority' => 90]
+            'Crud.beforeRedirect' => ['callable' => 'beforeRedirect', 'priority' => 90],
         ];
     }
 

--- a/src/Listener/RelatedModelsListener.php
+++ b/src/Listener/RelatedModelsListener.php
@@ -117,7 +117,7 @@ class RelatedModelsListener extends BaseListener
     protected function _findOptions(Association $association)
     {
         return [
-            'keyField' => $association->getBindingKey()
+            'keyField' => $association->getBindingKey(),
         ];
     }
 

--- a/src/Listener/SearchListener.php
+++ b/src/Listener/SearchListener.php
@@ -16,9 +16,9 @@ class SearchListener extends BaseListener
     protected $_defaultConfig = [
         'enabled' => [
             'Crud.beforeLookup',
-            'Crud.beforePaginate'
+            'Crud.beforePaginate',
         ],
-        'collection' => 'default'
+        'collection' => 'default',
     ];
 
     /**
@@ -31,7 +31,7 @@ class SearchListener extends BaseListener
     {
         return [
             'Crud.beforeLookup' => ['callable' => 'injectSearch'],
-            'Crud.beforePaginate' => ['callable' => 'injectSearch']
+            'Crud.beforePaginate' => ['callable' => 'injectSearch'],
         ];
     }
 

--- a/src/TestSuite/IntegrationTestCase.php
+++ b/src/TestSuite/IntegrationTestCase.php
@@ -16,7 +16,6 @@ use FriendsOfCake\TestUtilities\CounterHelperTrait;
  */
 abstract class IntegrationTestCase extends \Cake\TestSuite\IntegrationTestCase
 {
-
     use AccessibilityHelperTrait;
     use CounterHelperTrait;
     use CrudTestTrait;

--- a/src/TestSuite/TestCase.php
+++ b/src/TestSuite/TestCase.php
@@ -12,7 +12,6 @@ use FriendsOfCake\TestUtilities\CounterHelperTrait;
  */
 abstract class TestCase extends \Cake\TestSuite\TestCase
 {
-
     use AccessibilityHelperTrait;
     use CounterHelperTrait;
     use CrudTestTrait;

--- a/src/Traits/FindMethodTrait.php
+++ b/src/Traits/FindMethodTrait.php
@@ -61,7 +61,7 @@ trait FindMethodTrait
 
         $subject->set([
             'repository' => $repository,
-            'query' => $query
+            'query' => $query,
         ]);
 
         $this->_trigger('beforeFind', $subject);

--- a/tests/App/Controller/BlogsController.php
+++ b/tests/App/Controller/BlogsController.php
@@ -6,7 +6,6 @@ use Crud\Controller\ControllerTrait;
 
 class BlogsController extends Controller
 {
-
     use ControllerTrait;
 
     public $paginate = ['limit' => 3];
@@ -40,8 +39,8 @@ class BlogsController extends Controller
             'listeners' => [
                 'Crud.Api',
                 'Crud.RelatedModels',
-                'Crud.Redirect'
-            ]
-        ]
+                'Crud.Redirect',
+            ],
+        ],
     ];
 }

--- a/tests/App/Controller/UsersController.php
+++ b/tests/App/Controller/UsersController.php
@@ -6,7 +6,6 @@ use Crud\Controller\ControllerTrait;
 
 class UsersController extends Controller
 {
-
     use ControllerTrait;
 
     public $paginate = ['limit' => 3];
@@ -40,8 +39,8 @@ class UsersController extends Controller
             'listeners' => [
                 'Crud.Api',
                 'Crud.RelatedModels',
-                'Crud.Redirect'
-            ]
-        ]
+                'Crud.Redirect',
+            ],
+        ],
     ];
 }

--- a/tests/Fixture/BlogsFixture.php
+++ b/tests/Fixture/BlogsFixture.php
@@ -11,7 +11,7 @@ class BlogsFixture extends TestFixture
         'is_active' => ['type' => 'boolean', 'default' => true, 'null' => false],
         'name' => ['type' => 'string', 'length' => 255, 'null' => false],
         'body' => ['type' => 'text', 'null' => false],
-        '_constraints' => ['primary' => ['type' => 'primary', 'columns' => ['id']]]
+        '_constraints' => ['primary' => ['type' => 'primary', 'columns' => ['id']]],
     ];
 
     public $records = [
@@ -19,6 +19,6 @@ class BlogsFixture extends TestFixture
         ['name' => '2nd post', 'body' => '2nd post body'],
         ['name' => '3rd post', 'body' => '3rd post body'],
         ['name' => '4th post', 'body' => '4th post body'],
-        ['name' => '5th post', 'body' => '5th post body']
+        ['name' => '5th post', 'body' => '5th post body'],
     ];
 }

--- a/tests/Fixture/UsersFixture.php
+++ b/tests/Fixture/UsersFixture.php
@@ -10,7 +10,7 @@ class UsersFixture extends TestFixture
         'id' => ['type' => 'uuid'],
         'is_active' => ['type' => 'boolean', 'default' => true, 'null' => false],
         'username' => ['type' => 'string', 'length' => 255, 'null' => false],
-        '_constraints' => ['primary' => ['type' => 'primary', 'columns' => ['id']]]
+        '_constraints' => ['primary' => ['type' => 'primary', 'columns' => ['id']]],
     ];
 
     public $records = [
@@ -18,6 +18,6 @@ class UsersFixture extends TestFixture
         ['id' => '968ad2b3-f41d-4de3-909a-74a3ce85e826', 'username' => 'test_2'],
         ['id' => 'fac4fb37-7d1e-4063-adef-4dcde4c009ef', 'username' => 'test_3'],
         ['id' => 'b2a00e96-c403-48c4-9043-e8fa1f55399b', 'username' => 'test_4'],
-        ['id' => 'abd0c4a2-ceea-4f3c-8e00-b82b54982a96', 'username' => 'test_5']
+        ['id' => 'abd0c4a2-ceea-4f3c-8e00-b82b54982a96', 'username' => 'test_5'],
     ];
 }

--- a/tests/TestCase/Action/AddActionTest.php
+++ b/tests/TestCase/Action/AddActionTest.php
@@ -115,7 +115,7 @@ class AddActionTest extends IntegrationTestCase
                         [
                             'element' => 'default',
                             'params' => ['class' => 'message success', 'original' => 'Successfully created blog'],
-                            'key' => 'flash'
+                            'key' => 'flash',
                         ]
                     );
 
@@ -125,7 +125,7 @@ class AddActionTest extends IntegrationTestCase
 
         $this->post('/blogs/add', [
             'name' => 'Hello World',
-            'body' => 'Pretty hot body'
+            'body' => 'Pretty hot body',
         ]);
 
         $this->assertEvents(['beforeSave', 'afterSave', 'setFlash', 'beforeRedirect']);
@@ -160,7 +160,7 @@ class AddActionTest extends IntegrationTestCase
                         [
                             'element' => 'default',
                             'params' => ['class' => 'message success', 'original' => 'Successfully created blog'],
-                            'key' => 'flash'
+                            'key' => 'flash',
                         ]
                     );
 
@@ -171,7 +171,7 @@ class AddActionTest extends IntegrationTestCase
         $this->post('/blogs/add', [
             'name' => 'Hello World',
             'body' => 'Pretty hot body',
-            '_add' => 1
+            '_add' => 1,
         ]);
 
         $this->assertEvents(['beforeSave', 'afterSave', 'setFlash', 'beforeRedirect']);
@@ -205,7 +205,7 @@ class AddActionTest extends IntegrationTestCase
                         [
                             'element' => 'default',
                             'params' => ['class' => 'message success', 'original' => 'Successfully created blog'],
-                            'key' => 'flash'
+                            'key' => 'flash',
                         ]
                     );
 
@@ -216,7 +216,7 @@ class AddActionTest extends IntegrationTestCase
         $this->post('/blogs/add', [
             'name' => 'Hello World',
             'body' => 'Pretty hot body',
-            '_edit' => 1
+            '_edit' => 1,
         ]);
 
         $this->assertEvents(['beforeSave', 'afterSave', 'setFlash', 'beforeRedirect']);
@@ -249,7 +249,7 @@ class AddActionTest extends IntegrationTestCase
                         [
                             'element' => 'default',
                             'params' => ['class' => 'message error', 'original' => 'Could not create blog'],
-                            'key' => 'flash'
+                            'key' => 'flash',
                         ]
                     );
 
@@ -270,7 +270,7 @@ class AddActionTest extends IntegrationTestCase
 
         $this->post('/blogs/add', [
             'name' => 'Hello World',
-            'body' => 'Pretty hot body'
+            'body' => 'Pretty hot body',
         ]);
 
         $this->assertEvents(['beforeSave', 'afterSave', 'setFlash', 'beforeRender']);
@@ -302,7 +302,7 @@ class AddActionTest extends IntegrationTestCase
                         [
                             'element' => 'default',
                             'params' => ['class' => 'message error', 'original' => 'Could not create blog'],
-                            'key' => 'flash'
+                            'key' => 'flash',
                         ]
                     );
 
@@ -315,14 +315,14 @@ class AddActionTest extends IntegrationTestCase
                         'length' => [
                             'rule' => ['minLength', 10],
                             'message' => 'Name need to be at least 10 characters long',
-                        ]
+                        ],
                     ]);
             }
         );
 
         $this->post('/blogs/add', [
             'name' => 'Hello',
-            'body' => 'Pretty hot body'
+            'body' => 'Pretty hot body',
         ]);
 
         $this->assertEvents(['beforeSave', 'afterSave', 'setFlash', 'beforeRender']);
@@ -347,7 +347,7 @@ class AddActionTest extends IntegrationTestCase
     {
         return [
             ['get'],
-            ['delete']
+            ['delete'],
         ];
     }
 
@@ -380,7 +380,7 @@ class AddActionTest extends IntegrationTestCase
     {
         return [
             ['put'],
-            ['post']
+            ['post'],
         ];
     }
 
@@ -415,7 +415,7 @@ class AddActionTest extends IntegrationTestCase
 
         $this->{$method}('/blogs/add.json', [
             'name' => '6th blog post',
-            'body' => 'Amazing blog post'
+            'body' => 'Amazing blog post',
         ]);
         $this->assertEvents(['beforeSave', 'afterSave', 'setFlash', 'beforeRedirect']);
         $this->assertTrue($this->_subject->success);
@@ -464,14 +464,14 @@ class AddActionTest extends IntegrationTestCase
                         'length' => [
                             'rule' => ['minLength', 10],
                             'message' => 'Name need to be at least 10 characters long',
-                        ]
+                        ],
                     ]);
             }
         );
 
         $this->{$method}('/blogs/add.json', [
             'name' => 'too short',
-            'body' => 'Amazing blog post'
+            'body' => 'Amazing blog post',
         ]);
 
         $this->assertResponseCode(422);
@@ -517,13 +517,13 @@ class AddActionTest extends IntegrationTestCase
                         'length' => [
                             'rule' => ['minLength', 10],
                             'message' => 'Name need to be at least 10 characters long',
-                        ]
+                        ],
                     ]);
             }
         );
 
         $this->{$method}('/blogs/add.json', [
-            'name' => 'too short'
+            'name' => 'too short',
         ]);
 
         $this->assertResponseError();
@@ -555,7 +555,7 @@ class AddActionTest extends IntegrationTestCase
                         [
                             'element' => 'default',
                             'params' => ['class' => 'message error', 'original' => 'Could not create blog'],
-                            'key' => 'flash'
+                            'key' => 'flash',
                         ]
                     );
 
@@ -609,7 +609,7 @@ class AddActionTest extends IntegrationTestCase
                         [
                             'element' => 'default',
                             'params' => ['class' => 'message success', 'original' => 'Successfully created blog'],
-                            'key' => 'flash'
+                            'key' => 'flash',
                         ]
                     );
 

--- a/tests/TestCase/Action/BaseActionTest.php
+++ b/tests/TestCase/Action/BaseActionTest.php
@@ -32,9 +32,9 @@ class BaseActionTest extends TestCase
             ->setMethods(['set'])
             ->setConstructorArgs([
                 $this->Request,
-                new \Cake\Network\Response,
+                new \Cake\Network\Response(),
                 'CrudExamples',
-                \Cake\Event\EventManager::instance()
+                \Cake\Event\EventManager::instance(),
             ])
             ->getMock();
         $this->Registry = $this->Controller->components();
@@ -76,12 +76,12 @@ class BaseActionTest extends TestCase
             'validateId' => null,
             'saveOptions' => [
                 'validate' => 'first',
-                'atomic' => true
+                'atomic' => true,
             ],
             'serialize' => [
                 'success',
-                'data'
-            ]
+                'data',
+            ],
         ]);
     }
 
@@ -101,13 +101,13 @@ class BaseActionTest extends TestCase
             'validateId' => 'id',
             'saveOptions' => [
                 'validate' => 'never',
-                'atomic' => false
+                'atomic' => false,
             ],
             'serialize' => [
                 'yay',
-                'ney'
+                'ney',
             ],
-            'action' => 'add'
+            'action' => 'add',
         ];
 
         $ActionClass = new $this->actionClassName($this->Controller, $expected);
@@ -230,7 +230,7 @@ class BaseActionTest extends TestCase
             'element' => 'default',
             'params' => [
                 'class' => 'message success',
-                'original' => 'Ahoy'
+                'original' => 'Ahoy',
             ],
             'key' => 'custom',
             'type' => 'add.success',
@@ -268,7 +268,7 @@ class BaseActionTest extends TestCase
 
         $this->ActionClass->setConfig('name', 'test');
         $this->ActionClass->setConfig('messages', [
-            'success' => ['text' => 'Ahoy', 'key' => 'custom']
+            'success' => ['text' => 'Ahoy', 'key' => 'custom'],
         ]);
         $this->ActionClass->setFlash('success', $Subject);
     }
@@ -284,7 +284,7 @@ class BaseActionTest extends TestCase
 
         $expected = [
             'validate' => 'first',
-            'atomic' => true
+            'atomic' => true,
         ];
         $actual = $CrudAction->getConfig('saveOptions');
         $this->assertEquals($expected, $actual);
@@ -292,18 +292,18 @@ class BaseActionTest extends TestCase
         $CrudAction->setConfig('saveOptions.atomic', true);
         $expected = [
             'validate' => 'first',
-            'atomic' => true
+            'atomic' => true,
         ];
         $actual = $CrudAction->getConfig('saveOptions');
         $this->assertEquals($expected, $actual);
 
         $CrudAction->setConfig('saveOptions', [
-            'fieldList' => ['hello']
+            'fieldList' => ['hello'],
         ]);
         $expected = [
             'validate' => 'first',
             'atomic' => true,
-            'fieldList' => ['hello']
+            'fieldList' => ['hello'],
         ];
         $actual = $CrudAction->getConfig('saveOptions');
         $this->assertEquals($expected, $actual);
@@ -356,12 +356,12 @@ class BaseActionTest extends TestCase
             'element' => 'default',
             'params' => [
                 'class' => 'message simple',
-                'original' => 'Simple message'
+                'original' => 'Simple message',
             ],
             'key' => 'flash',
             'type' => 'add.simple',
             'name' => 'my model',
-            'text' => 'Simple message'
+            'text' => 'Simple message',
         ];
         $actual = $this->ActionClass->message('simple');
         $this->assertEquals($expected, $actual);
@@ -381,12 +381,12 @@ class BaseActionTest extends TestCase
             'element' => 'default',
             'params' => [
                 'class' => 'message simple',
-                'original' => 'Overridden message'
+                'original' => 'Overridden message',
             ],
             'key' => 'flash',
             'type' => 'add.simple',
             'name' => 'my model',
-            'text' => 'Overridden message'
+            'text' => 'Overridden message',
         ];
         $actual = $this->ActionClass->message('simple');
         $this->assertEquals($expected, $actual);
@@ -405,12 +405,12 @@ class BaseActionTest extends TestCase
             'element' => 'default',
             'params' => [
                 'class' => 'message simple',
-                'original' => 'Simple message'
+                'original' => 'Simple message',
             ],
             'key' => 'flash',
             'type' => 'add.simple',
             'name' => 'my model',
-            'text' => 'Simple message'
+            'text' => 'Simple message',
         ];
         $actual = $this->ActionClass->message('simple');
         $this->assertEquals($expected, $actual);
@@ -429,12 +429,12 @@ class BaseActionTest extends TestCase
             'element' => 'default',
             'params' => [
                 'class' => 'message simple',
-                'original' => 'Simple message with id "{id}"'
+                'original' => 'Simple message with id "{id}"',
             ],
             'key' => 'flash',
             'type' => 'add.simple',
             'name' => 'my model',
-            'text' => 'Simple message with id "123"'
+            'text' => 'Simple message with id "123"',
         ];
         $actual = $this->ActionClass->message('simple', ['id' => 123]);
         $this->assertEquals($expected, $actual);
@@ -453,12 +453,12 @@ class BaseActionTest extends TestCase
             'element' => 'default',
             'params' => [
                 'class' => 'message invalidId',
-                'original' => 'Invalid id'
+                'original' => 'Invalid id',
             ],
             'key' => 'flash',
             'type' => 'add.invalidId',
             'name' => 'my model',
-            'text' => 'Invalid id'
+            'text' => 'Invalid id',
         ];
         $actual = $this->ActionClass->message('invalidId');
         $this->assertEquals($expected, $actual);
@@ -477,12 +477,12 @@ class BaseActionTest extends TestCase
             'element' => 'default',
             'params' => [
                 'class' => 'message recordNotFound',
-                'original' => 'Not found'
+                'original' => 'Not found',
             ],
             'key' => 'flash',
             'type' => 'add.recordNotFound',
             'name' => 'my model',
-            'text' => 'Not found'
+            'text' => 'Not found',
         ];
         $actual = $this->ActionClass->message('recordNotFound');
         $this->assertEquals($expected, $actual);
@@ -501,12 +501,12 @@ class BaseActionTest extends TestCase
             'element' => 'default',
             'params' => [
                 'class' => 'message badRequestMethod',
-                'original' => 'Method not allowed. This action permits only {methods}'
+                'original' => 'Method not allowed. This action permits only {methods}',
             ],
             'key' => 'flash',
             'type' => 'add.badRequestMethod',
             'name' => 'my model',
-            'text' => 'Method not allowed. This action permits only THESE ONES'
+            'text' => 'Method not allowed. This action permits only THESE ONES',
         ];
         $actual = $this->ActionClass->message('badRequestMethod', ['methods' => 'THESE ONES']);
         $this->assertEquals($expected, $actual);

--- a/tests/TestCase/Action/Bulk/DeleteActionTest.php
+++ b/tests/TestCase/Action/Bulk/DeleteActionTest.php
@@ -19,7 +19,7 @@ class DeleteActionTest extends IntegrationTestCase
      */
     public $fixtures = [
         'plugin.Crud.Blogs',
-        'plugin.Crud.Users'
+        'plugin.Crud.Users',
     ];
 
     /**
@@ -79,7 +79,7 @@ class DeleteActionTest extends IntegrationTestCase
                         [
                             'element' => 'default',
                             'params' => ['class' => 'message success', 'original' => 'Delete completed successfully'],
-                            'key' => 'flash'
+                            'key' => 'flash',
                         ]
                     );
 
@@ -123,7 +123,7 @@ class DeleteActionTest extends IntegrationTestCase
                         [
                             'element' => 'default',
                             'params' => ['class' => 'message error', 'original' => 'Could not complete deletion'],
-                            'key' => 'flash'
+                            'key' => 'flash',
                         ]
                     );
 
@@ -171,7 +171,7 @@ class DeleteActionTest extends IntegrationTestCase
                         [
                             'element' => 'default',
                             'params' => ['class' => 'message success', 'original' => 'Delete completed successfully'],
-                            'key' => 'flash'
+                            'key' => 'flash',
                         ]
                     );
 

--- a/tests/TestCase/Action/Bulk/SetValueActionTest.php
+++ b/tests/TestCase/Action/Bulk/SetValueActionTest.php
@@ -79,7 +79,7 @@ class SetValueActionTest extends IntegrationTestCase
                         [
                             'element' => 'default',
                             'params' => ['class' => 'message success', 'original' => 'Set value successfully'],
-                            'key' => 'flash'
+                            'key' => 'flash',
                         ]
                     );
 
@@ -123,7 +123,7 @@ class SetValueActionTest extends IntegrationTestCase
                         [
                             'element' => 'default',
                             'params' => ['class' => 'message error', 'original' => 'Could not set value'],
-                            'key' => 'flash'
+                            'key' => 'flash',
                         ]
                     );
 
@@ -171,7 +171,7 @@ class SetValueActionTest extends IntegrationTestCase
                         [
                             'element' => 'default',
                             'params' => ['class' => 'message success', 'original' => 'Set value successfully'],
-                            'key' => 'flash'
+                            'key' => 'flash',
                         ]
                     );
 

--- a/tests/TestCase/Action/Bulk/ToggleActionTest.php
+++ b/tests/TestCase/Action/Bulk/ToggleActionTest.php
@@ -19,7 +19,7 @@ class ToggleActionTest extends IntegrationTestCase
      */
     public $fixtures = [
         'plugin.Crud.Blogs',
-        'plugin.Crud.Users'
+        'plugin.Crud.Users',
     ];
 
     /**
@@ -79,7 +79,7 @@ class ToggleActionTest extends IntegrationTestCase
                         [
                             'element' => 'default',
                             'params' => ['class' => 'message success', 'original' => 'Value toggled successfully'],
-                            'key' => 'flash'
+                            'key' => 'flash',
                         ]
                     );
 
@@ -123,7 +123,7 @@ class ToggleActionTest extends IntegrationTestCase
                         [
                             'element' => 'default',
                             'params' => ['class' => 'message error', 'original' => 'Could not toggle value'],
-                            'key' => 'flash'
+                            'key' => 'flash',
                         ]
                     );
 
@@ -171,7 +171,7 @@ class ToggleActionTest extends IntegrationTestCase
                         [
                             'element' => 'default',
                             'params' => ['class' => 'message success', 'original' => 'Value toggled successfully'],
-                            'key' => 'flash'
+                            'key' => 'flash',
                         ]
                     );
 

--- a/tests/TestCase/Action/DeleteActionTest.php
+++ b/tests/TestCase/Action/DeleteActionTest.php
@@ -52,7 +52,7 @@ class DeleteActionTest extends IntegrationTestCase
     {
         return [
             ['post'],
-            ['delete']
+            ['delete'],
         ];
     }
 
@@ -81,7 +81,7 @@ class DeleteActionTest extends IntegrationTestCase
                         [
                             'element' => 'default',
                             'params' => ['class' => 'message success', 'original' => 'Successfully deleted blog'],
-                            'key' => 'flash'
+                            'key' => 'flash',
                         ]
                     );
 
@@ -131,7 +131,7 @@ class DeleteActionTest extends IntegrationTestCase
                         [
                             'element' => 'default',
                             'params' => ['class' => 'message error', 'original' => 'Could not delete blog'],
-                            'key' => 'flash'
+                            'key' => 'flash',
                         ]
                     );
 
@@ -185,7 +185,7 @@ class DeleteActionTest extends IntegrationTestCase
                         [
                             'element' => 'default',
                             'params' => ['class' => 'message success', 'original' => 'Successfully deleted blog'],
-                            'key' => 'flash'
+                            'key' => 'flash',
                         ]
                     );
 

--- a/tests/TestCase/Action/EditActionTest.php
+++ b/tests/TestCase/Action/EditActionTest.php
@@ -135,7 +135,7 @@ class EditActionTest extends IntegrationTestCase
                         [
                             'element' => 'default',
                             'params' => ['class' => 'message success', 'original' => 'Successfully updated blog'],
-                            'key' => 'flash'
+                            'key' => 'flash',
                         ]
                     );
 
@@ -145,7 +145,7 @@ class EditActionTest extends IntegrationTestCase
 
         $this->post('/blogs/edit/1', [
             'name' => 'Hello World',
-            'body' => 'Pretty hot body'
+            'body' => 'Pretty hot body',
         ]);
 
         $this->assertEvents(['beforeFind', 'afterFind', 'beforeSave', 'afterSave', 'setFlash', 'beforeRedirect']);
@@ -178,7 +178,7 @@ class EditActionTest extends IntegrationTestCase
                         [
                             'element' => 'default',
                             'params' => ['class' => 'message error', 'original' => 'Could not update blog'],
-                            'key' => 'flash'
+                            'key' => 'flash',
                         ]
                     );
 
@@ -199,7 +199,7 @@ class EditActionTest extends IntegrationTestCase
 
         $this->put('/blogs/edit/1', [
             'name' => 'Hello World',
-            'body' => 'Pretty hot body'
+            'body' => 'Pretty hot body',
         ]);
 
         $this->assertEvents(['beforeFind', 'afterFind', 'beforeSave', 'afterSave', 'setFlash', 'beforeRender']);
@@ -231,7 +231,7 @@ class EditActionTest extends IntegrationTestCase
                         [
                             'element' => 'default',
                             'params' => ['class' => 'message error', 'original' => 'Could not update blog'],
-                            'key' => 'flash'
+                            'key' => 'flash',
                         ]
                     );
 
@@ -244,14 +244,14 @@ class EditActionTest extends IntegrationTestCase
                         'length' => [
                             'rule' => ['minLength', 10],
                             'message' => 'Name need to be at least 10 characters long',
-                        ]
+                        ],
                     ]);
             }
         );
 
         $this->put('/blogs/edit/1', [
             'name' => 'Hello',
-            'body' => 'Pretty hot body'
+            'body' => 'Pretty hot body',
         ]);
 
         $this->assertEvents(['beforeFind', 'afterFind', 'beforeSave', 'afterSave', 'setFlash', 'beforeRender']);
@@ -291,7 +291,7 @@ class EditActionTest extends IntegrationTestCase
                         [
                             'element' => 'default',
                             'params' => ['class' => 'message success', 'original' => 'Successfully updated blog'],
-                            'key' => 'flash'
+                            'key' => 'flash',
                         ]
                     );
 
@@ -301,7 +301,7 @@ class EditActionTest extends IntegrationTestCase
 
         $this->patch('/blogs/edit/1', [
             'name' => 'Hello World',
-            'body' => 'Even hotter body'
+            'body' => 'Even hotter body',
         ]);
 
         $this->assertEvents(['beforeFind', 'afterFind', 'beforeSave', 'afterSave', 'setFlash', 'beforeRedirect']);

--- a/tests/TestCase/Action/IndexActionTest.php
+++ b/tests/TestCase/Action/IndexActionTest.php
@@ -48,7 +48,7 @@ class IndexActionTest extends IntegrationTestCase
             ['get'],
             ['post'],
             ['put'],
-            ['delete']
+            ['delete'],
         ];
     }
 

--- a/tests/TestCase/Action/ViewActionTest.php
+++ b/tests/TestCase/Action/ViewActionTest.php
@@ -48,7 +48,7 @@ class ViewActionTest extends IntegrationTestCase
             ['get'],
             ['post'],
             ['put'],
-            ['delete']
+            ['delete'],
         ];
     }
 

--- a/tests/TestCase/Controller/Component/CrudComponentTest.php
+++ b/tests/TestCase/Controller/Component/CrudComponentTest.php
@@ -28,7 +28,7 @@ class TestCrudEventManager extends \Cake\Event\EventManager
     {
         $this->_log[] = [
             'name' => $event->name(),
-            'subject' => $event->getSubject()
+            'subject' => $event->getSubject(),
         ];
         parent::dispatch($event);
     }
@@ -68,13 +68,13 @@ class CrudExamplesController extends \Cake\Controller\Controller
                 'Crud.Add',
                 'Crud.Edit',
                 'Crud.Delete',
-                'Crud.View'
-            ]
-        ]
+                'Crud.View',
+            ],
+        ],
     ];
 
     public $paginate = [
-        'limit' => 1000
+        'limit' => 1000,
     ];
 
     /**
@@ -173,7 +173,7 @@ class CrudComponentTest extends TestCase
      * What fixture is used is almost irrelevant, was chosen as it is simple
      */
     public $fixtures = [
-        'core.Posts'
+        'core.Posts',
     ];
 
     /**
@@ -210,8 +210,8 @@ class CrudComponentTest extends TestCase
                 'Crud.Add',
                 'Crud.Edit',
                 'Crud.View',
-                'Crud.Delete'
-            ]
+                'Crud.Delete',
+            ],
         ];
 
         $this->Crud = new TestCrudComponent($this->Registry, $config);
@@ -249,8 +249,8 @@ class CrudComponentTest extends TestCase
                 'view' => ['className' => 'Crud.View', 'viewVar' => 'beers'],
             ],
             'listeners' => [
-                'Crud.Related'
-            ]
+                'Crud.Related',
+            ],
         ];
         $Crud = $this->getMockBuilder('Crud\Controller\Component\CrudComponent')
             ->setMethods(['_loadListeners', 'trigger'])
@@ -356,7 +356,7 @@ class CrudComponentTest extends TestCase
 
         $this->Crud->mapAction('kittens', [
             'className' => 'Crud.Index',
-            'relatedModels' => false
+            'relatedModels' => false,
         ]);
 
         $result = $this->Crud->isActionMapped('kittens');
@@ -364,7 +364,7 @@ class CrudComponentTest extends TestCase
 
         $expected = [
             'className' => 'Crud.Index',
-            'relatedModels' => false
+            'relatedModels' => false,
         ];
         $this->assertEquals($expected, $this->Crud->getConfig('actions.kittens'));
     }
@@ -430,8 +430,8 @@ class CrudComponentTest extends TestCase
 
         $expected = [
             [
-                'callable' => 'fakeCallback'
-            ]
+                'callable' => 'fakeCallback',
+            ],
         ];
         $this->assertSame($expected, $return);
     }
@@ -450,14 +450,14 @@ class CrudComponentTest extends TestCase
 
         $expected = [
             [
-                'callable' => 'fakeHighPriority'
+                'callable' => 'fakeHighPriority',
             ],
             [
-                'callable' => 'fakeCallback'
+                'callable' => 'fakeCallback',
             ],
             [
-                'callable' => 'fakeLowPriority'
-            ]
+                'callable' => 'fakeLowPriority',
+            ],
         ];
         $this->assertSame($expected, $return);
     }
@@ -595,20 +595,20 @@ class CrudComponentTest extends TestCase
                 'invalidId' => [
                     'code' => 400,
                     'class' => BadRequestException::class,
-                    'text' => 'Invalid id'
+                    'text' => 'Invalid id',
                 ],
                 'recordNotFound' => [
                     'code' => 404,
                     'class' => NotFoundException::class,
-                    'text' => 'Not found'
+                    'text' => 'Not found',
                 ],
                 'badRequestMethod' => [
                     'code' => 405,
                     'class' => MethodNotAllowedException::class,
-                    'text' => 'Method not allowed. This action permits only {methods}'
-                ]
+                    'text' => 'Method not allowed. This action permits only {methods}',
+                ],
             ],
-            'eventLogging' => false
+            'eventLogging' => false,
         ];
         $this->assertEquals($expected, $result);
     }
@@ -624,8 +624,8 @@ class CrudComponentTest extends TestCase
     {
         $config = [
             'listeners' => [
-                'api' => 'Crud.Api'
-            ]
+                'api' => 'Crud.Api',
+            ],
         ];
 
         $Crud = new CrudComponent($this->Registry, $config);
@@ -634,27 +634,27 @@ class CrudComponentTest extends TestCase
             'actions' => [],
             'eventPrefix' => 'Crud',
             'listeners' => [
-                'api' => ['className' => 'Crud.Api']
+                'api' => ['className' => 'Crud.Api'],
             ],
             'messages' => [
                 'domain' => 'crud',
                 'invalidId' => [
                     'code' => 400,
                     'class' => BadRequestException::class,
-                    'text' => 'Invalid id'
+                    'text' => 'Invalid id',
                 ],
                 'recordNotFound' => [
                     'code' => 404,
                     'class' => NotFoundException::class,
-                    'text' => 'Not found'
+                    'text' => 'Not found',
                 ],
                 'badRequestMethod' => [
                     'code' => 405,
                     'class' => MethodNotAllowedException::class,
-                    'text' => 'Method not allowed. This action permits only {methods}'
-                ]
+                    'text' => 'Method not allowed. This action permits only {methods}',
+                ],
             ],
-            'eventLogging' => false
+            'eventLogging' => false,
         ];
         $this->assertEquals($expected, $result);
     }
@@ -670,7 +670,7 @@ class CrudComponentTest extends TestCase
     {
         $config = [
             'listeners' => [
-            ]
+            ],
         ];
 
         $Crud = new CrudComponent($this->Registry, $config);
@@ -684,20 +684,20 @@ class CrudComponentTest extends TestCase
                 'invalidId' => [
                     'code' => 400,
                     'class' => BadRequestException::class,
-                    'text' => 'Invalid id'
+                    'text' => 'Invalid id',
                 ],
                 'recordNotFound' => [
                     'code' => 404,
                     'class' => NotFoundException::class,
-                    'text' => 'Not found'
+                    'text' => 'Not found',
                 ],
                 'badRequestMethod' => [
                     'code' => 405,
                     'class' => MethodNotAllowedException::class,
-                    'text' => 'Method not allowed. This action permits only {methods}'
-                ]
+                    'text' => 'Method not allowed. This action permits only {methods}',
+                ],
             ],
-            'eventLogging' => false
+            'eventLogging' => false,
         ];
         $this->assertEquals($expected, $result);
     }
@@ -719,7 +719,7 @@ class CrudComponentTest extends TestCase
 
         $listeners = $this->Crud->getConfig('listeners');
         $expected = [
-            'api' => ['className' => 'Crud.Api']
+            'api' => ['className' => 'Crud.Api'],
         ];
         $this->assertEquals($expected, $listeners);
 
@@ -741,7 +741,7 @@ class CrudComponentTest extends TestCase
 
         $listeners = $this->Crud->getConfig('listeners');
         $expected = [
-            'api' => ['className' => 'Crud.Api', 'test' => 1]
+            'api' => ['className' => 'Crud.Api', 'test' => 1],
         ];
         $this->assertEquals($expected, $listeners);
 
@@ -761,7 +761,7 @@ class CrudComponentTest extends TestCase
         $this->Crud->addListener('api', 'Crud.Api');
         $listeners = $this->Crud->getConfig('listeners');
         $expected = [
-            'api' => ['className' => 'Crud.Api']
+            'api' => ['className' => 'Crud.Api'],
         ];
         $this->assertEquals($expected, $listeners);
 
@@ -953,7 +953,7 @@ class CrudComponentTest extends TestCase
         $expected = [
             'code' => 500,
             'class' => BadRequestException::class,
-            'text' => 'Invalid id'
+            'text' => 'Invalid id',
         ];
         $result = $this->Crud->getConfig('messages.invalidId');
         $this->assertEquals($expected, $result);
@@ -971,18 +971,18 @@ class CrudComponentTest extends TestCase
         $expected = [
             'domain' => 'crud',
             'invalidId' => [
-                'code' => 500
+                'code' => 500,
             ],
             'recordNotFound' => [
                 'code' => 404,
                 'class' => NotFoundException::class,
-                'text' => 'Not found'
+                'text' => 'Not found',
             ],
             'badRequestMethod' => [
                 'code' => 405,
                 'class' => MethodNotAllowedException::class,
-                'text' => 'Method not allowed. This action permits only {methods}'
-            ]
+                'text' => 'Method not allowed. This action permits only {methods}',
+            ],
         ];
         $result = $this->Crud->getConfig('messages');
         $this->assertEquals($expected, $result);
@@ -1012,7 +1012,7 @@ class CrudComponentTest extends TestCase
     public function testLoadListener()
     {
         $this->Crud->setConfig('listeners.HasSetup', [
-            'className' => 'Crud\TestCase\Controller\Crud\TestListener'
+            'className' => 'Crud\TestCase\Controller\Crud\TestListener',
         ]);
 
         $this->setReflectionClassInstance($this->Crud);

--- a/tests/TestCase/Error/ExceptionRendererTest.php
+++ b/tests/TestCase/Error/ExceptionRendererTest.php
@@ -59,7 +59,7 @@ class ExceptionRendererTest extends TestCase
                 'class' => 'Cake\Core\Exception\Exception',
                 'code' => 500,
                 'message' => 'Hello World',
-            ]
+            ],
         ];
 
         $actual = $viewVars['data'];
@@ -135,7 +135,7 @@ class ExceptionRendererTest extends TestCase
                 'class' => 'Cake\Core\Exception\Exception',
                 'code' => 500,
                 'message' => 'Hello World',
-            ]
+            ],
         ];
 
         $actual = $viewVars['data'];
@@ -205,7 +205,7 @@ class ExceptionRendererTest extends TestCase
                 'class' => 'Cake\Core\Exception\Exception',
                 'code' => 500,
                 'message' => 'Hello World',
-            ]
+            ],
         ];
 
         $actual = $viewVars['data'];
@@ -269,7 +269,7 @@ class ExceptionRendererTest extends TestCase
                 'class' => 'Cake\Core\Exception\Exception',
                 'code' => 500,
                 'message' => 'Hello World',
-            ]
+            ],
         ];
 
         $actual = $viewVars['data'];
@@ -335,7 +335,7 @@ class ExceptionRendererTest extends TestCase
                 'class' => 'Cake\Core\Exception\Exception',
                 'code' => 500,
                 'message' => 'Hello World',
-            ]
+            ],
         ];
         $actual = $viewVars['data'];
         unset($actual['trace']);
@@ -391,10 +391,10 @@ class ExceptionRendererTest extends TestCase
             'errorCount' => 1,
             'errors' => [
                 'title' => [
-                    'error message'
-                ]
+                    'error message',
+                ],
             ],
-            'message' => 'A validation error occurred'
+            'message' => 'A validation error occurred',
         ];
         $this->assertEquals($expected, $Controller->viewVars['data']);
     }
@@ -436,15 +436,15 @@ class ExceptionRendererTest extends TestCase
             'errorCount' => 1,
             'errors' => [
                 'title' => [
-                    'error message'
-                ]
+                    'error message',
+                ],
             ],
             'exception' => [
                 'class' => 'Crud\Error\Exception\ValidationException',
                 'code' => 422,
-                'message' => 'A validation error occurred'
+                'message' => 'A validation error occurred',
             ],
-            'message' => 'A validation error occurred'
+            'message' => 'A validation error occurred',
         ];
         $this->assertEquals($expected, $Controller->viewVars['data']);
     }
@@ -454,7 +454,7 @@ class ExceptionRendererTest extends TestCase
         $entity = new Entity();
         $entity->setErrors([
             'title' => ['error message'],
-            'body' => ['another field message']
+            'body' => ['another field message'],
         ]);
 
         $Exception = new ValidationException($entity);
@@ -485,17 +485,17 @@ class ExceptionRendererTest extends TestCase
             'errorCount' => 2,
             'errors' => [
                 'title' => [
-                    'error message'
+                    'error message',
                 ],
                 'body' => [
-                    'another field message'
-                ]
+                    'another field message',
+                ],
             ],
             'exception' => [
                 'class' => 'Crud\Error\Exception\ValidationException',
                 'code' => 422,
                 'message' => '2 validation errors occurred',
-            ]
+            ],
         ];
         $data = $Controller->viewVars['data'];
         unset($data['trace']);

--- a/tests/TestCase/Listener/ApiListenerTest.php
+++ b/tests/TestCase/Listener/ApiListenerTest.php
@@ -39,7 +39,7 @@ class ApiListenerTest extends TestCase
             'Crud.setFlash' => ['callable' => [$listener, 'setFlash'], 'priority' => 5],
 
             'Crud.beforeRender' => ['callable' => [$listener, 'respond'], 'priority' => 100],
-            'Crud.beforeRedirect' => ['callable' => [$listener, 'respond'], 'priority' => 100]
+            'Crud.beforeRedirect' => ['callable' => [$listener, 'respond'], 'priority' => 100],
         ];
         $result = $listener->implementedEvents();
         $this->assertEquals($expected, $result);
@@ -259,20 +259,20 @@ class ApiListenerTest extends TestCase
         $expected = [
             'viewClasses' => [
                 'json' => 'Json',
-                'xml' => 'Xml'
+                'xml' => 'Xml',
             ],
             'detectors' => [
                 'json' => ['ext' => 'json', 'accepts' => 'application/json'],
-                'xml' => ['ext' => 'xml', 'accepts' => 'text/xml']
+                'xml' => ['ext' => 'xml', 'accepts' => 'text/xml'],
             ],
             'exception' => [
                 'type' => 'default',
                 'class' => 'Cake\Http\Exception\BadRequestException',
                 'message' => 'Unknown error',
-                'code' => 0
+                'code' => 0,
             ],
             'exceptionRenderer' => 'Crud\Error\ExceptionRenderer',
-            'setFlash' => false
+            'setFlash' => false,
         ];
         $result = $listener->getConfig();
         $this->assertEquals($expected, $result);
@@ -290,35 +290,35 @@ class ApiListenerTest extends TestCase
                 [],
                 '\Cake\Http\Exception\BadRequestException',
                 'Unknown error',
-                0
+                0,
             ],
 
             'change exception class' => [
                 ['class' => '\Cake\Core\Exception\Exception'],
                 '\Cake\Core\Exception\Exception',
                 'Unknown error',
-                0
+                0,
             ],
 
             'change exception code' => [
                 ['code' => 10],
                 '\Cake\Http\Exception\BadRequestException',
                 'Unknown error',
-                10
+                10,
             ],
 
             'change exception message' => [
                 ['message' => 'epic message'],
                 '\Cake\Http\Exception\BadRequestException',
                 'epic message',
-                0
+                0,
             ],
 
             'Validate case #1 - no validation errors' => [
                 ['class' => '\Crud\Error\Exception\ValidationException', 'type' => 'validate'],
                 '\Crud\Error\Exception\ValidationException',
                 '0 validation errors occurred',
-                422
+                422,
             ],
 
             'Validate case #2 - one validation error' => [
@@ -326,7 +326,7 @@ class ApiListenerTest extends TestCase
                 '\Crud\Error\Exception\ValidationException',
                 'A validation error occurred',
                 422,
-                [['id' => 'hello world']]
+                [['id' => 'hello world']],
             ],
 
             'Validate case #3 - two validation errors' => [
@@ -334,8 +334,8 @@ class ApiListenerTest extends TestCase
                 '\Crud\Error\Exception\ValidationException',
                 '2 validation errors occurred',
                 422,
-                [['id' => 'hello world', 'name' => 'fail me']]
-            ]
+                [['id' => 'hello world', 'name' => 'fail me']],
+            ],
         ];
     }
 
@@ -369,7 +369,7 @@ class ApiListenerTest extends TestCase
             $event->getSubject()->set([
                 'entity' => $this->getMockBuilder('\Cake\ORM\Entity')
                     ->setMethods(['errors'])
-                    ->getMock()
+                    ->getMock(),
             ]);
 
             $event->getSubject()->entity
@@ -766,8 +766,8 @@ class ApiListenerTest extends TestCase
         $config = ['data' => [
             'subject' => [
                 '{modelClass}.id' => 'id',
-                'modelClass'
-            ]
+                'modelClass',
+            ],
         ]];
 
         $i = 0;
@@ -1005,20 +1005,20 @@ class ApiListenerTest extends TestCase
             'simple string' => [
                 new \Crud\Event\Subject(['modelClass' => 'MyModel']),
                 '{modelClass}.id',
-                'MyModel.id'
+                'MyModel.id',
             ],
 
             'string and integer' => [
                 new \Crud\Event\Subject(['modelClass' => 'MyModel', 'id' => 1]),
                 '{modelClass}.{id}',
-                'MyModel.1'
+                'MyModel.1',
             ],
 
             'ignore non scalar' => [
-                new \Crud\Event\Subject(['modelClass' => 'MyModel', 'complex' => new \StdClass]),
+                new \Crud\Event\Subject(['modelClass' => 'MyModel', 'complex' => new \StdClass()]),
                 '{modelClass}.{id}',
-                'MyModel.{id}'
-            ]
+                'MyModel.{id}',
+            ],
         ];
     }
 
@@ -1101,7 +1101,7 @@ class ApiListenerTest extends TestCase
         $detectors = [
             'json' => ['ext' => 'json', 'accepts' => 'application/json'],
             'xml' => ['ext' => 'xml', 'accepts' => 'text/xml'],
-            'jsonapi' => ['ext' => false, 'accepts' => 'application/vnd.api+json']
+            'jsonapi' => ['ext' => false, 'accepts' => 'application/vnd.api+json'],
         ];
 
         $listener = $this
@@ -1192,23 +1192,23 @@ class ApiListenerTest extends TestCase
             'defaults' => [
                 [],
                 false,
-                []
+                [],
             ],
             'valid get' => [
                 ['methods' => ['get']],
                 true,
-                ['get' => true]
+                ['get' => true],
             ],
             'invalid post' => [
                 ['methods' => ['post']],
                 'Cake\Http\Exception\MethodNotAllowedException',
-                ['post' => false]
+                ['post' => false],
             ],
             'valid put' => [
                 ['methods' => ['post', 'get', 'put']],
                 true,
-                ['post' => false, 'get' => false, 'put' => true]
-            ]
+                ['post' => false, 'get' => false, 'put' => true],
+            ],
         ];
     }
 
@@ -1320,7 +1320,7 @@ class ApiListenerTest extends TestCase
         $result = $apiListener->getConfig('viewClasses');
         $expected = [
             'json' => 'Json',
-            'xml' => 'Xml'
+            'xml' => 'Xml',
         ];
         $this->assertEquals($expected, $result, 'The default viewClasses setting has changed');
     }

--- a/tests/TestCase/Listener/ApiPaginationListenerTest.php
+++ b/tests/TestCase/Listener/ApiPaginationListenerTest.php
@@ -32,7 +32,7 @@ class ApiPaginationListenerTest extends TestCase
 
         $result = $Instance->implementedEvents();
         $expected = [
-            'Crud.beforeRender' => ['callable' => 'beforeRender', 'priority' => 75]
+            'Crud.beforeRender' => ['callable' => 'beforeRender', 'priority' => 75],
         ];
         $this->assertEquals($expected, $result);
     }
@@ -126,8 +126,8 @@ class ApiPaginationListenerTest extends TestCase
                 'nextPage' => true,
                 'prevPage' => true,
                 'count' => 100,
-                'limit' => 10
-            ]
+                'limit' => 10,
+            ],
         ]);
 
         $expected = [
@@ -136,7 +136,7 @@ class ApiPaginationListenerTest extends TestCase
             'has_next_page' => true,
             'has_prev_page' => true,
             'count' => 100,
-            'limit' => 10
+            'limit' => 10,
         ];
 
         $Controller = $this
@@ -200,8 +200,8 @@ class ApiPaginationListenerTest extends TestCase
                 'nextPage' => true,
                 'prevPage' => true,
                 'count' => 100,
-                'limit' => 10
-            ]
+                'limit' => 10,
+            ],
         ]);
 
         $expected = [
@@ -210,7 +210,7 @@ class ApiPaginationListenerTest extends TestCase
             'has_next_page' => true,
             'has_prev_page' => true,
             'count' => 100,
-            'limit' => 10
+            'limit' => 10,
         ];
 
         $Controller = $this
@@ -274,8 +274,8 @@ class ApiPaginationListenerTest extends TestCase
                 'nextPage' => true,
                 'prevPage' => true,
                 'count' => 100,
-                'limit' => 10
-            ]
+                'limit' => 10,
+            ],
         ]);
 
         $expected = [
@@ -284,7 +284,7 @@ class ApiPaginationListenerTest extends TestCase
             'has_next_page' => true,
             'has_prev_page' => true,
             'count' => 100,
-            'limit' => 10
+            'limit' => 10,
         ];
 
         $Controller = $this

--- a/tests/TestCase/Listener/ApiQueryLogListenerTest.php
+++ b/tests/TestCase/Listener/ApiQueryLogListenerTest.php
@@ -50,7 +50,7 @@ class ApiQueryLogListenerTest extends TestCase
         $result = $Instance->implementedEvents();
         $expected = [
             'Crud.beforeFilter' => ['callable' => [$Instance, 'setupLogging'], 'priority' => 1],
-            'Crud.beforeRender' => ['callable' => [$Instance, 'beforeRender'], 'priority' => 75]
+            'Crud.beforeRender' => ['callable' => [$Instance, 'beforeRender'], 'priority' => 75],
         ];
 
         $this->assertEquals($expected, $result);
@@ -210,7 +210,7 @@ class ApiQueryLogListenerTest extends TestCase
         $this->setReflectionClassInstance($listener);
 
         $expected = [
-            'test' => []
+            'test' => [],
         ];
 
         $this->assertEquals($expected, $this->callProtectedMethod('_getQueryLogs', [], $listener));
@@ -227,7 +227,7 @@ class ApiQueryLogListenerTest extends TestCase
         $listener->setupLogging(new Event('something'));
 
         $expected = [
-            'test' => []
+            'test' => [],
         ];
 
         $this->assertEquals($expected, $listener->getQueryLogs());

--- a/tests/TestCase/Listener/RedirectListenerTest.php
+++ b/tests/TestCase/Listener/RedirectListenerTest.php
@@ -27,7 +27,7 @@ class RedirectListenerTest extends TestCase
 
         $result = $listener->implementedEvents();
         $expected = [
-            'Crud.beforeRedirect' => ['callable' => 'beforeRedirect', 'priority' => 90]
+            'Crud.beforeRedirect' => ['callable' => 'beforeRedirect', 'priority' => 90],
         ];
         $this->assertEquals($expected, $result);
     }
@@ -57,14 +57,14 @@ class RedirectListenerTest extends TestCase
             'request' => [
                 'key',
                 'data',
-                'query'
+                'query',
             ],
             'entity' => [
-                'field'
+                'field',
             ],
             'subject' => [
-                'key'
-            ]
+                'key',
+            ],
         ];
         $this->assertEquals($expected, $result);
     }
@@ -365,7 +365,7 @@ class RedirectListenerTest extends TestCase
         $action->redirectConfig('add', [
             'reader' => 'request.key',
             'key' => 'hello',
-            'url' => ['action' => 'index']
+            'url' => ['action' => 'index'],
         ]);
 
         $subject = new \Crud\Event\Subject();
@@ -402,7 +402,7 @@ class RedirectListenerTest extends TestCase
      */
     public function dataProviderGetUrl()
     {
-        $Request = new ServerRequest;
+        $Request = new ServerRequest();
         $Request = $Request->withParam('action', 'index')
             ->withQueryParams(['parent_id' => 10])
             ->withData('epic', 'jippi');
@@ -416,33 +416,33 @@ class RedirectListenerTest extends TestCase
             [
                 new \Crud\Event\Subject(),
                 ['action' => 'index'],
-                ['action' => 'index']
+                ['action' => 'index'],
             ],
             [
                 new \Crud\Event\Subject(),
                 ['controller' => 'posts', 'action' => 'index'],
-                ['controller' => 'posts', 'action' => 'index']
+                ['controller' => 'posts', 'action' => 'index'],
             ],
             [
                 new \Crud\Event\Subject(['request' => $Request]),
                 ['action' => ['request.key', 'action']],
-                ['action' => 'index']
+                ['action' => 'index'],
             ],
             [
                 new \Crud\Event\Subject(['request' => $Request]),
                 ['action' => ['request.data', 'epic']],
-                ['action' => 'jippi']
+                ['action' => 'jippi'],
             ],
             [
                 new \Crud\Event\Subject(['request' => $Request]),
                 ['action' => ['request.query', 'parent_id']],
-                ['action' => 10]
+                ['action' => 10],
             ],
             [
                 new \Crud\Event\Subject(['id' => 69]),
                 ['action' => 'edit', ['subject.key', 'id']],
-                ['action' => 'edit', 69]
-            ]
+                ['action' => 'edit', 69],
+            ],
         ];
     }
 

--- a/tests/TestCase/Listener/SearchListenerTest.php
+++ b/tests/TestCase/Listener/SearchListenerTest.php
@@ -44,7 +44,7 @@ class SearchListenerTest extends TestCase
         $result = $listener->implementedEvents();
         $expected = [
             'Crud.beforeLookup' => ['callable' => 'injectSearch'],
-            'Crud.beforePaginate' => ['callable' => 'injectSearch']
+            'Crud.beforePaginate' => ['callable' => 'injectSearch'],
         ];
         $this->assertEquals($expected, $result);
     }
@@ -92,8 +92,8 @@ class SearchListenerTest extends TestCase
 
         $listener = new SearchListener($controller, [
             'enabled' => [
-                'Crud.beforeLookup'
-            ]
+                'Crud.beforeLookup',
+            ],
         ]);
 
         $listener->injectSearch(new Event('Crud.beforePaginate', $subject));
@@ -114,7 +114,7 @@ class SearchListenerTest extends TestCase
             'search' => [
                 'name' => '1st post',
             ],
-            'collection' => 'search'
+            'collection' => 'search',
         ];
 
         $request = (new ServerRequest())->withQueryParams($params['search']);
@@ -159,9 +159,9 @@ class SearchListenerTest extends TestCase
 
         $listener = new SearchListener($controller, [
             'enabled' => [
-                'Crud.beforeLookup'
+                'Crud.beforeLookup',
             ],
-            'collection' => 'search'
+            'collection' => 'search',
         ]);
         $listener->injectSearch($event);
     }
@@ -182,7 +182,7 @@ class SearchListenerTest extends TestCase
             'search' => [
                 'name' => '1st post',
             ],
-            'collection' => 'search'
+            'collection' => 'search',
         ];
 
         $request = new ServerRequest(['query' => $params['search']]);
@@ -208,9 +208,9 @@ class SearchListenerTest extends TestCase
 
         $listener = new SearchListener($controller, [
             'enabled' => [
-                'Crud.beforeLookup'
+                'Crud.beforeLookup',
             ],
-            'collection' => 'search'
+            'collection' => 'search',
         ]);
         $listener->injectSearch($event);
     }


### PR DESCRIPTION
- Travis was broken. Couldn't parse the yml file, because of a missing space.
- Enormous list of style errors, which phpcbf could fix. It tried to cherry-pick c7849bb5b5c35e500c26b674577b37db77ae781e, but too many conflicts.