### PR TITLE
Adds option to control which connections to log

### DIFF
--- a/docs/listeners/api-query-log.rst
+++ b/docs/listeners/api-query-log.rst
@@ -29,7 +29,7 @@ you want to attach it only to specific controllers and actions
 
     }
 
-Attach it using components array, this is recommended if you want to
+Attach it in :code:`AppController::initialize()`, this is recommended if you want to
 attach it to all controllers, application wide
 
 
@@ -88,3 +88,23 @@ Paginated results will include a
             }
         }
     }
+
+
+Configuration
+-------------
+
+By default this listener will log all defined connections.
+
+If you need to select specific connections to log, you can use the :code:`connections` configuration:
+
+.. code-block:: php
+
+    $this->loadComponent('Crud.Crud', [
+        'listeners' => [
+            'Crud.Api',
+            'ApiQueryLog' => [
+                'className' => 'Crud.ApiQueryLog',
+                'connections' => ['default', 'elastic']
+            ]
+        ]
+    ]);

--- a/src/Action/BaseAction.php
+++ b/src/Action/BaseAction.php
@@ -10,6 +10,7 @@ use Cake\Utility\Inflector;
 use Cake\Utility\Text;
 use Crud\Core\BaseObject;
 use Crud\Event\Subject;
+use Exception;
 
 /**
  * Base Crud class
@@ -132,7 +133,7 @@ abstract class BaseAction extends BaseObject
         if (empty($config)) {
             $config = $crud->getConfig('messages.' . $type);
             if (empty($config)) {
-                throw new \Exception(sprintf('Invalid message type "%s"', $type));
+                throw new Exception(sprintf('Invalid message type "%s"', $type));
             }
         }
 
@@ -149,7 +150,7 @@ abstract class BaseAction extends BaseObject
         ], $config);
 
         if (!isset($config['text'])) {
-            throw new \Exception(sprintf('Invalid message config for "%s" no text key found', $type));
+            throw new Exception(sprintf('Invalid message config for "%s" no text key found', $type));
         }
 
         $config['params']['original'] = ucfirst(str_replace('{name}', $config['name'], $config['text']));

--- a/src/Error/Exception/CrudException.php
+++ b/src/Error/Exception/CrudException.php
@@ -3,9 +3,10 @@ declare(strict_types=1);
 
 namespace Crud\Error\Exception;
 
+use Cake\Core\Exception\Exception;
 use Psr\Http\Message\ResponseInterface;
 
-class CrudException extends \Cake\Core\Exception\Exception
+class CrudException extends Exception
 {
     /**
      * @var \Psr\Http\Message\ResponseInterface|null

--- a/src/Event/Subject.php
+++ b/src/Event/Subject.php
@@ -3,6 +3,8 @@ declare(strict_types=1);
 
 namespace Crud\Event;
 
+use Exception;
+
 /**
  * Crud subject
  *
@@ -105,7 +107,7 @@ class Subject
                 return !in_array($this->action, $actions);
 
             default:
-                throw new \Exception('Invalid mode');
+                throw new Exception('Invalid mode');
         }
     }
 }

--- a/src/Listener/ApiQueryLogListener.php
+++ b/src/Listener/ApiQueryLogListener.php
@@ -23,6 +23,15 @@ use Crud\Log\QueryLogger;
 class ApiQueryLogListener extends BaseListener
 {
     /**
+     * {@inheritDoc}
+     *
+     * `connections` List of connection names to log. Empty means all defined connections.
+     */
+    protected $_defaultConfig = [
+        'connections' => [],
+    ];
+
+    /**
      * Returns a list of all events that will fire in the controller during its lifecycle.
      * You can override this function to add you own listener callbacks
      *
@@ -50,7 +59,9 @@ class ApiQueryLogListener extends BaseListener
      */
     public function setupLogging(EventInterface $event): void
     {
-        foreach ($this->_getSources() as $connectionName) {
+        $connections = $this->getConfig('connections') ?: $this->_getSources();
+
+        foreach ($connections as $connectionName) {
             try {
                 $connection = $this->_getSource($connectionName);
                 $connection->enableQueryLogging(true);

--- a/tests/TestCase/Action/AddActionTest.php
+++ b/tests/TestCase/Action/AddActionTest.php
@@ -85,7 +85,7 @@ class AddActionTest extends IntegrationTestCase
             'Controller.initialize',
             ['priority' => 11],
             function ($event) {
-                $this->_controller->Flash = $this->getMockBuilder('Cake\Controller\Component\FlashComponent')
+                $this->_controller->Flash = $this->getMockBuilder(\Cake\Controller\Component\FlashComponent::class)
                     ->setMethods(['set'])
                     ->disableOriginalConstructor()
                     ->getMock();
@@ -130,7 +130,7 @@ class AddActionTest extends IntegrationTestCase
             'Controller.initialize',
             ['priority' => 11],
             function ($event) {
-                $this->_controller->Flash = $this->getMockBuilder('Cake\Controller\Component\FlashComponent')
+                $this->_controller->Flash = $this->getMockBuilder(\Cake\Controller\Component\FlashComponent::class)
                     ->setMethods(['set'])
                     ->disableOriginalConstructor()
                     ->getMock();
@@ -175,7 +175,7 @@ class AddActionTest extends IntegrationTestCase
             'Controller.initialize',
             ['priority' => 11],
             function ($event) {
-                $this->_controller->Flash = $this->getMockBuilder('Cake\Controller\Component\FlashComponent')
+                $this->_controller->Flash = $this->getMockBuilder(\Cake\Controller\Component\FlashComponent::class)
                     ->setMethods(['set'])
                     ->disableOriginalConstructor()
                     ->getMock();
@@ -219,7 +219,7 @@ class AddActionTest extends IntegrationTestCase
             'Controller.initialize',
             ['priority' => 11],
             function ($event) {
-                $this->_controller->Flash = $this->getMockBuilder('Cake\Controller\Component\FlashComponent')
+                $this->_controller->Flash = $this->getMockBuilder(\Cake\Controller\Component\FlashComponent::class)
                     ->setMethods(['set'])
                     ->disableOriginalConstructor()
                     ->getMock();
@@ -272,7 +272,7 @@ class AddActionTest extends IntegrationTestCase
             'Controller.initialize',
             ['priority' => 11],
             function ($event) {
-                $this->_controller->Flash = $this->getMockBuilder('Cake\Controller\Component\FlashComponent')
+                $this->_controller->Flash = $this->getMockBuilder(\Cake\Controller\Component\FlashComponent::class)
                     ->setMethods(['set'])
                     ->disableOriginalConstructor()
                     ->getMock();
@@ -380,7 +380,7 @@ class AddActionTest extends IntegrationTestCase
             'Controller.initialize',
             ['priority' => 11],
             function ($event) {
-                $this->_controller->Flash = $this->getMockBuilder('Cake\Controller\Component\FlashComponent')
+                $this->_controller->Flash = $this->getMockBuilder(\Cake\Controller\Component\FlashComponent::class)
                     ->setMethods(['set'])
                     ->disableOriginalConstructor()
                     ->getMock();
@@ -425,7 +425,7 @@ class AddActionTest extends IntegrationTestCase
                     return;
                 }
 
-                $this->_controller->Flash = $this->getMockBuilder('Cake\Controller\Component\FlashComponent')
+                $this->_controller->Flash = $this->getMockBuilder(\Cake\Controller\Component\FlashComponent::class)
                     ->setMethods(['set'])
                     ->disableOriginalConstructor()
                     ->getMock();
@@ -477,7 +477,7 @@ class AddActionTest extends IntegrationTestCase
                     return;
                 }
 
-                $this->_controller->Flash = $this->getMockBuilder('Cake\Controller\Component\FlashComponent')
+                $this->_controller->Flash = $this->getMockBuilder(\Cake\Controller\Component\FlashComponent::class)
                     ->setMethods(['set'])
                     ->disableOriginalConstructor()
                     ->getMock();
@@ -523,7 +523,7 @@ class AddActionTest extends IntegrationTestCase
             'Controller.initialize',
             ['priority' => 11],
             function ($event) {
-                $this->_controller->Flash = $this->getMockBuilder('Cake\Controller\Component\FlashComponent')
+                $this->_controller->Flash = $this->getMockBuilder(\Cake\Controller\Component\FlashComponent::class)
                     ->setMethods(['set'])
                     ->disableOriginalConstructor()
                     ->getMock();
@@ -573,7 +573,7 @@ class AddActionTest extends IntegrationTestCase
             'Controller.initialize',
             ['priority' => 11],
             function ($event) {
-                $this->_controller->Flash = $this->getMockBuilder('Cake\Controller\Component\FlashComponent')
+                $this->_controller->Flash = $this->getMockBuilder(\Cake\Controller\Component\FlashComponent::class)
                     ->setMethods(['set'])
                     ->disableOriginalConstructor()
                     ->getMock();

--- a/tests/TestCase/Action/AddActionTest.php
+++ b/tests/TestCase/Action/AddActionTest.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Crud\Test\TestCase\Action;
 
+use Cake\Controller\Component\FlashComponent;
 use Cake\Routing\Router;
 use Crud\TestSuite\IntegrationTestCase;
 
@@ -85,7 +86,7 @@ class AddActionTest extends IntegrationTestCase
             'Controller.initialize',
             ['priority' => 11],
             function ($event) {
-                $this->_controller->Flash = $this->getMockBuilder(\Cake\Controller\Component\FlashComponent::class)
+                $this->_controller->Flash = $this->getMockBuilder(FlashComponent::class)
                     ->setMethods(['set'])
                     ->disableOriginalConstructor()
                     ->getMock();
@@ -130,7 +131,7 @@ class AddActionTest extends IntegrationTestCase
             'Controller.initialize',
             ['priority' => 11],
             function ($event) {
-                $this->_controller->Flash = $this->getMockBuilder(\Cake\Controller\Component\FlashComponent::class)
+                $this->_controller->Flash = $this->getMockBuilder(FlashComponent::class)
                     ->setMethods(['set'])
                     ->disableOriginalConstructor()
                     ->getMock();
@@ -175,7 +176,7 @@ class AddActionTest extends IntegrationTestCase
             'Controller.initialize',
             ['priority' => 11],
             function ($event) {
-                $this->_controller->Flash = $this->getMockBuilder(\Cake\Controller\Component\FlashComponent::class)
+                $this->_controller->Flash = $this->getMockBuilder(FlashComponent::class)
                     ->setMethods(['set'])
                     ->disableOriginalConstructor()
                     ->getMock();
@@ -219,7 +220,7 @@ class AddActionTest extends IntegrationTestCase
             'Controller.initialize',
             ['priority' => 11],
             function ($event) {
-                $this->_controller->Flash = $this->getMockBuilder(\Cake\Controller\Component\FlashComponent::class)
+                $this->_controller->Flash = $this->getMockBuilder(FlashComponent::class)
                     ->setMethods(['set'])
                     ->disableOriginalConstructor()
                     ->getMock();
@@ -272,7 +273,7 @@ class AddActionTest extends IntegrationTestCase
             'Controller.initialize',
             ['priority' => 11],
             function ($event) {
-                $this->_controller->Flash = $this->getMockBuilder(\Cake\Controller\Component\FlashComponent::class)
+                $this->_controller->Flash = $this->getMockBuilder(FlashComponent::class)
                     ->setMethods(['set'])
                     ->disableOriginalConstructor()
                     ->getMock();
@@ -380,7 +381,7 @@ class AddActionTest extends IntegrationTestCase
             'Controller.initialize',
             ['priority' => 11],
             function ($event) {
-                $this->_controller->Flash = $this->getMockBuilder(\Cake\Controller\Component\FlashComponent::class)
+                $this->_controller->Flash = $this->getMockBuilder(FlashComponent::class)
                     ->setMethods(['set'])
                     ->disableOriginalConstructor()
                     ->getMock();
@@ -425,7 +426,7 @@ class AddActionTest extends IntegrationTestCase
                     return;
                 }
 
-                $this->_controller->Flash = $this->getMockBuilder(\Cake\Controller\Component\FlashComponent::class)
+                $this->_controller->Flash = $this->getMockBuilder(FlashComponent::class)
                     ->setMethods(['set'])
                     ->disableOriginalConstructor()
                     ->getMock();
@@ -477,7 +478,7 @@ class AddActionTest extends IntegrationTestCase
                     return;
                 }
 
-                $this->_controller->Flash = $this->getMockBuilder(\Cake\Controller\Component\FlashComponent::class)
+                $this->_controller->Flash = $this->getMockBuilder(FlashComponent::class)
                     ->setMethods(['set'])
                     ->disableOriginalConstructor()
                     ->getMock();
@@ -523,7 +524,7 @@ class AddActionTest extends IntegrationTestCase
             'Controller.initialize',
             ['priority' => 11],
             function ($event) {
-                $this->_controller->Flash = $this->getMockBuilder(\Cake\Controller\Component\FlashComponent::class)
+                $this->_controller->Flash = $this->getMockBuilder(FlashComponent::class)
                     ->setMethods(['set'])
                     ->disableOriginalConstructor()
                     ->getMock();
@@ -573,7 +574,7 @@ class AddActionTest extends IntegrationTestCase
             'Controller.initialize',
             ['priority' => 11],
             function ($event) {
-                $this->_controller->Flash = $this->getMockBuilder(\Cake\Controller\Component\FlashComponent::class)
+                $this->_controller->Flash = $this->getMockBuilder(FlashComponent::class)
                     ->setMethods(['set'])
                     ->disableOriginalConstructor()
                     ->getMock();

--- a/tests/TestCase/Action/BaseActionTest.php
+++ b/tests/TestCase/Action/BaseActionTest.php
@@ -25,7 +25,7 @@ class BaseActionTest extends TestCase
 
         $this->Request = $this->getMockBuilder(ServerRequest::class)
             ->getMock();
-        $this->Controller = $this->getMockBuilder('Cake\Controller\Controller')
+        $this->Controller = $this->getMockBuilder(\Cake\Controller\Controller::class)
             ->setMethods(['set'])
             ->setConstructorArgs([
                 $this->Request,
@@ -35,7 +35,7 @@ class BaseActionTest extends TestCase
             ])
             ->getMock();
         $this->Registry = $this->Controller->components();
-        $this->Crud = $this->getMockBuilder('Crud\Controller\Component\CrudComponent')
+        $this->Crud = $this->getMockBuilder(\Crud\Controller\Component\CrudComponent::class)
             ->setConstructorArgs([$this->Registry])
             ->setMethods(['foobar'])
             ->getMock();
@@ -142,7 +142,7 @@ class BaseActionTest extends TestCase
             ->method('getMethod')
             ->will($this->returnValue('GET'));
 
-        $Action = $this->getMockBuilder('Crud\Action\BaseAction')
+        $Action = $this->getMockBuilder(\Crud\Action\BaseAction::class)
             ->setMethods(['_request', '_get'])
             ->setConstructorArgs([$this->Controller])
             ->getMock();
@@ -180,7 +180,7 @@ class BaseActionTest extends TestCase
     {
         $i = 0;
 
-        $Action = $this->getMockBuilder('Crud\Action\BaseAction')
+        $Action = $this->getMockBuilder(\Crud\Action\BaseAction::class)
             ->setMethods(['setConfig'])
             ->setConstructorArgs([$this->Controller])
             ->getMock();
@@ -204,7 +204,7 @@ class BaseActionTest extends TestCase
     {
         $i = 0;
 
-        $Action = $this->getMockBuilder('Crud\Action\BaseAction')
+        $Action = $this->getMockBuilder(\Crud\Action\BaseAction::class)
             ->setMethods(['setConfig'])
             ->setConstructorArgs([$this->Controller])
             ->getMock();
@@ -237,7 +237,7 @@ class BaseActionTest extends TestCase
 
         $Subject = new Subject();
 
-        $this->Controller->Crud = $this->getMockBuilder('Crud\Controller\Component\CrudComponent')
+        $this->Controller->Crud = $this->getMockBuilder(\Crud\Controller\Component\CrudComponent::class)
             ->setMethods(['trigger'])
             ->setConstructorArgs([$this->Registry])
             ->getMock();
@@ -247,7 +247,7 @@ class BaseActionTest extends TestCase
             ->with('setFlash', $Subject)
             ->will($this->returnValue(new \Cake\Event\Event('Crud.setFlash')));
 
-        $this->Controller->Flash = $this->getMockBuilder('Cake\Controller\Component\FlashComponent')
+        $this->Controller->Flash = $this->getMockBuilder(\Cake\Controller\Component\FlashComponent::class)
             ->setMethods(['set'])
             ->setConstructorArgs([$this->Registry])
             ->getMock();
@@ -508,7 +508,7 @@ class BaseActionTest extends TestCase
      */
     public function testHandle()
     {
-        $Action = $this->getMockBuilder('Crud\Action\BaseAction')
+        $Action = $this->getMockBuilder(\Crud\Action\BaseAction::class)
             ->setMethods(['_request', '_get', 'getConfig'])
             ->setConstructorArgs([$this->Controller])
             ->getMock();
@@ -548,7 +548,7 @@ class BaseActionTest extends TestCase
      */
     public function testHandleDisabled()
     {
-        $Action = $this->getMockBuilder('Crud\Action\BaseAction')
+        $Action = $this->getMockBuilder(\Crud\Action\BaseAction::class)
             ->setMethods(['_handle', '_get', 'getConfig'])
             ->setConstructorArgs([$this->Controller])
             ->getMock();
@@ -576,7 +576,7 @@ class BaseActionTest extends TestCase
      */
     public function testGenericHandle()
     {
-        $Action = $this->getMockBuilder('Crud\Action\BaseAction')
+        $Action = $this->getMockBuilder(\Crud\Action\BaseAction::class)
             ->setMethods(['_handle', '_request', 'getConfig'])
             ->setConstructorArgs([$this->Controller])
             ->getMock();
@@ -618,7 +618,7 @@ class BaseActionTest extends TestCase
     {
         $this->expectException(NotImplementedException::class);
 
-        $Action = $this->getMockBuilder('Crud\Action\BaseAction')
+        $Action = $this->getMockBuilder(\Crud\Action\BaseAction::class)
             ->setMethods(['_request', 'getConfig'])
             ->setConstructorArgs([$this->Controller])
             ->getMock();

--- a/tests/TestCase/Action/BaseActionTest.php
+++ b/tests/TestCase/Action/BaseActionTest.php
@@ -3,6 +3,10 @@ declare(strict_types=1);
 
 namespace Crud\TestCase\Action;
 
+use Cake\Controller\Component\FlashComponent;
+use Cake\Controller\Controller;
+use Cake\Event\Event;
+use Cake\Event\EventManager;
 use Cake\Http\Exception\BadRequestException;
 use Cake\Http\Exception\MethodNotAllowedException;
 use Cake\Http\Exception\NotFoundException;
@@ -10,8 +14,11 @@ use Cake\Http\Exception\NotImplementedException;
 use Cake\Http\Response;
 use Cake\Http\ServerRequest;
 use Cake\ORM\TableRegistry;
+use Crud\Action\BaseAction;
+use Crud\Controller\Component\CrudComponent;
 use Crud\Event\Subject;
 use Crud\TestSuite\TestCase;
+use Exception;
 
 /**
  * Licensed under The MIT License
@@ -25,23 +32,23 @@ class BaseActionTest extends TestCase
 
         $this->Request = $this->getMockBuilder(ServerRequest::class)
             ->getMock();
-        $this->Controller = $this->getMockBuilder(\Cake\Controller\Controller::class)
+        $this->Controller = $this->getMockBuilder(Controller::class)
             ->setMethods(['set'])
             ->setConstructorArgs([
                 $this->Request,
                 new Response(),
                 'CrudExamples',
-                \Cake\Event\EventManager::instance(),
+                EventManager::instance(),
             ])
             ->getMock();
         $this->Registry = $this->Controller->components();
-        $this->Crud = $this->getMockBuilder(\Crud\Controller\Component\CrudComponent::class)
+        $this->Crud = $this->getMockBuilder(CrudComponent::class)
             ->setConstructorArgs([$this->Registry])
             ->setMethods(['foobar'])
             ->getMock();
         $this->Controller->Crud = $this->Crud;
         $this->Controller->modelClass = 'CrudExamples';
-        $this->Controller->CrudExamples = \Cake\ORM\TableRegistry::get('Crud.CrudExamples');
+        $this->Controller->CrudExamples = TableRegistry::get('Crud.CrudExamples');
         $this->Controller->CrudExamples->setAlias('MyModel');
 
         $this->actionClassName = $this->getMockClass('Crud\Action\BaseAction', ['_handle']);
@@ -142,7 +149,7 @@ class BaseActionTest extends TestCase
             ->method('getMethod')
             ->will($this->returnValue('GET'));
 
-        $Action = $this->getMockBuilder(\Crud\Action\BaseAction::class)
+        $Action = $this->getMockBuilder(BaseAction::class)
             ->setMethods(['_request', '_get'])
             ->setConstructorArgs([$this->Controller])
             ->getMock();
@@ -180,7 +187,7 @@ class BaseActionTest extends TestCase
     {
         $i = 0;
 
-        $Action = $this->getMockBuilder(\Crud\Action\BaseAction::class)
+        $Action = $this->getMockBuilder(BaseAction::class)
             ->setMethods(['setConfig'])
             ->setConstructorArgs([$this->Controller])
             ->getMock();
@@ -204,7 +211,7 @@ class BaseActionTest extends TestCase
     {
         $i = 0;
 
-        $Action = $this->getMockBuilder(\Crud\Action\BaseAction::class)
+        $Action = $this->getMockBuilder(BaseAction::class)
             ->setMethods(['setConfig'])
             ->setConstructorArgs([$this->Controller])
             ->getMock();
@@ -237,7 +244,7 @@ class BaseActionTest extends TestCase
 
         $Subject = new Subject();
 
-        $this->Controller->Crud = $this->getMockBuilder(\Crud\Controller\Component\CrudComponent::class)
+        $this->Controller->Crud = $this->getMockBuilder(CrudComponent::class)
             ->setMethods(['trigger'])
             ->setConstructorArgs([$this->Registry])
             ->getMock();
@@ -245,9 +252,9 @@ class BaseActionTest extends TestCase
             ->expects($this->once())
             ->method('trigger')
             ->with('setFlash', $Subject)
-            ->will($this->returnValue(new \Cake\Event\Event('Crud.setFlash')));
+            ->will($this->returnValue(new Event('Crud.setFlash')));
 
-        $this->Controller->Flash = $this->getMockBuilder(\Cake\Controller\Component\FlashComponent::class)
+        $this->Controller->Flash = $this->getMockBuilder(FlashComponent::class)
             ->setMethods(['set'])
             ->setConstructorArgs([$this->Registry])
             ->getMock();
@@ -311,7 +318,7 @@ class BaseActionTest extends TestCase
      */
     public function testUndefinedMessage()
     {
-        $this->expectException(\Exception::class);
+        $this->expectException(Exception::class);
         $this->expectExceptionMessage('Invalid message type "not defined"');
 
         $this->ActionClass->message('not defined');
@@ -322,7 +329,7 @@ class BaseActionTest extends TestCase
      */
     public function testBadMessageConfig()
     {
-        $this->expectException(\Exception::class);
+        $this->expectException(Exception::class);
         $this->expectExceptionMessage('Invalid message config for "badConfig" no text key found');
 
         $this->Crud->setConfig('messages.badConfig', ['foo' => 'bar']);
@@ -508,7 +515,7 @@ class BaseActionTest extends TestCase
      */
     public function testHandle()
     {
-        $Action = $this->getMockBuilder(\Crud\Action\BaseAction::class)
+        $Action = $this->getMockBuilder(BaseAction::class)
             ->setMethods(['_request', '_get', 'getConfig'])
             ->setConstructorArgs([$this->Controller])
             ->getMock();
@@ -548,7 +555,7 @@ class BaseActionTest extends TestCase
      */
     public function testHandleDisabled()
     {
-        $Action = $this->getMockBuilder(\Crud\Action\BaseAction::class)
+        $Action = $this->getMockBuilder(BaseAction::class)
             ->setMethods(['_handle', '_get', 'getConfig'])
             ->setConstructorArgs([$this->Controller])
             ->getMock();
@@ -576,7 +583,7 @@ class BaseActionTest extends TestCase
      */
     public function testGenericHandle()
     {
-        $Action = $this->getMockBuilder(\Crud\Action\BaseAction::class)
+        $Action = $this->getMockBuilder(BaseAction::class)
             ->setMethods(['_handle', '_request', 'getConfig'])
             ->setConstructorArgs([$this->Controller])
             ->getMock();
@@ -618,7 +625,7 @@ class BaseActionTest extends TestCase
     {
         $this->expectException(NotImplementedException::class);
 
-        $Action = $this->getMockBuilder(\Crud\Action\BaseAction::class)
+        $Action = $this->getMockBuilder(BaseAction::class)
             ->setMethods(['_request', 'getConfig'])
             ->setConstructorArgs([$this->Controller])
             ->getMock();

--- a/tests/TestCase/Action/Bulk/DeleteActionTest.php
+++ b/tests/TestCase/Action/Bulk/DeleteActionTest.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Crud\Test\TestCase\Action\Bulk;
 
+use Cake\Controller\Component\FlashComponent;
 use Crud\TestSuite\IntegrationTestCase;
 
 /**
@@ -53,7 +54,7 @@ class DeleteActionTest extends IntegrationTestCase
             'Controller.initialize',
             ['priority' => 11],
             function ($event) {
-                $this->_controller->Flash = $this->getMockBuilder(\Cake\Controller\Component\FlashComponent::class)
+                $this->_controller->Flash = $this->getMockBuilder(FlashComponent::class)
                     ->setMethods(['set'])
                     ->disableOriginalConstructor()
                     ->getMock();
@@ -97,7 +98,7 @@ class DeleteActionTest extends IntegrationTestCase
             'Controller.initialize',
             ['priority' => 11],
             function ($event) {
-                $this->_controller->Flash = $this->getMockBuilder(\Cake\Controller\Component\FlashComponent::class)
+                $this->_controller->Flash = $this->getMockBuilder(FlashComponent::class)
                     ->setMethods(['set'])
                     ->disableOriginalConstructor()
                     ->getMock();
@@ -145,7 +146,7 @@ class DeleteActionTest extends IntegrationTestCase
             'Controller.initialize',
             ['priority' => 11],
             function ($event) {
-                $this->_controller->Flash = $this->getMockBuilder(\Cake\Controller\Component\FlashComponent::class)
+                $this->_controller->Flash = $this->getMockBuilder(FlashComponent::class)
                     ->setMethods(['set'])
                     ->disableOriginalConstructor()
                     ->getMock();

--- a/tests/TestCase/Action/Bulk/DeleteActionTest.php
+++ b/tests/TestCase/Action/Bulk/DeleteActionTest.php
@@ -53,7 +53,7 @@ class DeleteActionTest extends IntegrationTestCase
             'Controller.initialize',
             ['priority' => 11],
             function ($event) {
-                $this->_controller->Flash = $this->getMockBuilder('Cake\Controller\Component\FlashComponent')
+                $this->_controller->Flash = $this->getMockBuilder(\Cake\Controller\Component\FlashComponent::class)
                     ->setMethods(['set'])
                     ->disableOriginalConstructor()
                     ->getMock();
@@ -97,7 +97,7 @@ class DeleteActionTest extends IntegrationTestCase
             'Controller.initialize',
             ['priority' => 11],
             function ($event) {
-                $this->_controller->Flash = $this->getMockBuilder('Cake\Controller\Component\FlashComponent')
+                $this->_controller->Flash = $this->getMockBuilder(\Cake\Controller\Component\FlashComponent::class)
                     ->setMethods(['set'])
                     ->disableOriginalConstructor()
                     ->getMock();
@@ -145,7 +145,7 @@ class DeleteActionTest extends IntegrationTestCase
             'Controller.initialize',
             ['priority' => 11],
             function ($event) {
-                $this->_controller->Flash = $this->getMockBuilder('Cake\Controller\Component\FlashComponent')
+                $this->_controller->Flash = $this->getMockBuilder(\Cake\Controller\Component\FlashComponent::class)
                     ->setMethods(['set'])
                     ->disableOriginalConstructor()
                     ->getMock();

--- a/tests/TestCase/Action/Bulk/SetValueActionTest.php
+++ b/tests/TestCase/Action/Bulk/SetValueActionTest.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Crud\Test\TestCase\Action\Bulk;
 
+use Cake\Controller\Component\FlashComponent;
 use Crud\TestSuite\IntegrationTestCase;
 
 /**
@@ -53,7 +54,7 @@ class SetValueActionTest extends IntegrationTestCase
             'Controller.initialize',
             ['priority' => 11],
             function ($event) {
-                $this->_controller->Flash = $this->getMockBuilder(\Cake\Controller\Component\FlashComponent::class)
+                $this->_controller->Flash = $this->getMockBuilder(FlashComponent::class)
                     ->setMethods(['set'])
                     ->disableOriginalConstructor()
                     ->getMock();
@@ -97,7 +98,7 @@ class SetValueActionTest extends IntegrationTestCase
             'Controller.initialize',
             ['priority' => 11],
             function ($event) {
-                $this->_controller->Flash = $this->getMockBuilder(\Cake\Controller\Component\FlashComponent::class)
+                $this->_controller->Flash = $this->getMockBuilder(FlashComponent::class)
                     ->setMethods(['set'])
                     ->disableOriginalConstructor()
                     ->getMock();
@@ -145,7 +146,7 @@ class SetValueActionTest extends IntegrationTestCase
             'Controller.initialize',
             ['priority' => 11],
             function ($event) {
-                $this->_controller->Flash = $this->getMockBuilder(\Cake\Controller\Component\FlashComponent::class)
+                $this->_controller->Flash = $this->getMockBuilder(FlashComponent::class)
                     ->setMethods(['set'])
                     ->disableOriginalConstructor()
                     ->getMock();

--- a/tests/TestCase/Action/Bulk/SetValueActionTest.php
+++ b/tests/TestCase/Action/Bulk/SetValueActionTest.php
@@ -53,7 +53,7 @@ class SetValueActionTest extends IntegrationTestCase
             'Controller.initialize',
             ['priority' => 11],
             function ($event) {
-                $this->_controller->Flash = $this->getMockBuilder('Cake\Controller\Component\FlashComponent')
+                $this->_controller->Flash = $this->getMockBuilder(\Cake\Controller\Component\FlashComponent::class)
                     ->setMethods(['set'])
                     ->disableOriginalConstructor()
                     ->getMock();
@@ -97,7 +97,7 @@ class SetValueActionTest extends IntegrationTestCase
             'Controller.initialize',
             ['priority' => 11],
             function ($event) {
-                $this->_controller->Flash = $this->getMockBuilder('Cake\Controller\Component\FlashComponent')
+                $this->_controller->Flash = $this->getMockBuilder(\Cake\Controller\Component\FlashComponent::class)
                     ->setMethods(['set'])
                     ->disableOriginalConstructor()
                     ->getMock();
@@ -145,7 +145,7 @@ class SetValueActionTest extends IntegrationTestCase
             'Controller.initialize',
             ['priority' => 11],
             function ($event) {
-                $this->_controller->Flash = $this->getMockBuilder('Cake\Controller\Component\FlashComponent')
+                $this->_controller->Flash = $this->getMockBuilder(\Cake\Controller\Component\FlashComponent::class)
                     ->setMethods(['set'])
                     ->disableOriginalConstructor()
                     ->getMock();

--- a/tests/TestCase/Action/Bulk/ToggleActionTest.php
+++ b/tests/TestCase/Action/Bulk/ToggleActionTest.php
@@ -53,7 +53,7 @@ class ToggleActionTest extends IntegrationTestCase
             'Controller.initialize',
             ['priority' => 11],
             function ($event) {
-                $this->_controller->Flash = $this->getMockBuilder('Cake\Controller\Component\FlashComponent')
+                $this->_controller->Flash = $this->getMockBuilder(\Cake\Controller\Component\FlashComponent::class)
                     ->setMethods(['set'])
                     ->disableOriginalConstructor()
                     ->getMock();
@@ -97,7 +97,7 @@ class ToggleActionTest extends IntegrationTestCase
             'Controller.initialize',
             ['priority' => 11],
             function ($event) {
-                $this->_controller->Flash = $this->getMockBuilder('Cake\Controller\Component\FlashComponent')
+                $this->_controller->Flash = $this->getMockBuilder(\Cake\Controller\Component\FlashComponent::class)
                     ->setMethods(['set'])
                     ->disableOriginalConstructor()
                     ->getMock();
@@ -145,7 +145,7 @@ class ToggleActionTest extends IntegrationTestCase
             'Controller.initialize',
             ['priority' => 11],
             function ($event) {
-                $this->_controller->Flash = $this->getMockBuilder('Cake\Controller\Component\FlashComponent')
+                $this->_controller->Flash = $this->getMockBuilder(\Cake\Controller\Component\FlashComponent::class)
                     ->setMethods(['set'])
                     ->disableOriginalConstructor()
                     ->getMock();

--- a/tests/TestCase/Action/Bulk/ToggleActionTest.php
+++ b/tests/TestCase/Action/Bulk/ToggleActionTest.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Crud\Test\TestCase\Action\Bulk;
 
+use Cake\Controller\Component\FlashComponent;
 use Crud\TestSuite\IntegrationTestCase;
 
 /**
@@ -53,7 +54,7 @@ class ToggleActionTest extends IntegrationTestCase
             'Controller.initialize',
             ['priority' => 11],
             function ($event) {
-                $this->_controller->Flash = $this->getMockBuilder(\Cake\Controller\Component\FlashComponent::class)
+                $this->_controller->Flash = $this->getMockBuilder(FlashComponent::class)
                     ->setMethods(['set'])
                     ->disableOriginalConstructor()
                     ->getMock();
@@ -97,7 +98,7 @@ class ToggleActionTest extends IntegrationTestCase
             'Controller.initialize',
             ['priority' => 11],
             function ($event) {
-                $this->_controller->Flash = $this->getMockBuilder(\Cake\Controller\Component\FlashComponent::class)
+                $this->_controller->Flash = $this->getMockBuilder(FlashComponent::class)
                     ->setMethods(['set'])
                     ->disableOriginalConstructor()
                     ->getMock();
@@ -145,7 +146,7 @@ class ToggleActionTest extends IntegrationTestCase
             'Controller.initialize',
             ['priority' => 11],
             function ($event) {
-                $this->_controller->Flash = $this->getMockBuilder(\Cake\Controller\Component\FlashComponent::class)
+                $this->_controller->Flash = $this->getMockBuilder(FlashComponent::class)
                     ->setMethods(['set'])
                     ->disableOriginalConstructor()
                     ->getMock();

--- a/tests/TestCase/Action/DeleteActionTest.php
+++ b/tests/TestCase/Action/DeleteActionTest.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Crud\Test\TestCase\Action;
 
+use Cake\Controller\Component\FlashComponent;
 use Crud\TestSuite\IntegrationTestCase;
 
 /**
@@ -50,7 +51,7 @@ class DeleteActionTest extends IntegrationTestCase
             'Controller.initialize',
             ['priority' => 11],
             function ($event) {
-                $this->_controller->Flash = $this->getMockBuilder(\Cake\Controller\Component\FlashComponent::class)
+                $this->_controller->Flash = $this->getMockBuilder(FlashComponent::class)
                     ->setMethods(['set'])
                     ->disableOriginalConstructor()
                     ->getMock();
@@ -100,7 +101,7 @@ class DeleteActionTest extends IntegrationTestCase
             'Controller.initialize',
             ['priority' => 11],
             function ($event) {
-                $this->_controller->Flash = $this->getMockBuilder(\Cake\Controller\Component\FlashComponent::class)
+                $this->_controller->Flash = $this->getMockBuilder(FlashComponent::class)
                     ->setMethods(['set'])
                     ->disableOriginalConstructor()
                     ->getMock();
@@ -154,7 +155,7 @@ class DeleteActionTest extends IntegrationTestCase
             'Controller.initialize',
             ['priority' => 11],
             function ($event) {
-                $this->_controller->Flash = $this->getMockBuilder(\Cake\Controller\Component\FlashComponent::class)
+                $this->_controller->Flash = $this->getMockBuilder(FlashComponent::class)
                     ->setMethods(['set'])
                     ->disableOriginalConstructor()
                     ->getMock();

--- a/tests/TestCase/Action/DeleteActionTest.php
+++ b/tests/TestCase/Action/DeleteActionTest.php
@@ -50,7 +50,7 @@ class DeleteActionTest extends IntegrationTestCase
             'Controller.initialize',
             ['priority' => 11],
             function ($event) {
-                $this->_controller->Flash = $this->getMockBuilder('Cake\Controller\Component\FlashComponent')
+                $this->_controller->Flash = $this->getMockBuilder(\Cake\Controller\Component\FlashComponent::class)
                     ->setMethods(['set'])
                     ->disableOriginalConstructor()
                     ->getMock();
@@ -100,7 +100,7 @@ class DeleteActionTest extends IntegrationTestCase
             'Controller.initialize',
             ['priority' => 11],
             function ($event) {
-                $this->_controller->Flash = $this->getMockBuilder('Cake\Controller\Component\FlashComponent')
+                $this->_controller->Flash = $this->getMockBuilder(\Cake\Controller\Component\FlashComponent::class)
                     ->setMethods(['set'])
                     ->disableOriginalConstructor()
                     ->getMock();
@@ -154,7 +154,7 @@ class DeleteActionTest extends IntegrationTestCase
             'Controller.initialize',
             ['priority' => 11],
             function ($event) {
-                $this->_controller->Flash = $this->getMockBuilder('Cake\Controller\Component\FlashComponent')
+                $this->_controller->Flash = $this->getMockBuilder(\Cake\Controller\Component\FlashComponent::class)
                     ->setMethods(['set'])
                     ->disableOriginalConstructor()
                     ->getMock();

--- a/tests/TestCase/Action/EditActionTest.php
+++ b/tests/TestCase/Action/EditActionTest.php
@@ -104,7 +104,7 @@ class EditActionTest extends IntegrationTestCase
             'Controller.initialize',
             ['priority' => 11],
             function ($event) {
-                $this->_controller->Flash = $this->getMockBuilder('Cake\Controller\Component\FlashComponent')
+                $this->_controller->Flash = $this->getMockBuilder(\Cake\Controller\Component\FlashComponent::class)
                     ->setMethods(['set'])
                     ->disableOriginalConstructor()
                     ->getMock();
@@ -147,7 +147,7 @@ class EditActionTest extends IntegrationTestCase
             'Controller.initialize',
             ['priority' => 11],
             function ($event) {
-                $this->_controller->Flash = $this->getMockBuilder('Cake\Controller\Component\FlashComponent')
+                $this->_controller->Flash = $this->getMockBuilder(\Cake\Controller\Component\FlashComponent::class)
                     ->setMethods(['set'])
                     ->disableOriginalConstructor()
                     ->getMock();
@@ -200,7 +200,7 @@ class EditActionTest extends IntegrationTestCase
             'Controller.initialize',
             ['priority' => 11],
             function ($event) {
-                $this->_controller->Flash = $this->getMockBuilder('Cake\Controller\Component\FlashComponent')
+                $this->_controller->Flash = $this->getMockBuilder(\Cake\Controller\Component\FlashComponent::class)
                     ->setMethods(['set'])
                     ->disableOriginalConstructor()
                     ->getMock();
@@ -260,7 +260,7 @@ class EditActionTest extends IntegrationTestCase
             'Controller.initialize',
             ['priority' => 11],
             function ($event) {
-                $this->_controller->Flash = $this->getMockBuilder('Cake\Controller\Component\FlashComponent')
+                $this->_controller->Flash = $this->getMockBuilder(\Cake\Controller\Component\FlashComponent::class)
                     ->setMethods(['set'])
                     ->disableOriginalConstructor()
                     ->getMock();

--- a/tests/TestCase/Action/EditActionTest.php
+++ b/tests/TestCase/Action/EditActionTest.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Crud\Test\TestCase\Action;
 
+use Cake\Controller\Component\FlashComponent;
 use Crud\TestSuite\IntegrationTestCase;
 
 /**
@@ -104,7 +105,7 @@ class EditActionTest extends IntegrationTestCase
             'Controller.initialize',
             ['priority' => 11],
             function ($event) {
-                $this->_controller->Flash = $this->getMockBuilder(\Cake\Controller\Component\FlashComponent::class)
+                $this->_controller->Flash = $this->getMockBuilder(FlashComponent::class)
                     ->setMethods(['set'])
                     ->disableOriginalConstructor()
                     ->getMock();
@@ -147,7 +148,7 @@ class EditActionTest extends IntegrationTestCase
             'Controller.initialize',
             ['priority' => 11],
             function ($event) {
-                $this->_controller->Flash = $this->getMockBuilder(\Cake\Controller\Component\FlashComponent::class)
+                $this->_controller->Flash = $this->getMockBuilder(FlashComponent::class)
                     ->setMethods(['set'])
                     ->disableOriginalConstructor()
                     ->getMock();
@@ -200,7 +201,7 @@ class EditActionTest extends IntegrationTestCase
             'Controller.initialize',
             ['priority' => 11],
             function ($event) {
-                $this->_controller->Flash = $this->getMockBuilder(\Cake\Controller\Component\FlashComponent::class)
+                $this->_controller->Flash = $this->getMockBuilder(FlashComponent::class)
                     ->setMethods(['set'])
                     ->disableOriginalConstructor()
                     ->getMock();
@@ -260,7 +261,7 @@ class EditActionTest extends IntegrationTestCase
             'Controller.initialize',
             ['priority' => 11],
             function ($event) {
-                $this->_controller->Flash = $this->getMockBuilder(\Cake\Controller\Component\FlashComponent::class)
+                $this->_controller->Flash = $this->getMockBuilder(FlashComponent::class)
                     ->setMethods(['set'])
                     ->disableOriginalConstructor()
                     ->getMock();

--- a/tests/TestCase/Controller/Component/CrudComponentTest.php
+++ b/tests/TestCase/Controller/Component/CrudComponentTest.php
@@ -108,7 +108,7 @@ class CrudComponentTest extends TestCase
                 'Crud.Related',
             ],
         ];
-        $Crud = $this->getMockBuilder('Crud\Controller\Component\CrudComponent')
+        $Crud = $this->getMockBuilder(\Crud\Controller\Component\CrudComponent::class)
             ->setMethods(['_loadListeners', 'trigger'])
             ->setConstructorArgs([$this->Registry, $config])
             ->getMock();
@@ -161,7 +161,7 @@ class CrudComponentTest extends TestCase
     {
         $config = ['actions' => ['Crud.Index']];
 
-        $Crud = $this->getMockBuilder('Crud\Controller\Component\CrudComponent')
+        $Crud = $this->getMockBuilder(\Crud\Controller\Component\CrudComponent::class)
             ->setMethods(['execute'])
             ->setConstructorArgs([$this->Registry, $config])
             ->getMock();

--- a/tests/TestCase/Controller/Component/CrudComponentTest.php
+++ b/tests/TestCase/Controller/Component/CrudComponentTest.php
@@ -17,6 +17,7 @@ use Crud\Test\App\Controller\CrudExamplesController;
 use Crud\Test\App\Event\TestCrudEventManager;
 use Crud\Test\App\Listener\TestListener;
 use Crud\TestSuite\TestCase;
+use Exception;
 
 /**
  * CrudComponentTestCase
@@ -108,7 +109,7 @@ class CrudComponentTest extends TestCase
                 'Crud.Related',
             ],
         ];
-        $Crud = $this->getMockBuilder(\Crud\Controller\Component\CrudComponent::class)
+        $Crud = $this->getMockBuilder(CrudComponent::class)
             ->setMethods(['_loadListeners', 'trigger'])
             ->setConstructorArgs([$this->Registry, $config])
             ->getMock();
@@ -161,7 +162,7 @@ class CrudComponentTest extends TestCase
     {
         $config = ['actions' => ['Crud.Index']];
 
-        $Crud = $this->getMockBuilder(\Crud\Controller\Component\CrudComponent::class)
+        $Crud = $this->getMockBuilder(CrudComponent::class)
             ->setMethods(['execute'])
             ->setConstructorArgs([$this->Registry, $config])
             ->getMock();
@@ -341,7 +342,7 @@ class CrudComponentTest extends TestCase
      */
     public function testCrudWillComplainAboutUnmappedAction()
     {
-        $this->expectException(\Exception::class);
+        $this->expectException(Exception::class);
 
         $this->Crud->execute('show_all');
     }
@@ -420,7 +421,7 @@ class CrudComponentTest extends TestCase
      */
     public function testMappingNonExistentAction()
     {
-        $this->expectException(\Exception::class);
+        $this->expectException(Exception::class);
         $this->expectExceptionMessage('Could not find action class: Sample.Index');
 
         $this->Crud->mapAction('test', 'Sample.Index');

--- a/tests/TestCase/Error/ExceptionRendererTest.php
+++ b/tests/TestCase/Error/ExceptionRendererTest.php
@@ -24,13 +24,13 @@ class ExceptionRendererTest extends TestCase
     {
         $Exception = new Exception('Hello World');
 
-        $Controller = $this->getMockBuilder('Cake\Controller\Controller')
+        $Controller = $this->getMockBuilder(\Cake\Controller\Controller::class)
             ->setMethods(['render'])
             ->getMock();
         $Controller->request = new ServerRequest();
         $Controller->response = new Response();
 
-        $Renderer = $this->getMockBuilder('Crud\Error\ExceptionRenderer')
+        $Renderer = $this->getMockBuilder(\Crud\Error\ExceptionRenderer::class)
             ->setMethods(['_getController'])
             ->disableOriginalConstructor()
             ->getMock();
@@ -88,7 +88,7 @@ class ExceptionRendererTest extends TestCase
     {
         $Exception = new Exception('Hello World');
 
-        $QueryLogger = $this->getMockBuilder('Crud\Log\QueryLogger')
+        $QueryLogger = $this->getMockBuilder(\Crud\Log\QueryLogger::class)
             ->setMethods(['getLogs'])
             ->getMock();
         $currentLogger = ConnectionManager::get('test')->getLogger();
@@ -100,13 +100,13 @@ class ExceptionRendererTest extends TestCase
             ->with()
             ->will($this->returnValue(['query']));
 
-        $Controller = $this->getMockBuilder('Cake\Controller\Controller')
+        $Controller = $this->getMockBuilder(\Cake\Controller\Controller::class)
             ->setMethods(['render'])
             ->getMock();
         $Controller->request = new ServerRequest();
         $Controller->response = new Response();
 
-        $Renderer = $this->getMockBuilder('Crud\Error\ExceptionRenderer')
+        $Renderer = $this->getMockBuilder(\Crud\Error\ExceptionRenderer::class)
             ->setMethods(['_getController'])
             ->disableOriginalConstructor()
             ->getMock();
@@ -170,13 +170,13 @@ class ExceptionRendererTest extends TestCase
     {
         $Exception = new Exception('Hello World');
 
-        $Controller = $this->getMockBuilder('Cake\Controller\Controller')
+        $Controller = $this->getMockBuilder(\Cake\Controller\Controller::class)
             ->setMethods(['render'])
             ->getMock();
         $Controller->request = new ServerRequest();
         $Controller->response = new Response();
 
-        $Renderer = $this->getMockBuilder('Crud\Error\ExceptionRenderer')
+        $Renderer = $this->getMockBuilder(\Crud\Error\ExceptionRenderer::class)
             ->setMethods(['_getController'])
             ->disableOriginalConstructor()
             ->getMock();
@@ -232,7 +232,7 @@ class ExceptionRendererTest extends TestCase
     {
         $Exception = new Exception('Hello World');
 
-        $Controller = $this->getMockBuilder('Cake\Controller\Controller')
+        $Controller = $this->getMockBuilder(\Cake\Controller\Controller::class)
             ->setMethods(['render'])
             ->getMock();
         $Controller->request = new ServerRequest();
@@ -240,7 +240,7 @@ class ExceptionRendererTest extends TestCase
             ->setMethods(['send'])
             ->getMock();
 
-        $Renderer = $this->getMockBuilder('Crud\Error\ExceptionRenderer')
+        $Renderer = $this->getMockBuilder(\Crud\Error\ExceptionRenderer::class)
             ->setMethods(['_getController'])
             ->disableOriginalConstructor()
             ->getMock();
@@ -299,14 +299,14 @@ class ExceptionRendererTest extends TestCase
         $Exception = new Exception('Hello World');
         $NestedException = new Exception('Generic Exception Description');
 
-        $Controller = $this->getMockBuilder('Cake\Controller\Controller')
+        $Controller = $this->getMockBuilder(\Cake\Controller\Controller::class)
             ->setMethods(['render'])
             ->getMock();
         $Controller->request = new ServerRequest();
         $Controller->response = $this->getMockBuilder(Response::class)
             ->getMock();
 
-        $Renderer = $this->getMockBuilder('Crud\Error\ExceptionRenderer')
+        $Renderer = $this->getMockBuilder(\Crud\Error\ExceptionRenderer::class)
             ->setMethods(['_getController'])
             ->disableOriginalConstructor()
             ->getMock();
@@ -365,13 +365,13 @@ class ExceptionRendererTest extends TestCase
 
         $Exception = new ValidationException($entity);
 
-        $Controller = $this->getMockBuilder('Cake\Controller\Controller')
+        $Controller = $this->getMockBuilder(\Cake\Controller\Controller::class)
             ->setMethods(['render'])
             ->getMock();
         $Controller->request = new ServerRequest();
         $Controller->response = new Response();
 
-        $Renderer = $this->getMockBuilder('Crud\Error\ExceptionRenderer')
+        $Renderer = $this->getMockBuilder(\Crud\Error\ExceptionRenderer::class)
             ->setMethods(['_getController'])
             ->disableOriginalConstructor()
             ->getMock();
@@ -407,13 +407,13 @@ class ExceptionRendererTest extends TestCase
 
         $Exception = new ValidationException($entity);
 
-        $Controller = $this->getMockBuilder('Cake\Controller\Controller')
+        $Controller = $this->getMockBuilder(\Cake\Controller\Controller::class)
             ->setMethods(['render'])
             ->getMock();
         $Controller->request = new ServerRequest();
         $Controller->response = new Response();
 
-        $Renderer = $this->getMockBuilder('Crud\Error\ExceptionRenderer')
+        $Renderer = $this->getMockBuilder(\Crud\Error\ExceptionRenderer::class)
             ->setMethods(['_getController'])
             ->disableOriginalConstructor()
             ->getMock();
@@ -459,13 +459,13 @@ class ExceptionRendererTest extends TestCase
 
         $Exception = new ValidationException($entity);
 
-        $Controller = $this->getMockBuilder('Cake\Controller\Controller')
+        $Controller = $this->getMockBuilder(\Cake\Controller\Controller::class)
             ->setMethods(['render'])
             ->getMock();
         $Controller->request = new ServerRequest();
         $Controller->response = new Response();
 
-        $Renderer = $this->getMockBuilder('Crud\Error\ExceptionRenderer')
+        $Renderer = $this->getMockBuilder(\Crud\Error\ExceptionRenderer::class)
             ->setMethods(['_getController'])
             ->disableOriginalConstructor()
             ->getMock();

--- a/tests/TestCase/Error/ExceptionRendererTest.php
+++ b/tests/TestCase/Error/ExceptionRendererTest.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Crud\Test\TestCase\Error;
 
+use Cake\Controller\Controller;
 use Cake\Core\Configure;
 use Cake\Core\Exception\Exception;
 use Cake\Datasource\ConnectionManager;
@@ -11,6 +12,8 @@ use Cake\Http\ServerRequest;
 use Cake\ORM\Entity;
 use Cake\TestSuite\TestCase;
 use Crud\Error\Exception\ValidationException;
+use Crud\Error\ExceptionRenderer;
+use Crud\Log\QueryLogger;
 
 class ExceptionRendererTest extends TestCase
 {
@@ -24,13 +27,13 @@ class ExceptionRendererTest extends TestCase
     {
         $Exception = new Exception('Hello World');
 
-        $Controller = $this->getMockBuilder(\Cake\Controller\Controller::class)
+        $Controller = $this->getMockBuilder(Controller::class)
             ->setMethods(['render'])
             ->getMock();
         $Controller->request = new ServerRequest();
         $Controller->response = new Response();
 
-        $Renderer = $this->getMockBuilder(\Crud\Error\ExceptionRenderer::class)
+        $Renderer = $this->getMockBuilder(ExceptionRenderer::class)
             ->setMethods(['_getController'])
             ->disableOriginalConstructor()
             ->getMock();
@@ -88,7 +91,7 @@ class ExceptionRendererTest extends TestCase
     {
         $Exception = new Exception('Hello World');
 
-        $QueryLogger = $this->getMockBuilder(\Crud\Log\QueryLogger::class)
+        $QueryLogger = $this->getMockBuilder(QueryLogger::class)
             ->setMethods(['getLogs'])
             ->getMock();
         $currentLogger = ConnectionManager::get('test')->getLogger();
@@ -100,13 +103,13 @@ class ExceptionRendererTest extends TestCase
             ->with()
             ->will($this->returnValue(['query']));
 
-        $Controller = $this->getMockBuilder(\Cake\Controller\Controller::class)
+        $Controller = $this->getMockBuilder(Controller::class)
             ->setMethods(['render'])
             ->getMock();
         $Controller->request = new ServerRequest();
         $Controller->response = new Response();
 
-        $Renderer = $this->getMockBuilder(\Crud\Error\ExceptionRenderer::class)
+        $Renderer = $this->getMockBuilder(ExceptionRenderer::class)
             ->setMethods(['_getController'])
             ->disableOriginalConstructor()
             ->getMock();
@@ -170,13 +173,13 @@ class ExceptionRendererTest extends TestCase
     {
         $Exception = new Exception('Hello World');
 
-        $Controller = $this->getMockBuilder(\Cake\Controller\Controller::class)
+        $Controller = $this->getMockBuilder(Controller::class)
             ->setMethods(['render'])
             ->getMock();
         $Controller->request = new ServerRequest();
         $Controller->response = new Response();
 
-        $Renderer = $this->getMockBuilder(\Crud\Error\ExceptionRenderer::class)
+        $Renderer = $this->getMockBuilder(ExceptionRenderer::class)
             ->setMethods(['_getController'])
             ->disableOriginalConstructor()
             ->getMock();
@@ -232,7 +235,7 @@ class ExceptionRendererTest extends TestCase
     {
         $Exception = new Exception('Hello World');
 
-        $Controller = $this->getMockBuilder(\Cake\Controller\Controller::class)
+        $Controller = $this->getMockBuilder(Controller::class)
             ->setMethods(['render'])
             ->getMock();
         $Controller->request = new ServerRequest();
@@ -240,7 +243,7 @@ class ExceptionRendererTest extends TestCase
             ->setMethods(['send'])
             ->getMock();
 
-        $Renderer = $this->getMockBuilder(\Crud\Error\ExceptionRenderer::class)
+        $Renderer = $this->getMockBuilder(ExceptionRenderer::class)
             ->setMethods(['_getController'])
             ->disableOriginalConstructor()
             ->getMock();
@@ -299,14 +302,14 @@ class ExceptionRendererTest extends TestCase
         $Exception = new Exception('Hello World');
         $NestedException = new Exception('Generic Exception Description');
 
-        $Controller = $this->getMockBuilder(\Cake\Controller\Controller::class)
+        $Controller = $this->getMockBuilder(Controller::class)
             ->setMethods(['render'])
             ->getMock();
         $Controller->request = new ServerRequest();
         $Controller->response = $this->getMockBuilder(Response::class)
             ->getMock();
 
-        $Renderer = $this->getMockBuilder(\Crud\Error\ExceptionRenderer::class)
+        $Renderer = $this->getMockBuilder(ExceptionRenderer::class)
             ->setMethods(['_getController'])
             ->disableOriginalConstructor()
             ->getMock();
@@ -365,13 +368,13 @@ class ExceptionRendererTest extends TestCase
 
         $Exception = new ValidationException($entity);
 
-        $Controller = $this->getMockBuilder(\Cake\Controller\Controller::class)
+        $Controller = $this->getMockBuilder(Controller::class)
             ->setMethods(['render'])
             ->getMock();
         $Controller->request = new ServerRequest();
         $Controller->response = new Response();
 
-        $Renderer = $this->getMockBuilder(\Crud\Error\ExceptionRenderer::class)
+        $Renderer = $this->getMockBuilder(ExceptionRenderer::class)
             ->setMethods(['_getController'])
             ->disableOriginalConstructor()
             ->getMock();
@@ -407,13 +410,13 @@ class ExceptionRendererTest extends TestCase
 
         $Exception = new ValidationException($entity);
 
-        $Controller = $this->getMockBuilder(\Cake\Controller\Controller::class)
+        $Controller = $this->getMockBuilder(Controller::class)
             ->setMethods(['render'])
             ->getMock();
         $Controller->request = new ServerRequest();
         $Controller->response = new Response();
 
-        $Renderer = $this->getMockBuilder(\Crud\Error\ExceptionRenderer::class)
+        $Renderer = $this->getMockBuilder(ExceptionRenderer::class)
             ->setMethods(['_getController'])
             ->disableOriginalConstructor()
             ->getMock();
@@ -459,13 +462,13 @@ class ExceptionRendererTest extends TestCase
 
         $Exception = new ValidationException($entity);
 
-        $Controller = $this->getMockBuilder(\Cake\Controller\Controller::class)
+        $Controller = $this->getMockBuilder(Controller::class)
             ->setMethods(['render'])
             ->getMock();
         $Controller->request = new ServerRequest();
         $Controller->response = new Response();
 
-        $Renderer = $this->getMockBuilder(\Crud\Error\ExceptionRenderer::class)
+        $Renderer = $this->getMockBuilder(ExceptionRenderer::class)
             ->setMethods(['_getController'])
             ->disableOriginalConstructor()
             ->getMock();

--- a/tests/TestCase/Event/SubjectTest.php
+++ b/tests/TestCase/Event/SubjectTest.php
@@ -5,6 +5,7 @@ namespace Crud\TestCase\Event;
 
 use Crud\Event\Subject;
 use Crud\TestSuite\TestCase;
+use Exception;
 
 /**
  * Licensed under The MIT License
@@ -78,7 +79,7 @@ class SubjectTest extends TestCase
      */
     public function testInvalidMode()
     {
-        $this->expectException(\Exception::class);
+        $this->expectException(Exception::class);
         $this->expectExceptionMessage('Invalid mode');
 
         $this->Subject->shouldProcess('invalid');

--- a/tests/TestCase/Listener/ApiListenerTest.php
+++ b/tests/TestCase/Listener/ApiListenerTest.php
@@ -1176,7 +1176,7 @@ class ApiListenerTest extends TestCase
 
         $this->assertTrue(
             $request->is('api'),
-            "A request with xml extensions should be considered an api request"
+            'A request with xml extensions should be considered an api request'
         );
 
         $request = $request->withParam('_ext', null);
@@ -1184,7 +1184,7 @@ class ApiListenerTest extends TestCase
 
         $this->assertFalse(
             $request->is('api'),
-            "A request with no extensions should not be considered an api request"
+            'A request with no extensions should not be considered an api request'
         );
 
         //Ensure that no set extension will not result in a true
@@ -1193,7 +1193,7 @@ class ApiListenerTest extends TestCase
             ->method('_acceptHeaderDetector')
             ->will($this->returnValue(false));
 
-        $this->assertFalse($request->is('jsonapi'), "A request with no extensions should not be considered an jsonapi request");
+        $this->assertFalse($request->is('jsonapi'), 'A request with no extensions should not be considered an jsonapi request');
     }
 
     /**

--- a/tests/TestCase/Listener/ApiListenerTest.php
+++ b/tests/TestCase/Listener/ApiListenerTest.php
@@ -3,9 +3,21 @@ declare(strict_types=1);
 
 namespace Crud\Test\TestCase\Listener;
 
+use Cake\Controller\Component\RequestHandlerComponent;
+use Cake\Controller\Controller;
+use Cake\Event\Event;
 use Cake\Http\Response;
 use Cake\Http\ServerRequest;
+use Cake\ORM\Entity;
+use Crud\Action\AddAction;
+use Crud\Action\BaseAction;
+use Crud\Action\IndexAction;
+use Crud\Action\ViewAction;
+use Crud\Event\Subject;
+use Crud\Listener\ApiListener;
+use Crud\Test\App\Controller\BlogsController;
 use Crud\TestSuite\TestCase;
+use StdClass;
 
 /**
  * Licensed under The MIT License
@@ -21,7 +33,7 @@ class ApiListenerTest extends TestCase
     public function testImplementedEvents()
     {
         $listener = $this
-            ->getMockBuilder(\Crud\Listener\ApiListener::class)
+            ->getMockBuilder(ApiListener::class)
             ->setMethods(['setupDetectors', '_checkRequestType'])
             ->disableOriginalConstructor()
             ->getMock();
@@ -53,7 +65,7 @@ class ApiListenerTest extends TestCase
     public function testImplementedEventsWithoutApi()
     {
         $listener = $this
-            ->getMockBuilder(\Crud\Listener\ApiListener::class)
+            ->getMockBuilder(ApiListener::class)
             ->setMethods(['setupDetectors', '_checkRequestType'])
             ->disableOriginalConstructor()
             ->getMock();
@@ -79,7 +91,7 @@ class ApiListenerTest extends TestCase
     public function testBeforeHandle()
     {
         $listener = $this
-            ->getMockBuilder(\Crud\Listener\ApiListener::class)
+            ->getMockBuilder(ApiListener::class)
             ->setMethods(['_checkRequestMethods'])
             ->disableOriginalConstructor()
             ->getMock();
@@ -87,7 +99,7 @@ class ApiListenerTest extends TestCase
             ->expects($this->nextCounter($listener))
             ->method('_checkRequestMethods');
 
-        $listener->beforeHandle(new \Cake\Event\Event('Crud.beforeHandle'));
+        $listener->beforeHandle(new Event('Crud.beforeHandle'));
     }
 
     /**
@@ -98,7 +110,7 @@ class ApiListenerTest extends TestCase
     public function testResponse()
     {
         $action = $this
-            ->getMockBuilder(\Crud\Action\IndexAction::class)
+            ->getMockBuilder(IndexAction::class)
             ->disableOriginalConstructor()
             ->setMethods(['getConfig'])
             ->getMock();
@@ -109,14 +121,14 @@ class ApiListenerTest extends TestCase
             ->getMock();
 
         $subject = $this
-            ->getMockBuilder(\Crud\Event\Subject::class)
+            ->getMockBuilder(Subject::class)
             ->getMock();
         $subject->success = true;
 
-        $event = new \Cake\Event\Event('Crud.afterSave', $subject);
+        $event = new Event('Crud.afterSave', $subject);
 
         $listener = $this
-            ->getMockBuilder(\Crud\Listener\ApiListener::class)
+            ->getMockBuilder(ApiListener::class)
             ->disableOriginalConstructor()
             ->setMethods(['_action', 'render'])
             ->getMock();
@@ -152,7 +164,7 @@ class ApiListenerTest extends TestCase
     public function testResponseWithStatusCodeNotSpecified()
     {
         $action = $this
-            ->getMockBuilder(\Crud\Action\ViewAction::class)
+            ->getMockBuilder(ViewAction::class)
             ->disableOriginalConstructor()
             ->setMethods(['getConfig'])
             ->getMock();
@@ -163,14 +175,14 @@ class ApiListenerTest extends TestCase
             ->getMock();
 
         $subject = $this
-            ->getMockBuilder(\Crud\Event\Subject::class)
+            ->getMockBuilder(Subject::class)
             ->getMock();
         $subject->success = true;
 
-        $event = new \Cake\Event\Event('Crud.afterSave', $subject);
+        $event = new Event('Crud.afterSave', $subject);
 
         $listener = $this
-            ->getMockBuilder(\Crud\Listener\ApiListener::class)
+            ->getMockBuilder(ApiListener::class)
             ->disableOriginalConstructor()
             ->setMethods(['_action', 'render'])
             ->getMock();
@@ -204,21 +216,21 @@ class ApiListenerTest extends TestCase
     public function testResponseWithExceptionConfig()
     {
         $action = $this
-            ->getMockBuilder(\Crud\Action\IndexAction::class)
+            ->getMockBuilder(IndexAction::class)
             ->disableOriginalConstructor()
             ->setMethods(['getConfig'])
             ->getMock();
 
-        $subject = $this->getMockBuilder(\Crud\Event\Subject::class)
+        $subject = $this->getMockBuilder(Subject::class)
             ->getMock();
         $subject->success = true;
 
-        $event = new \Cake\Event\Event('Crud.afterSave', $subject);
+        $event = new Event('Crud.afterSave', $subject);
 
         $i = 0;
 
         $listener = $this
-            ->getMockBuilder(\Crud\Listener\ApiListener::class)
+            ->getMockBuilder(ApiListener::class)
             ->disableOriginalConstructor()
             ->setMethods(['_action', 'render', '_exceptionResponse'])
             ->getMock();
@@ -251,7 +263,7 @@ class ApiListenerTest extends TestCase
     public function testDefaultConfiguration()
     {
         $listener = $this
-            ->getMockBuilder(\Crud\Listener\ApiListener::class)
+            ->getMockBuilder(ApiListener::class)
             ->disableOriginalConstructor()
             ->setMethods(null)
             ->getMock();
@@ -357,16 +369,16 @@ class ApiListenerTest extends TestCase
         $validationErrors = []
     ) {
         $listener = $this
-            ->getMockBuilder(\Crud\Listener\ApiListener::class)
+            ->getMockBuilder(ApiListener::class)
             ->disableOriginalConstructor()
             ->setMethods(null)
             ->getMock();
 
-        $event = new \Cake\Event\Event('Crud.Exception', new \Crud\Event\Subject());
+        $event = new Event('Crud.Exception', new Subject());
 
         if (isset($apiConfig['type']) && $apiConfig['type'] === 'validate') {
             $event->getSubject()->set([
-                'entity' => $this->getMockBuilder(\Cake\ORM\Entity::class)
+                'entity' => $this->getMockBuilder(Entity::class)
                     ->setMethods(['errors'])
                     ->getMock(),
             ]);
@@ -391,19 +403,19 @@ class ApiListenerTest extends TestCase
     public function testEnsureSerializeWithViewVar()
     {
         $listener = $this
-            ->getMockBuilder(\Crud\Listener\ApiListener::class)
+            ->getMockBuilder(ApiListener::class)
             ->setMethods(['_action', '_controller'])
             ->disableOriginalConstructor()
             ->getMock();
 
         $controller = $this
-            ->getMockBuilder(\Cake\Controller\Controller::class)
+            ->getMockBuilder(Controller::class)
             ->setMethods(['set'])
             ->disableOriginalConstructor()
             ->getMock();
 
         $action = $this
-            ->getMockBuilder(\Crud\Action\IndexAction::class)
+            ->getMockBuilder(IndexAction::class)
             ->setMethods(['config', 'viewVar'])
             ->disableOriginalConstructor()
             ->getMock();
@@ -455,7 +467,7 @@ class ApiListenerTest extends TestCase
     public function testEnsureSerializeWithSerializeTrait($action)
     {
         $listener = $this
-            ->getMockBuilder(\Crud\Listener\ApiListener::class)
+            ->getMockBuilder(ApiListener::class)
             ->setMethods(['_action', '_controller'])
             ->disableOriginalConstructor()
             ->getMock();
@@ -467,7 +479,7 @@ class ApiListenerTest extends TestCase
             ->getMock();
 
         $controller = $this
-            ->getMockBuilder(\Cake\Controller\Controller::class)
+            ->getMockBuilder(Controller::class)
             ->setMethods(['set'])
             ->disableOriginalConstructor()
             ->getMock();
@@ -516,13 +528,13 @@ class ApiListenerTest extends TestCase
     public function testEnsureSerializeAlreadySet()
     {
         $listener = $this
-            ->getMockBuilder(\Crud\Listener\ApiListener::class)
+            ->getMockBuilder(ApiListener::class)
             ->setMethods(['_action', '_controller'])
             ->disableOriginalConstructor()
             ->getMock();
 
         $controller = $this
-            ->getMockBuilder(\Cake\Controller\Controller::class)
+            ->getMockBuilder(Controller::class)
             ->setMethods(['set'])
             ->disableOriginalConstructor()
             ->getMock();
@@ -530,7 +542,7 @@ class ApiListenerTest extends TestCase
         $controller->viewBuilder()->setOption('serialize', 'hello world');
 
         $action = $this
-            ->getMockBuilder(\Crud\Action\IndexAction::class)
+            ->getMockBuilder(IndexAction::class)
             ->setMethods(['config', 'viewVar'])
             ->disableOriginalConstructor()
             ->getMock();
@@ -567,19 +579,19 @@ class ApiListenerTest extends TestCase
     public function testEnsureSerializeWithViewVarChanged()
     {
         $listener = $this
-            ->getMockBuilder(\Crud\Listener\ApiListener::class)
+            ->getMockBuilder(ApiListener::class)
             ->setMethods(['_action', '_controller'])
             ->disableOriginalConstructor()
             ->getMock();
 
         $controller = $this
-            ->getMockBuilder(\Cake\Controller\Controller::class)
+            ->getMockBuilder(Controller::class)
             ->setMethods(['set'])
             ->disableOriginalConstructor()
             ->getMock();
 
         $action = $this
-            ->getMockBuilder(\Crud\Action\IndexAction::class)
+            ->getMockBuilder(IndexAction::class)
             ->setMethods(['config', 'viewVar'])
             ->disableOriginalConstructor()
             ->getMock();
@@ -615,19 +627,19 @@ class ApiListenerTest extends TestCase
     public function testEnsureSerializeWithoutViewVar()
     {
         $listener = $this
-            ->getMockBuilder(\Crud\Listener\ApiListener::class)
+            ->getMockBuilder(ApiListener::class)
             ->setMethods(['_action', '_controller'])
             ->disableOriginalConstructor()
             ->getMock();
 
         $controller = $this
-            ->getMockBuilder(\Crud\Test\App\Controller\BlogsController::class)
+            ->getMockBuilder(BlogsController::class)
             ->setMethods(['set', 'getName'])
             ->disableOriginalConstructor()
             ->getMock();
 
         $action = $this
-            ->getMockBuilder(\Crud\Action\AddAction::class)
+            ->getMockBuilder(AddAction::class)
             ->setMethods(['config', 'scope', '_controller'])
             ->disableOriginalConstructor()
             ->getMock();
@@ -669,15 +681,15 @@ class ApiListenerTest extends TestCase
     public function testEnsureSuccess()
     {
         $listener = $this
-            ->getMockBuilder(\Crud\Listener\ApiListener::class)
+            ->getMockBuilder(ApiListener::class)
             ->setMethods(['_controller'])
             ->disableOriginalConstructor()
             ->getMock();
 
-        $subject = new \Crud\Event\Subject(['success' => true]);
+        $subject = new Subject(['success' => true]);
 
         $controller = $this
-            ->getMockBuilder(\Cake\Controller\Controller::class)
+            ->getMockBuilder(Controller::class)
             ->setMethods(['set'])
             ->disableOriginalConstructor()
             ->getMock();
@@ -704,24 +716,24 @@ class ApiListenerTest extends TestCase
     public function testEnsureData()
     {
         $listener = $this
-            ->getMockBuilder(\Crud\Listener\ApiListener::class)
+            ->getMockBuilder(ApiListener::class)
             ->setMethods(['_controller', '_action'])
             ->disableOriginalConstructor()
             ->getMock();
 
         $controller = $this
-            ->getMockBuilder(\Cake\Controller\Controller::class)
+            ->getMockBuilder(Controller::class)
             ->setMethods(['set'])
             ->disableOriginalConstructor()
             ->getMock();
 
         $action = $this
-            ->getMockBuilder(\Crud\Action\BaseAction::class)
+            ->getMockBuilder(BaseAction::class)
             ->setMethods(['getConfig'])
             ->disableOriginalConstructor()
             ->getMock();
 
-        $subject = new \Crud\Event\Subject(['success' => true]);
+        $subject = new Subject(['success' => true]);
 
         $config = [];
 
@@ -756,24 +768,24 @@ class ApiListenerTest extends TestCase
     public function testEnsureDataSubject()
     {
         $listener = $this
-            ->getMockBuilder(\Crud\Listener\ApiListener::class)
+            ->getMockBuilder(ApiListener::class)
             ->setMethods(['_controller', '_action'])
             ->disableOriginalConstructor()
             ->getMock();
 
         $controller = $this
-            ->getMockBuilder(\Cake\Controller\Controller::class)
+            ->getMockBuilder(Controller::class)
             ->setMethods(['set'])
             ->disableOriginalConstructor()
             ->getMock();
 
         $action = $this
-            ->getMockBuilder(\Crud\Action\BaseAction::class)
+            ->getMockBuilder(BaseAction::class)
             ->setMethods(['getConfig'])
             ->disableOriginalConstructor()
             ->getMock();
 
-        $subject = new \Crud\Event\Subject(['success' => true, 'id' => 1, 'modelClass' => 'MyModel']);
+        $subject = new Subject(['success' => true, 'id' => 1, 'modelClass' => 'MyModel']);
 
         $config = ['data' => [
             'subject' => [
@@ -813,24 +825,24 @@ class ApiListenerTest extends TestCase
     public function testEnsureDataRaw()
     {
         $listener = $this
-            ->getMockBuilder(\Crud\Listener\ApiListener::class)
+            ->getMockBuilder(ApiListener::class)
             ->setMethods(['_controller', '_action'])
             ->disableOriginalConstructor()
             ->getMock();
 
         $controller = $this
-            ->getMockBuilder(\Cake\Controller\Controller::class)
+            ->getMockBuilder(Controller::class)
             ->setMethods(['set'])
             ->disableOriginalConstructor()
             ->getMock();
 
         $action = $this
-            ->getMockBuilder(\Crud\Action\BaseAction::class)
+            ->getMockBuilder(BaseAction::class)
             ->setMethods(['getConfig'])
             ->disableOriginalConstructor()
             ->getMock();
 
-        $subject = new \Crud\Event\Subject(['success' => true, 'id' => 1, 'modelClass' => 'MyModel']);
+        $subject = new Subject(['success' => true, 'id' => 1, 'modelClass' => 'MyModel']);
 
         $config = ['data' => ['raw' => ['{modelClass}.id' => 1]]];
 
@@ -865,24 +877,24 @@ class ApiListenerTest extends TestCase
     public function testEnsureDataError()
     {
         $listener = $this
-            ->getMockBuilder(\Crud\Listener\ApiListener::class)
+            ->getMockBuilder(ApiListener::class)
             ->setMethods(['_controller', '_action'])
             ->disableOriginalConstructor()
             ->getMock();
 
         $controller = $this
-            ->getMockBuilder(\Cake\Controller\Controller::class)
+            ->getMockBuilder(Controller::class)
             ->setMethods(['set'])
             ->disableOriginalConstructor()
             ->getMock();
 
         $action = $this
-            ->getMockBuilder(\Crud\Action\BaseAction::class)
+            ->getMockBuilder(BaseAction::class)
             ->setMethods(['getConfig'])
             ->disableOriginalConstructor()
             ->getMock();
 
-        $subject = new \Crud\Event\Subject(['success' => false]);
+        $subject = new Subject(['success' => false]);
 
         $config = [];
 
@@ -917,15 +929,15 @@ class ApiListenerTest extends TestCase
     public function testEnsureSuccessAlreadySet()
     {
         $listener = $this
-            ->getMockBuilder(\Crud\Listener\ApiListener::class)
+            ->getMockBuilder(ApiListener::class)
             ->setMethods(['_controller'])
             ->disableOriginalConstructor()
             ->getMock();
 
-        $subject = new \Crud\Event\Subject(['success' => true]);
+        $subject = new Subject(['success' => true]);
 
         $controller = $this
-            ->getMockBuilder(\Cake\Controller\Controller::class)
+            ->getMockBuilder(Controller::class)
             ->setMethods(['set'])
             ->disableOriginalConstructor()
             ->getMock();
@@ -960,15 +972,15 @@ class ApiListenerTest extends TestCase
             return true;
         }]);
 
-        $subject = new \Crud\Event\Subject(['request' => $Request]);
+        $subject = new Subject(['request' => $Request]);
 
         $apiListener = $listener = $this
-            ->getMockBuilder(\Crud\Listener\ApiListener::class)
+            ->getMockBuilder(ApiListener::class)
             ->setMethods(null)
             ->disableOriginalConstructor()
             ->getMock();
 
-        $event = new \Cake\Event\Event('Crud.setFlash', $subject);
+        $event = new Event('Crud.setFlash', $subject);
         $apiListener->setFlash($event);
 
         $stopped = $event->isStopped();
@@ -990,15 +1002,15 @@ class ApiListenerTest extends TestCase
             return true;
         }]);
 
-        $subject = new \Crud\Event\Subject(['request' => $Request]);
+        $subject = new Subject(['request' => $Request]);
 
         $apiListener = $listener = $this
-            ->getMockBuilder(\Crud\Listener\ApiListener::class)
+            ->getMockBuilder(ApiListener::class)
             ->setMethods(null)
             ->disableOriginalConstructor()
             ->getMock();
 
-        $event = new \Cake\Event\Event('Crud.setFlash', $subject);
+        $event = new Event('Crud.setFlash', $subject);
         $apiListener->setConfig(['setFlash' => true]);
         $apiListener->setFlash($event);
 
@@ -1015,19 +1027,19 @@ class ApiListenerTest extends TestCase
     {
         return [
             'simple string' => [
-                new \Crud\Event\Subject(['modelClass' => 'MyModel']),
+                new Subject(['modelClass' => 'MyModel']),
                 '{modelClass}.id',
                 'MyModel.id',
             ],
 
             'string and integer' => [
-                new \Crud\Event\Subject(['modelClass' => 'MyModel', 'id' => 1]),
+                new Subject(['modelClass' => 'MyModel', 'id' => 1]),
                 '{modelClass}.{id}',
                 'MyModel.1',
             ],
 
             'ignore non scalar' => [
-                new \Crud\Event\Subject(['modelClass' => 'MyModel', 'complex' => new \StdClass()]),
+                new Subject(['modelClass' => 'MyModel', 'complex' => new StdClass()]),
                 '{modelClass}.{id}',
                 'MyModel.{id}',
             ],
@@ -1043,7 +1055,7 @@ class ApiListenerTest extends TestCase
     public function testExpandPath($subject, $path, $expected)
     {
         $listener = $this
-            ->getMockBuilder(\Crud\Listener\ApiListener::class)
+            ->getMockBuilder(ApiListener::class)
             ->disableOriginalConstructor()
             ->setMethods(null)
             ->getMock();
@@ -1065,7 +1077,7 @@ class ApiListenerTest extends TestCase
         $detectors = ['xml' => [], 'json' => []];
 
         $listener = $this
-            ->getMockBuilder(\Crud\Listener\ApiListener::class)
+            ->getMockBuilder(ApiListener::class)
             ->setMethods(['_request', 'config'])
             ->disableOriginalConstructor()
             ->getMock();
@@ -1117,7 +1129,7 @@ class ApiListenerTest extends TestCase
         ];
 
         $listener = $this
-            ->getMockBuilder(\Crud\Listener\ApiListener::class)
+            ->getMockBuilder(ApiListener::class)
             ->setMethods(['_request', 'getConfig'])
             ->disableOriginalConstructor()
             ->getMock();
@@ -1236,13 +1248,13 @@ class ApiListenerTest extends TestCase
     public function testCheckRequestMethods($apiConfig, $exception, $requestMethods)
     {
         $listener = $this
-            ->getMockBuilder(\Crud\Listener\ApiListener::class)
+            ->getMockBuilder(ApiListener::class)
             ->setMethods(['_action', '_request'])
             ->disableOriginalConstructor()
             ->getMock();
 
         $action = $this
-            ->getMockBuilder(\Crud\Action\IndexAction::class)
+            ->getMockBuilder(IndexAction::class)
             ->setMethods(['getConfig'])
             ->disableOriginalConstructor()
             ->getMock();
@@ -1301,7 +1313,7 @@ class ApiListenerTest extends TestCase
     public function testViewClass()
     {
         $apiListener = $this
-            ->getMockBuilder(\Crud\Listener\ApiListener::class)
+            ->getMockBuilder(ApiListener::class)
             ->disableOriginalConstructor()
             ->setMethods(null)
             ->getMock();
@@ -1323,7 +1335,7 @@ class ApiListenerTest extends TestCase
     public function testViewClassDefaults()
     {
         $apiListener = $this
-            ->getMockBuilder(\Crud\Listener\ApiListener::class)
+            ->getMockBuilder(ApiListener::class)
             ->disableOriginalConstructor()
             ->setMethods(null)
             ->getMock();
@@ -1344,12 +1356,12 @@ class ApiListenerTest extends TestCase
     public function testInjectViewClasses()
     {
         $controller = $this
-            ->getMockBuilder(\Cake\Controller\Controller::class)
+            ->getMockBuilder(Controller::class)
             ->setMethods(['foobar'])
             ->disableOriginalConstructor()
             ->getMock();
 
-        $controller->RequestHandler = $this->getMockBuilder(\Cake\Controller\Component\RequestHandlerComponent::class)
+        $controller->RequestHandler = $this->getMockBuilder(RequestHandlerComponent::class)
             ->setMethods(['setConfig'])
             ->disableOriginalConstructor()
             ->getMock();
@@ -1362,7 +1374,7 @@ class ApiListenerTest extends TestCase
             ->method('setConfig')
             ->with('viewClassMap', ['xml' => 'Xml']);
 
-        $apiListener = $this->getMockBuilder(\Crud\Listener\ApiListener::class)
+        $apiListener = $this->getMockBuilder(ApiListener::class)
             ->disableOriginalConstructor()
             ->setMethods(['_controller'])
             ->getMock();

--- a/tests/TestCase/Listener/ApiListenerTest.php
+++ b/tests/TestCase/Listener/ApiListenerTest.php
@@ -21,7 +21,7 @@ class ApiListenerTest extends TestCase
     public function testImplementedEvents()
     {
         $listener = $this
-            ->getMockBuilder('\Crud\Listener\ApiListener')
+            ->getMockBuilder(\Crud\Listener\ApiListener::class)
             ->setMethods(['setupDetectors', '_checkRequestType'])
             ->disableOriginalConstructor()
             ->getMock();
@@ -53,7 +53,7 @@ class ApiListenerTest extends TestCase
     public function testImplementedEventsWithoutApi()
     {
         $listener = $this
-            ->getMockBuilder('\Crud\Listener\ApiListener')
+            ->getMockBuilder(\Crud\Listener\ApiListener::class)
             ->setMethods(['setupDetectors', '_checkRequestType'])
             ->disableOriginalConstructor()
             ->getMock();
@@ -79,7 +79,7 @@ class ApiListenerTest extends TestCase
     public function testBeforeHandle()
     {
         $listener = $this
-            ->getMockBuilder('\Crud\Listener\ApiListener')
+            ->getMockBuilder(\Crud\Listener\ApiListener::class)
             ->setMethods(['_checkRequestMethods'])
             ->disableOriginalConstructor()
             ->getMock();
@@ -98,7 +98,7 @@ class ApiListenerTest extends TestCase
     public function testResponse()
     {
         $action = $this
-            ->getMockBuilder('\Crud\Action\IndexAction')
+            ->getMockBuilder(\Crud\Action\IndexAction::class)
             ->disableOriginalConstructor()
             ->setMethods(['getConfig'])
             ->getMock();
@@ -109,14 +109,14 @@ class ApiListenerTest extends TestCase
             ->getMock();
 
         $subject = $this
-            ->getMockBuilder('\Crud\Event\Subject')
+            ->getMockBuilder(\Crud\Event\Subject::class)
             ->getMock();
         $subject->success = true;
 
         $event = new \Cake\Event\Event('Crud.afterSave', $subject);
 
         $listener = $this
-            ->getMockBuilder('\Crud\Listener\ApiListener')
+            ->getMockBuilder(\Crud\Listener\ApiListener::class)
             ->disableOriginalConstructor()
             ->setMethods(['_action', 'render'])
             ->getMock();
@@ -152,7 +152,7 @@ class ApiListenerTest extends TestCase
     public function testResponseWithStatusCodeNotSpecified()
     {
         $action = $this
-            ->getMockBuilder('\Crud\Action\ViewAction')
+            ->getMockBuilder(\Crud\Action\ViewAction::class)
             ->disableOriginalConstructor()
             ->setMethods(['getConfig'])
             ->getMock();
@@ -163,14 +163,14 @@ class ApiListenerTest extends TestCase
             ->getMock();
 
         $subject = $this
-            ->getMockBuilder('\Crud\Event\Subject')
+            ->getMockBuilder(\Crud\Event\Subject::class)
             ->getMock();
         $subject->success = true;
 
         $event = new \Cake\Event\Event('Crud.afterSave', $subject);
 
         $listener = $this
-            ->getMockBuilder('\Crud\Listener\ApiListener')
+            ->getMockBuilder(\Crud\Listener\ApiListener::class)
             ->disableOriginalConstructor()
             ->setMethods(['_action', 'render'])
             ->getMock();
@@ -204,12 +204,12 @@ class ApiListenerTest extends TestCase
     public function testResponseWithExceptionConfig()
     {
         $action = $this
-            ->getMockBuilder('\Crud\Action\IndexAction')
+            ->getMockBuilder(\Crud\Action\IndexAction::class)
             ->disableOriginalConstructor()
             ->setMethods(['getConfig'])
             ->getMock();
 
-        $subject = $this->getMockBuilder('\Crud\Event\Subject')
+        $subject = $this->getMockBuilder(\Crud\Event\Subject::class)
             ->getMock();
         $subject->success = true;
 
@@ -218,7 +218,7 @@ class ApiListenerTest extends TestCase
         $i = 0;
 
         $listener = $this
-            ->getMockBuilder('\Crud\Listener\ApiListener')
+            ->getMockBuilder(\Crud\Listener\ApiListener::class)
             ->disableOriginalConstructor()
             ->setMethods(['_action', 'render', '_exceptionResponse'])
             ->getMock();
@@ -251,7 +251,7 @@ class ApiListenerTest extends TestCase
     public function testDefaultConfiguration()
     {
         $listener = $this
-            ->getMockBuilder('\Crud\Listener\ApiListener')
+            ->getMockBuilder(\Crud\Listener\ApiListener::class)
             ->disableOriginalConstructor()
             ->setMethods(null)
             ->getMock();
@@ -357,7 +357,7 @@ class ApiListenerTest extends TestCase
         $validationErrors = []
     ) {
         $listener = $this
-            ->getMockBuilder('\Crud\Listener\ApiListener')
+            ->getMockBuilder(\Crud\Listener\ApiListener::class)
             ->disableOriginalConstructor()
             ->setMethods(null)
             ->getMock();
@@ -366,7 +366,7 @@ class ApiListenerTest extends TestCase
 
         if (isset($apiConfig['type']) && $apiConfig['type'] === 'validate') {
             $event->getSubject()->set([
-                'entity' => $this->getMockBuilder('\Cake\ORM\Entity')
+                'entity' => $this->getMockBuilder(\Cake\ORM\Entity::class)
                     ->setMethods(['errors'])
                     ->getMock(),
             ]);
@@ -391,19 +391,19 @@ class ApiListenerTest extends TestCase
     public function testEnsureSerializeWithViewVar()
     {
         $listener = $this
-            ->getMockBuilder('\Crud\Listener\ApiListener')
+            ->getMockBuilder(\Crud\Listener\ApiListener::class)
             ->setMethods(['_action', '_controller'])
             ->disableOriginalConstructor()
             ->getMock();
 
         $controller = $this
-            ->getMockBuilder('\Cake\Controller\Controller')
+            ->getMockBuilder(\Cake\Controller\Controller::class)
             ->setMethods(['set'])
             ->disableOriginalConstructor()
             ->getMock();
 
         $action = $this
-            ->getMockBuilder('\Crud\Action\IndexAction')
+            ->getMockBuilder(\Crud\Action\IndexAction::class)
             ->setMethods(['config', 'viewVar'])
             ->disableOriginalConstructor()
             ->getMock();
@@ -455,7 +455,7 @@ class ApiListenerTest extends TestCase
     public function testEnsureSerializeWithSerializeTrait($action)
     {
         $listener = $this
-            ->getMockBuilder('\Crud\Listener\ApiListener')
+            ->getMockBuilder(\Crud\Listener\ApiListener::class)
             ->setMethods(['_action', '_controller'])
             ->disableOriginalConstructor()
             ->getMock();
@@ -467,7 +467,7 @@ class ApiListenerTest extends TestCase
             ->getMock();
 
         $controller = $this
-            ->getMockBuilder('\Cake\Controller\Controller')
+            ->getMockBuilder(\Cake\Controller\Controller::class)
             ->setMethods(['set'])
             ->disableOriginalConstructor()
             ->getMock();
@@ -516,13 +516,13 @@ class ApiListenerTest extends TestCase
     public function testEnsureSerializeAlreadySet()
     {
         $listener = $this
-            ->getMockBuilder('\Crud\Listener\ApiListener')
+            ->getMockBuilder(\Crud\Listener\ApiListener::class)
             ->setMethods(['_action', '_controller'])
             ->disableOriginalConstructor()
             ->getMock();
 
         $controller = $this
-            ->getMockBuilder('\Cake\Controller\Controller')
+            ->getMockBuilder(\Cake\Controller\Controller::class)
             ->setMethods(['set'])
             ->disableOriginalConstructor()
             ->getMock();
@@ -530,7 +530,7 @@ class ApiListenerTest extends TestCase
         $controller->viewBuilder()->setOption('serialize', 'hello world');
 
         $action = $this
-            ->getMockBuilder('\Crud\Action\IndexAction')
+            ->getMockBuilder(\Crud\Action\IndexAction::class)
             ->setMethods(['config', 'viewVar'])
             ->disableOriginalConstructor()
             ->getMock();
@@ -567,19 +567,19 @@ class ApiListenerTest extends TestCase
     public function testEnsureSerializeWithViewVarChanged()
     {
         $listener = $this
-            ->getMockBuilder('\Crud\Listener\ApiListener')
+            ->getMockBuilder(\Crud\Listener\ApiListener::class)
             ->setMethods(['_action', '_controller'])
             ->disableOriginalConstructor()
             ->getMock();
 
         $controller = $this
-            ->getMockBuilder('\Cake\Controller\Controller')
+            ->getMockBuilder(\Cake\Controller\Controller::class)
             ->setMethods(['set'])
             ->disableOriginalConstructor()
             ->getMock();
 
         $action = $this
-            ->getMockBuilder('\Crud\Action\IndexAction')
+            ->getMockBuilder(\Crud\Action\IndexAction::class)
             ->setMethods(['config', 'viewVar'])
             ->disableOriginalConstructor()
             ->getMock();
@@ -615,19 +615,19 @@ class ApiListenerTest extends TestCase
     public function testEnsureSerializeWithoutViewVar()
     {
         $listener = $this
-            ->getMockBuilder('\Crud\Listener\ApiListener')
+            ->getMockBuilder(\Crud\Listener\ApiListener::class)
             ->setMethods(['_action', '_controller'])
             ->disableOriginalConstructor()
             ->getMock();
 
         $controller = $this
-            ->getMockBuilder('\Crud\Test\App\Controller\BlogsController')
+            ->getMockBuilder(\Crud\Test\App\Controller\BlogsController::class)
             ->setMethods(['set', 'getName'])
             ->disableOriginalConstructor()
             ->getMock();
 
         $action = $this
-            ->getMockBuilder('\Crud\Action\AddAction')
+            ->getMockBuilder(\Crud\Action\AddAction::class)
             ->setMethods(['config', 'scope', '_controller'])
             ->disableOriginalConstructor()
             ->getMock();
@@ -669,7 +669,7 @@ class ApiListenerTest extends TestCase
     public function testEnsureSuccess()
     {
         $listener = $this
-            ->getMockBuilder('\Crud\Listener\ApiListener')
+            ->getMockBuilder(\Crud\Listener\ApiListener::class)
             ->setMethods(['_controller'])
             ->disableOriginalConstructor()
             ->getMock();
@@ -677,7 +677,7 @@ class ApiListenerTest extends TestCase
         $subject = new \Crud\Event\Subject(['success' => true]);
 
         $controller = $this
-            ->getMockBuilder('\Cake\Controller\Controller')
+            ->getMockBuilder(\Cake\Controller\Controller::class)
             ->setMethods(['set'])
             ->disableOriginalConstructor()
             ->getMock();
@@ -704,19 +704,19 @@ class ApiListenerTest extends TestCase
     public function testEnsureData()
     {
         $listener = $this
-            ->getMockBuilder('\Crud\Listener\ApiListener')
+            ->getMockBuilder(\Crud\Listener\ApiListener::class)
             ->setMethods(['_controller', '_action'])
             ->disableOriginalConstructor()
             ->getMock();
 
         $controller = $this
-            ->getMockBuilder('\Cake\Controller\Controller')
+            ->getMockBuilder(\Cake\Controller\Controller::class)
             ->setMethods(['set'])
             ->disableOriginalConstructor()
             ->getMock();
 
         $action = $this
-            ->getMockBuilder('Crud\Action\BaseAction')
+            ->getMockBuilder(\Crud\Action\BaseAction::class)
             ->setMethods(['getConfig'])
             ->disableOriginalConstructor()
             ->getMock();
@@ -756,19 +756,19 @@ class ApiListenerTest extends TestCase
     public function testEnsureDataSubject()
     {
         $listener = $this
-            ->getMockBuilder('\Crud\Listener\ApiListener')
+            ->getMockBuilder(\Crud\Listener\ApiListener::class)
             ->setMethods(['_controller', '_action'])
             ->disableOriginalConstructor()
             ->getMock();
 
         $controller = $this
-            ->getMockBuilder('\Cake\Controller\Controller')
+            ->getMockBuilder(\Cake\Controller\Controller::class)
             ->setMethods(['set'])
             ->disableOriginalConstructor()
             ->getMock();
 
         $action = $this
-            ->getMockBuilder('Crud\Action\BaseAction')
+            ->getMockBuilder(\Crud\Action\BaseAction::class)
             ->setMethods(['getConfig'])
             ->disableOriginalConstructor()
             ->getMock();
@@ -813,19 +813,19 @@ class ApiListenerTest extends TestCase
     public function testEnsureDataRaw()
     {
         $listener = $this
-            ->getMockBuilder('\Crud\Listener\ApiListener')
+            ->getMockBuilder(\Crud\Listener\ApiListener::class)
             ->setMethods(['_controller', '_action'])
             ->disableOriginalConstructor()
             ->getMock();
 
         $controller = $this
-            ->getMockBuilder('\Cake\Controller\Controller')
+            ->getMockBuilder(\Cake\Controller\Controller::class)
             ->setMethods(['set'])
             ->disableOriginalConstructor()
             ->getMock();
 
         $action = $this
-            ->getMockBuilder('\Crud\Action\BaseAction')
+            ->getMockBuilder(\Crud\Action\BaseAction::class)
             ->setMethods(['getConfig'])
             ->disableOriginalConstructor()
             ->getMock();
@@ -865,19 +865,19 @@ class ApiListenerTest extends TestCase
     public function testEnsureDataError()
     {
         $listener = $this
-            ->getMockBuilder('\Crud\Listener\ApiListener')
+            ->getMockBuilder(\Crud\Listener\ApiListener::class)
             ->setMethods(['_controller', '_action'])
             ->disableOriginalConstructor()
             ->getMock();
 
         $controller = $this
-            ->getMockBuilder('\Cake\Controller\Controller')
+            ->getMockBuilder(\Cake\Controller\Controller::class)
             ->setMethods(['set'])
             ->disableOriginalConstructor()
             ->getMock();
 
         $action = $this
-            ->getMockBuilder('\Crud\Action\BaseAction')
+            ->getMockBuilder(\Crud\Action\BaseAction::class)
             ->setMethods(['getConfig'])
             ->disableOriginalConstructor()
             ->getMock();
@@ -917,7 +917,7 @@ class ApiListenerTest extends TestCase
     public function testEnsureSuccessAlreadySet()
     {
         $listener = $this
-            ->getMockBuilder('\Crud\Listener\ApiListener')
+            ->getMockBuilder(\Crud\Listener\ApiListener::class)
             ->setMethods(['_controller'])
             ->disableOriginalConstructor()
             ->getMock();
@@ -925,7 +925,7 @@ class ApiListenerTest extends TestCase
         $subject = new \Crud\Event\Subject(['success' => true]);
 
         $controller = $this
-            ->getMockBuilder('\Cake\Controller\Controller')
+            ->getMockBuilder(\Cake\Controller\Controller::class)
             ->setMethods(['set'])
             ->disableOriginalConstructor()
             ->getMock();
@@ -963,7 +963,7 @@ class ApiListenerTest extends TestCase
         $subject = new \Crud\Event\Subject(['request' => $Request]);
 
         $apiListener = $listener = $this
-            ->getMockBuilder('\Crud\Listener\ApiListener')
+            ->getMockBuilder(\Crud\Listener\ApiListener::class)
             ->setMethods(null)
             ->disableOriginalConstructor()
             ->getMock();
@@ -993,7 +993,7 @@ class ApiListenerTest extends TestCase
         $subject = new \Crud\Event\Subject(['request' => $Request]);
 
         $apiListener = $listener = $this
-            ->getMockBuilder('\Crud\Listener\ApiListener')
+            ->getMockBuilder(\Crud\Listener\ApiListener::class)
             ->setMethods(null)
             ->disableOriginalConstructor()
             ->getMock();
@@ -1043,7 +1043,7 @@ class ApiListenerTest extends TestCase
     public function testExpandPath($subject, $path, $expected)
     {
         $listener = $this
-            ->getMockBuilder('\Crud\Listener\ApiListener')
+            ->getMockBuilder(\Crud\Listener\ApiListener::class)
             ->disableOriginalConstructor()
             ->setMethods(null)
             ->getMock();
@@ -1065,7 +1065,7 @@ class ApiListenerTest extends TestCase
         $detectors = ['xml' => [], 'json' => []];
 
         $listener = $this
-            ->getMockBuilder('\Crud\Listener\ApiListener')
+            ->getMockBuilder(\Crud\Listener\ApiListener::class)
             ->setMethods(['_request', 'config'])
             ->disableOriginalConstructor()
             ->getMock();
@@ -1117,7 +1117,7 @@ class ApiListenerTest extends TestCase
         ];
 
         $listener = $this
-            ->getMockBuilder('\Crud\Listener\ApiListener')
+            ->getMockBuilder(\Crud\Listener\ApiListener::class)
             ->setMethods(['_request', 'getConfig'])
             ->disableOriginalConstructor()
             ->getMock();
@@ -1236,13 +1236,13 @@ class ApiListenerTest extends TestCase
     public function testCheckRequestMethods($apiConfig, $exception, $requestMethods)
     {
         $listener = $this
-            ->getMockBuilder('\Crud\Listener\ApiListener')
+            ->getMockBuilder(\Crud\Listener\ApiListener::class)
             ->setMethods(['_action', '_request'])
             ->disableOriginalConstructor()
             ->getMock();
 
         $action = $this
-            ->getMockBuilder('\Crud\Action\IndexAction')
+            ->getMockBuilder(\Crud\Action\IndexAction::class)
             ->setMethods(['getConfig'])
             ->disableOriginalConstructor()
             ->getMock();
@@ -1301,7 +1301,7 @@ class ApiListenerTest extends TestCase
     public function testViewClass()
     {
         $apiListener = $this
-            ->getMockBuilder('\Crud\Listener\ApiListener')
+            ->getMockBuilder(\Crud\Listener\ApiListener::class)
             ->disableOriginalConstructor()
             ->setMethods(null)
             ->getMock();
@@ -1323,7 +1323,7 @@ class ApiListenerTest extends TestCase
     public function testViewClassDefaults()
     {
         $apiListener = $this
-            ->getMockBuilder('\Crud\Listener\ApiListener')
+            ->getMockBuilder(\Crud\Listener\ApiListener::class)
             ->disableOriginalConstructor()
             ->setMethods(null)
             ->getMock();
@@ -1344,12 +1344,12 @@ class ApiListenerTest extends TestCase
     public function testInjectViewClasses()
     {
         $controller = $this
-            ->getMockBuilder('\Cake\Controller\Controller')
+            ->getMockBuilder(\Cake\Controller\Controller::class)
             ->setMethods(['foobar'])
             ->disableOriginalConstructor()
             ->getMock();
 
-        $controller->RequestHandler = $this->getMockBuilder('\Cake\Controller\Component\RequestHandlerComponent')
+        $controller->RequestHandler = $this->getMockBuilder(\Cake\Controller\Component\RequestHandlerComponent::class)
             ->setMethods(['setConfig'])
             ->disableOriginalConstructor()
             ->getMock();
@@ -1362,7 +1362,7 @@ class ApiListenerTest extends TestCase
             ->method('setConfig')
             ->with('viewClassMap', ['xml' => 'Xml']);
 
-        $apiListener = $this->getMockBuilder('\Crud\Listener\ApiListener')
+        $apiListener = $this->getMockBuilder(\Crud\Listener\ApiListener::class)
             ->disableOriginalConstructor()
             ->setMethods(['_controller'])
             ->getMock();

--- a/tests/TestCase/Listener/ApiPaginationListenerTest.php
+++ b/tests/TestCase/Listener/ApiPaginationListenerTest.php
@@ -3,7 +3,11 @@ declare(strict_types=1);
 
 namespace Crud\Test\TestCase\Listener;
 
+use Cake\Controller\Controller;
+use Cake\Event\Event;
 use Cake\Http\ServerRequest;
+use Crud\Action\BaseAction;
+use Crud\Listener\ApiPaginationListener;
 use Crud\TestSuite\TestCase;
 
 /**
@@ -20,7 +24,7 @@ class ApiPaginationListenerTest extends TestCase
     public function testImplementedEvents()
     {
         $Instance = $this
-            ->getMockBuilder(\Crud\Listener\ApiPaginationListener::class)
+            ->getMockBuilder(ApiPaginationListener::class)
             ->disableOriginalConstructor()
             ->setMethods(['_checkRequestType'])
             ->getMock();
@@ -51,13 +55,13 @@ class ApiPaginationListenerTest extends TestCase
         $Request = $Request->withAttribute('paging', ['MyModel' => []]);
 
         $Controller = $this
-            ->getMockBuilder(\Cake\Controller\Controller::class)
+            ->getMockBuilder(Controller::class)
             ->disableOriginalConstructor()
             ->setMethods(null)
             ->getMock();
 
         $Instance = $this
-            ->getMockBuilder(\Crud\Listener\ApiPaginationListener::class)
+            ->getMockBuilder(ApiPaginationListener::class)
             ->disableOriginalConstructor()
             ->setMethods(['_request'])
             ->getMock();
@@ -68,7 +72,7 @@ class ApiPaginationListenerTest extends TestCase
 
         $Controller->modelClass = 'MyModel';
 
-        $Instance->beforeRender(new \Cake\Event\Event('something'));
+        $Instance->beforeRender(new Event('something'));
     }
 
     /**
@@ -85,7 +89,7 @@ class ApiPaginationListenerTest extends TestCase
             ->getMock();
 
         $Instance = $this
-            ->getMockBuilder(\Crud\Listener\ApiPaginationListener::class)
+            ->getMockBuilder(ApiPaginationListener::class)
             ->disableOriginalConstructor()
             ->setMethods(['_request', '_controller'])
             ->getMock();
@@ -99,7 +103,7 @@ class ApiPaginationListenerTest extends TestCase
 
         $Request = $Request->withAttribute('paging', null);
 
-        $Instance->beforeRender(new \Cake\Event\Event('something'));
+        $Instance->beforeRender(new Event('something'));
     }
 
     /**
@@ -135,7 +139,7 @@ class ApiPaginationListenerTest extends TestCase
         ];
 
         $Controller = $this
-            ->getMockBuilder(\Cake\Controller\Controller::class)
+            ->getMockBuilder(Controller::class)
             ->disableOriginalConstructor()
             ->setMethods(['set'])
             ->getMock();
@@ -145,7 +149,7 @@ class ApiPaginationListenerTest extends TestCase
             ->with('pagination', $expected);
 
         $Action = $this
-            ->getMockBuilder(\Crud\Action\BaseAction::class)
+            ->getMockBuilder(BaseAction::class)
             ->disableOriginalConstructor()
             ->setMethods(['setConfig'])
             ->getMock();
@@ -155,7 +159,7 @@ class ApiPaginationListenerTest extends TestCase
             ->with('serialize.pagination', 'pagination');
 
         $Instance = $this
-            ->getMockBuilder(\Crud\Listener\ApiPaginationListener::class)
+            ->getMockBuilder(ApiPaginationListener::class)
             ->disableOriginalConstructor()
             ->setMethods(['_request', '_controller', '_action'])
             ->getMock();
@@ -174,7 +178,7 @@ class ApiPaginationListenerTest extends TestCase
 
         $Controller->modelClass = 'MyModel';
 
-        $Instance->beforeRender(new \Cake\Event\Event('something'));
+        $Instance->beforeRender(new Event('something'));
     }
 
     /**
@@ -209,7 +213,7 @@ class ApiPaginationListenerTest extends TestCase
         ];
 
         $Controller = $this
-            ->getMockBuilder(\Cake\Controller\Controller::class)
+            ->getMockBuilder(Controller::class)
             ->disableOriginalConstructor()
             ->setMethods(['set'])
             ->getMock();
@@ -219,7 +223,7 @@ class ApiPaginationListenerTest extends TestCase
             ->with('pagination', $expected);
 
         $Action = $this
-            ->getMockBuilder(\Crud\Action\BaseAction::class)
+            ->getMockBuilder(BaseAction::class)
             ->disableOriginalConstructor()
             ->setMethods(['setConfig'])
             ->getMock();
@@ -229,7 +233,7 @@ class ApiPaginationListenerTest extends TestCase
             ->with('serialize.pagination', 'pagination');
 
         $Instance = $this
-            ->getMockBuilder(\Crud\Listener\ApiPaginationListener::class)
+            ->getMockBuilder(ApiPaginationListener::class)
             ->disableOriginalConstructor()
             ->setMethods(['_request', '_controller', '_action'])
             ->getMock();
@@ -248,7 +252,7 @@ class ApiPaginationListenerTest extends TestCase
 
         $Controller->modelClass = 'MyPlugin.MyModel';
 
-        $Instance->beforeRender(new \Cake\Event\Event('something'));
+        $Instance->beforeRender(new Event('something'));
     }
 
     /**
@@ -283,7 +287,7 @@ class ApiPaginationListenerTest extends TestCase
         ];
 
         $Controller = $this
-            ->getMockBuilder(\Cake\Controller\Controller::class)
+            ->getMockBuilder(Controller::class)
             ->disableOriginalConstructor()
             ->setMethods(['set'])
             ->getMock();
@@ -293,13 +297,13 @@ class ApiPaginationListenerTest extends TestCase
             ->with('pagination', $expected);
 
         $Action = $this
-            ->getMockBuilder(\Crud\Action\BaseAction::class)
+            ->getMockBuilder(BaseAction::class)
             ->disableOriginalConstructor()
             ->setMethods(null)
             ->getMock();
 
         $Instance = $this
-            ->getMockBuilder(\Crud\Listener\ApiPaginationListener::class)
+            ->getMockBuilder(ApiPaginationListener::class)
             ->disableOriginalConstructor()
             ->setMethods(['_request', '_controller', '_action'])
             ->getMock();
@@ -318,7 +322,7 @@ class ApiPaginationListenerTest extends TestCase
 
         $Controller->modelClass = 'MyModel';
 
-        $Instance->beforeRender(new \Cake\Event\Event('something'));
+        $Instance->beforeRender(new Event('something'));
 
         $this->assertSame('pagination', $Action->getConfig('serialize.pagination'));
     }

--- a/tests/TestCase/Listener/ApiPaginationListenerTest.php
+++ b/tests/TestCase/Listener/ApiPaginationListenerTest.php
@@ -20,7 +20,7 @@ class ApiPaginationListenerTest extends TestCase
     public function testImplementedEvents()
     {
         $Instance = $this
-            ->getMockBuilder('\Crud\Listener\ApiPaginationListener')
+            ->getMockBuilder(\Crud\Listener\ApiPaginationListener::class)
             ->disableOriginalConstructor()
             ->setMethods(['_checkRequestType'])
             ->getMock();
@@ -51,13 +51,13 @@ class ApiPaginationListenerTest extends TestCase
         $Request = $Request->withAttribute('paging', ['MyModel' => []]);
 
         $Controller = $this
-            ->getMockBuilder('\Cake\Controller\Controller')
+            ->getMockBuilder(\Cake\Controller\Controller::class)
             ->disableOriginalConstructor()
             ->setMethods(null)
             ->getMock();
 
         $Instance = $this
-            ->getMockBuilder('\Crud\Listener\ApiPaginationListener')
+            ->getMockBuilder(\Crud\Listener\ApiPaginationListener::class)
             ->disableOriginalConstructor()
             ->setMethods(['_request'])
             ->getMock();
@@ -85,7 +85,7 @@ class ApiPaginationListenerTest extends TestCase
             ->getMock();
 
         $Instance = $this
-            ->getMockBuilder('\Crud\Listener\ApiPaginationListener')
+            ->getMockBuilder(\Crud\Listener\ApiPaginationListener::class)
             ->disableOriginalConstructor()
             ->setMethods(['_request', '_controller'])
             ->getMock();
@@ -135,7 +135,7 @@ class ApiPaginationListenerTest extends TestCase
         ];
 
         $Controller = $this
-            ->getMockBuilder('\Cake\Controller\Controller')
+            ->getMockBuilder(\Cake\Controller\Controller::class)
             ->disableOriginalConstructor()
             ->setMethods(['set'])
             ->getMock();
@@ -145,7 +145,7 @@ class ApiPaginationListenerTest extends TestCase
             ->with('pagination', $expected);
 
         $Action = $this
-            ->getMockBuilder('\Crud\Action\BaseAction')
+            ->getMockBuilder(\Crud\Action\BaseAction::class)
             ->disableOriginalConstructor()
             ->setMethods(['setConfig'])
             ->getMock();
@@ -155,7 +155,7 @@ class ApiPaginationListenerTest extends TestCase
             ->with('serialize.pagination', 'pagination');
 
         $Instance = $this
-            ->getMockBuilder('\Crud\Listener\ApiPaginationListener')
+            ->getMockBuilder(\Crud\Listener\ApiPaginationListener::class)
             ->disableOriginalConstructor()
             ->setMethods(['_request', '_controller', '_action'])
             ->getMock();
@@ -209,7 +209,7 @@ class ApiPaginationListenerTest extends TestCase
         ];
 
         $Controller = $this
-            ->getMockBuilder('\Cake\Controller\Controller')
+            ->getMockBuilder(\Cake\Controller\Controller::class)
             ->disableOriginalConstructor()
             ->setMethods(['set'])
             ->getMock();
@@ -219,7 +219,7 @@ class ApiPaginationListenerTest extends TestCase
             ->with('pagination', $expected);
 
         $Action = $this
-            ->getMockBuilder('\Crud\Action\BaseAction')
+            ->getMockBuilder(\Crud\Action\BaseAction::class)
             ->disableOriginalConstructor()
             ->setMethods(['setConfig'])
             ->getMock();
@@ -229,7 +229,7 @@ class ApiPaginationListenerTest extends TestCase
             ->with('serialize.pagination', 'pagination');
 
         $Instance = $this
-            ->getMockBuilder('\Crud\Listener\ApiPaginationListener')
+            ->getMockBuilder(\Crud\Listener\ApiPaginationListener::class)
             ->disableOriginalConstructor()
             ->setMethods(['_request', '_controller', '_action'])
             ->getMock();
@@ -283,7 +283,7 @@ class ApiPaginationListenerTest extends TestCase
         ];
 
         $Controller = $this
-            ->getMockBuilder('\Cake\Controller\Controller')
+            ->getMockBuilder(\Cake\Controller\Controller::class)
             ->disableOriginalConstructor()
             ->setMethods(['set'])
             ->getMock();
@@ -293,13 +293,13 @@ class ApiPaginationListenerTest extends TestCase
             ->with('pagination', $expected);
 
         $Action = $this
-            ->getMockBuilder('\Crud\Action\BaseAction')
+            ->getMockBuilder(\Crud\Action\BaseAction::class)
             ->disableOriginalConstructor()
             ->setMethods(null)
             ->getMock();
 
         $Instance = $this
-            ->getMockBuilder('\Crud\Listener\ApiPaginationListener')
+            ->getMockBuilder(\Crud\Listener\ApiPaginationListener::class)
             ->disableOriginalConstructor()
             ->setMethods(['_request', '_controller', '_action'])
             ->getMock();

--- a/tests/TestCase/Listener/ApiQueryLogListenerTest.php
+++ b/tests/TestCase/Listener/ApiQueryLogListenerTest.php
@@ -37,7 +37,7 @@ class ApiQueryLogListenerTest extends TestCase
     public function testImplementedEvents()
     {
         $Instance = $this
-            ->getMockBuilder('\Crud\Listener\ApiQueryLogListener')
+            ->getMockBuilder(\Crud\Listener\ApiQueryLogListener::class)
             ->disableOriginalConstructor()
             ->setMethods(['_checkRequestType'])
             ->getMock();
@@ -64,7 +64,7 @@ class ApiQueryLogListenerTest extends TestCase
     public function testImplementedEventsNotApiRequest()
     {
         $Instance = $this
-            ->getMockBuilder('\Crud\Listener\ApiQueryLogListener')
+            ->getMockBuilder(\Crud\Listener\ApiQueryLogListener::class)
             ->disableOriginalConstructor()
             ->setMethods(['_checkRequestType'])
             ->getMock();
@@ -91,7 +91,7 @@ class ApiQueryLogListenerTest extends TestCase
         Configure::write('debug', false);
 
         $Instance = $this
-            ->getMockBuilder('\Crud\Listener\ApiQueryLogListener')
+            ->getMockBuilder(\Crud\Listener\ApiQueryLogListener::class)
             ->disableOriginalConstructor()
             ->setMethods(['_getQueryLogs'])
             ->getMock();
@@ -114,7 +114,7 @@ class ApiQueryLogListenerTest extends TestCase
         Configure::write('debug', true);
 
         $Action = $this
-            ->getMockBuilder('\Crud\Action\BaseAction')
+            ->getMockBuilder(\Crud\Action\BaseAction::class)
             ->disableOriginalConstructor()
             ->setMethods(['setConfig'])
             ->getMock();
@@ -124,7 +124,7 @@ class ApiQueryLogListenerTest extends TestCase
             ->with('serialize.queryLog', 'queryLog');
 
         $Controller = $this
-            ->getMockBuilder('\Cake\Controller\Controller')
+            ->getMockBuilder(\Cake\Controller\Controller::class)
             ->disableOriginalConstructor()
             ->setMethods(['set'])
             ->getMock();
@@ -134,7 +134,7 @@ class ApiQueryLogListenerTest extends TestCase
             ->with('queryLog', []);
 
         $Instance = $this
-            ->getMockBuilder('\Crud\Listener\ApiQueryLogListener')
+            ->getMockBuilder(\Crud\Listener\ApiQueryLogListener::class)
             ->disableOriginalConstructor()
             ->setMethods(['_getQueryLogs', '_action', '_controller'])
             ->getMock();
@@ -167,7 +167,7 @@ class ApiQueryLogListenerTest extends TestCase
         }
 
         $DefaultSource = $this
-            ->getMockBuilder('\Cake\Database\Connection')
+            ->getMockBuilder(\Cake\Database\Connection::class)
             ->disableOriginalConstructor()
             ->setMethods([$methodName, 'setLogger'])
             ->getMock();
@@ -178,10 +178,10 @@ class ApiQueryLogListenerTest extends TestCase
         $DefaultSource
             ->expects($this->once())
             ->method('setLogger')
-            ->with($this->isInstanceOf('\Crud\Log\QueryLogger'));
+            ->with($this->isInstanceOf(\Crud\Log\QueryLogger::class));
 
         $Instance = $this
-            ->getMockBuilder('\Crud\Listener\ApiQueryLogListener')
+            ->getMockBuilder(\Crud\Listener\ApiQueryLogListener::class)
             ->disableOriginalConstructor()
             ->setMethods(['_getSources', '_getSource'])
             ->getMock();
@@ -211,7 +211,7 @@ class ApiQueryLogListenerTest extends TestCase
         }
 
         $DefaultSource = $this
-            ->getMockBuilder('\Cake\Database\Connection')
+            ->getMockBuilder(\Cake\Database\Connection::class)
             ->disableOriginalConstructor()
             ->setMethods([$methodName, 'setLogger'])
             ->getMock();
@@ -222,10 +222,10 @@ class ApiQueryLogListenerTest extends TestCase
         $DefaultSource
             ->expects($this->once())
             ->method('setLogger')
-            ->with($this->isInstanceOf('\Crud\Log\QueryLogger'));
+            ->with($this->isInstanceOf(\Crud\Log\QueryLogger::class));
 
         $TestSource = $this
-            ->getMockBuilder('\Cake\Database\Connection')
+            ->getMockBuilder(\Cake\Database\Connection::class)
             ->disableOriginalConstructor()
             ->setMethods([$methodName, 'setLogger'])
             ->getMock();
@@ -236,10 +236,10 @@ class ApiQueryLogListenerTest extends TestCase
         $TestSource
             ->expects($this->once())
             ->method('setLogger')
-            ->with($this->isInstanceOf('\Crud\Log\QueryLogger'));
+            ->with($this->isInstanceOf(\Crud\Log\QueryLogger::class));
 
         $Instance = $this
-            ->getMockBuilder('\Crud\Listener\ApiQueryLogListener')
+            ->getMockBuilder(\Crud\Listener\ApiQueryLogListener::class)
             ->disableOriginalConstructor()
             ->setMethods(['_getSources', '_getSource'])
             ->getMock();

--- a/tests/TestCase/Listener/ApiQueryLogListenerTest.php
+++ b/tests/TestCase/Listener/ApiQueryLogListenerTest.php
@@ -5,8 +5,11 @@ namespace Crud\Test\TestCase\Listener;
 
 use Cake\Controller\Controller;
 use Cake\Core\Configure;
+use Cake\Database\Connection;
 use Cake\Event\Event;
+use Crud\Action\BaseAction;
 use Crud\Listener\ApiQueryLogListener;
+use Crud\Log\QueryLogger;
 use Crud\TestSuite\TestCase;
 
 /**
@@ -37,7 +40,7 @@ class ApiQueryLogListenerTest extends TestCase
     public function testImplementedEvents()
     {
         $Instance = $this
-            ->getMockBuilder(\Crud\Listener\ApiQueryLogListener::class)
+            ->getMockBuilder(ApiQueryLogListener::class)
             ->disableOriginalConstructor()
             ->setMethods(['_checkRequestType'])
             ->getMock();
@@ -64,7 +67,7 @@ class ApiQueryLogListenerTest extends TestCase
     public function testImplementedEventsNotApiRequest()
     {
         $Instance = $this
-            ->getMockBuilder(\Crud\Listener\ApiQueryLogListener::class)
+            ->getMockBuilder(ApiQueryLogListener::class)
             ->disableOriginalConstructor()
             ->setMethods(['_checkRequestType'])
             ->getMock();
@@ -91,7 +94,7 @@ class ApiQueryLogListenerTest extends TestCase
         Configure::write('debug', false);
 
         $Instance = $this
-            ->getMockBuilder(\Crud\Listener\ApiQueryLogListener::class)
+            ->getMockBuilder(ApiQueryLogListener::class)
             ->disableOriginalConstructor()
             ->setMethods(['_getQueryLogs'])
             ->getMock();
@@ -114,7 +117,7 @@ class ApiQueryLogListenerTest extends TestCase
         Configure::write('debug', true);
 
         $Action = $this
-            ->getMockBuilder(\Crud\Action\BaseAction::class)
+            ->getMockBuilder(BaseAction::class)
             ->disableOriginalConstructor()
             ->setMethods(['setConfig'])
             ->getMock();
@@ -124,7 +127,7 @@ class ApiQueryLogListenerTest extends TestCase
             ->with('serialize.queryLog', 'queryLog');
 
         $Controller = $this
-            ->getMockBuilder(\Cake\Controller\Controller::class)
+            ->getMockBuilder(Controller::class)
             ->disableOriginalConstructor()
             ->setMethods(['set'])
             ->getMock();
@@ -134,7 +137,7 @@ class ApiQueryLogListenerTest extends TestCase
             ->with('queryLog', []);
 
         $Instance = $this
-            ->getMockBuilder(\Crud\Listener\ApiQueryLogListener::class)
+            ->getMockBuilder(ApiQueryLogListener::class)
             ->disableOriginalConstructor()
             ->setMethods(['_getQueryLogs', '_action', '_controller'])
             ->getMock();
@@ -167,7 +170,7 @@ class ApiQueryLogListenerTest extends TestCase
         }
 
         $DefaultSource = $this
-            ->getMockBuilder(\Cake\Database\Connection::class)
+            ->getMockBuilder(Connection::class)
             ->disableOriginalConstructor()
             ->setMethods([$methodName, 'setLogger'])
             ->getMock();
@@ -178,10 +181,10 @@ class ApiQueryLogListenerTest extends TestCase
         $DefaultSource
             ->expects($this->once())
             ->method('setLogger')
-            ->with($this->isInstanceOf(\Crud\Log\QueryLogger::class));
+            ->with($this->isInstanceOf(QueryLogger::class));
 
         $Instance = $this
-            ->getMockBuilder(\Crud\Listener\ApiQueryLogListener::class)
+            ->getMockBuilder(ApiQueryLogListener::class)
             ->disableOriginalConstructor()
             ->setMethods(['_getSources', '_getSource'])
             ->getMock();
@@ -211,7 +214,7 @@ class ApiQueryLogListenerTest extends TestCase
         }
 
         $DefaultSource = $this
-            ->getMockBuilder(\Cake\Database\Connection::class)
+            ->getMockBuilder(Connection::class)
             ->disableOriginalConstructor()
             ->setMethods([$methodName, 'setLogger'])
             ->getMock();
@@ -222,10 +225,10 @@ class ApiQueryLogListenerTest extends TestCase
         $DefaultSource
             ->expects($this->once())
             ->method('setLogger')
-            ->with($this->isInstanceOf(\Crud\Log\QueryLogger::class));
+            ->with($this->isInstanceOf(QueryLogger::class));
 
         $TestSource = $this
-            ->getMockBuilder(\Cake\Database\Connection::class)
+            ->getMockBuilder(Connection::class)
             ->disableOriginalConstructor()
             ->setMethods([$methodName, 'setLogger'])
             ->getMock();
@@ -236,10 +239,10 @@ class ApiQueryLogListenerTest extends TestCase
         $TestSource
             ->expects($this->once())
             ->method('setLogger')
-            ->with($this->isInstanceOf(\Crud\Log\QueryLogger::class));
+            ->with($this->isInstanceOf(QueryLogger::class));
 
         $Instance = $this
-            ->getMockBuilder(\Crud\Listener\ApiQueryLogListener::class)
+            ->getMockBuilder(ApiQueryLogListener::class)
             ->disableOriginalConstructor()
             ->setMethods(['_getSources', '_getSource'])
             ->getMock();

--- a/tests/TestCase/Listener/RedirectListenerTest.php
+++ b/tests/TestCase/Listener/RedirectListenerTest.php
@@ -3,7 +3,12 @@ declare(strict_types=1);
 
 namespace Crud\Test\TestCase\Listener;
 
+use Cake\Event\Event;
 use Cake\Http\ServerRequest;
+use Cake\ORM\Entity;
+use Crud\Action\BaseAction;
+use Crud\Event\Subject;
+use Crud\Listener\RedirectListener;
 use Crud\TestSuite\TestCase;
 
 /**
@@ -20,7 +25,7 @@ class RedirectListenerTest extends TestCase
     public function testImplementedEvents()
     {
         $listener = $this
-            ->getMockBuilder(\Crud\Listener\RedirectListener::class)
+            ->getMockBuilder(RedirectListener::class)
             ->setMethods(null)
             ->disableoriginalConstructor()
             ->getMock();
@@ -40,7 +45,7 @@ class RedirectListenerTest extends TestCase
     public function testSetup()
     {
         $listener = $this
-            ->getMockBuilder(\Crud\Listener\RedirectListener::class)
+            ->getMockBuilder(RedirectListener::class)
             ->setMethods(null)
             ->disableoriginalConstructor()
             ->getMock();
@@ -77,7 +82,7 @@ class RedirectListenerTest extends TestCase
     public function testReaderGetWorks()
     {
         $listener = $this
-            ->getMockBuilder(\Crud\Listener\RedirectListener::class)
+            ->getMockBuilder(RedirectListener::class)
             ->setMethods(null)
             ->disableoriginalConstructor()
             ->getMock();
@@ -98,7 +103,7 @@ class RedirectListenerTest extends TestCase
     public function testReaderGetFails()
     {
         $listener = $this
-            ->getMockBuilder(\Crud\Listener\RedirectListener::class)
+            ->getMockBuilder(RedirectListener::class)
             ->setMethods(null)
             ->disableoriginalConstructor()
             ->getMock();
@@ -118,7 +123,7 @@ class RedirectListenerTest extends TestCase
     public function testReaderSetWorks()
     {
         $listener = $this
-            ->getMockBuilder(\Crud\Listener\RedirectListener::class)
+            ->getMockBuilder(RedirectListener::class)
             ->setMethods(null)
             ->disableoriginalConstructor()
             ->getMock();
@@ -143,14 +148,14 @@ class RedirectListenerTest extends TestCase
     public function testReaderRequestKey()
     {
         $listener = $this
-            ->getMockBuilder(\Crud\Listener\RedirectListener::class)
+            ->getMockBuilder(RedirectListener::class)
             ->setMethods(['_request'])
             ->disableoriginalConstructor()
             ->getMock();
 
         $listener->setup();
 
-        $subject = new \Crud\Event\Subject();
+        $subject = new Subject();
         $request = (new ServerRequest())->withParam('action', 'index');
 
         $listener->expects($this->any())->method('_request')->will($this->returnValue($request));
@@ -171,14 +176,14 @@ class RedirectListenerTest extends TestCase
     public function testReaderRequestData()
     {
         $listener = $this
-            ->getMockBuilder(\Crud\Listener\RedirectListener::class)
+            ->getMockBuilder(RedirectListener::class)
             ->setMethods(['_request'])
             ->disableoriginalConstructor()
             ->getMock();
 
         $listener->setup();
 
-        $subject = new \Crud\Event\Subject();
+        $subject = new Subject();
         $request = (new ServerRequest())->withData('hello', 'world');
 
         $listener->expects($this->any())->method('_request')->will($this->returnValue($request));
@@ -199,14 +204,14 @@ class RedirectListenerTest extends TestCase
     public function testReaderRequestQuery()
     {
         $listener = $this
-            ->getMockBuilder(\Crud\Listener\RedirectListener::class)
+            ->getMockBuilder(RedirectListener::class)
             ->setMethods(['_request'])
             ->disableoriginalConstructor()
             ->getMock();
 
         $listener->setup();
 
-        $subject = new \Crud\Event\Subject();
+        $subject = new Subject();
         $request = (new ServerRequest())->withQueryParams(['hello' => 'world']);
 
         $listener->expects($this->any())->method('_request')->will($this->returnValue($request));
@@ -227,16 +232,16 @@ class RedirectListenerTest extends TestCase
     public function testReaderEntityField()
     {
         $listener = $this
-            ->getMockBuilder(\Crud\Listener\RedirectListener::class)
+            ->getMockBuilder(RedirectListener::class)
             ->setMethods(null)
             ->disableoriginalConstructor()
             ->getMock();
 
         $listener->setup();
 
-        $subject = new \Crud\Event\Subject();
+        $subject = new Subject();
         $subject->entity = $this
-            ->getMockBuilder(\Cake\ORM\Entity::class)
+            ->getMockBuilder(Entity::class)
             ->setMethods(['get'])
             ->disableoriginalConstructor()
             ->getMock();
@@ -259,14 +264,14 @@ class RedirectListenerTest extends TestCase
     public function testReaderSubjectKey()
     {
         $listener = $this
-            ->getMockBuilder(\Crud\Listener\RedirectListener::class)
+            ->getMockBuilder(RedirectListener::class)
             ->setMethods(null)
             ->disableoriginalConstructor()
             ->getMock();
 
         $listener->setup();
 
-        $subject = new \Crud\Event\Subject();
+        $subject = new Subject();
         $subject->welcome = 'hello world';
 
         $reader = $listener->reader('subject.key');
@@ -286,13 +291,13 @@ class RedirectListenerTest extends TestCase
     public function testRedirectWithNoConfig()
     {
         $action = $this
-            ->getMockBuilder(\Crud\Action\BaseAction::class)
+            ->getMockBuilder(BaseAction::class)
             ->setMethods(null)
             ->disableoriginalConstructor()
             ->getMock();
 
         $listener = $this
-            ->getMockBuilder(\Crud\Listener\RedirectListener::class)
+            ->getMockBuilder(RedirectListener::class)
             ->setMethods(['_action', '_getKey'])
             ->disableoriginalConstructor()
             ->getMock();
@@ -304,9 +309,9 @@ class RedirectListenerTest extends TestCase
             ->expects($this->never())
             ->method('_getKey');
 
-        $subject = new \Crud\Event\Subject();
+        $subject = new Subject();
 
-        $listener->beforeRedirect(new \Cake\Event\Event('Crud.beforeRedirect', $subject));
+        $listener->beforeRedirect(new Event('Crud.beforeRedirect', $subject));
     }
 
     /**
@@ -318,17 +323,17 @@ class RedirectListenerTest extends TestCase
     public function testRedirectWithConfigButNoValidKey()
     {
         $action = $this
-            ->getMockBuilder(\Crud\Action\BaseAction::class)
+            ->getMockBuilder(BaseAction::class)
             ->setMethods(null)
             ->disableoriginalConstructor()
             ->getMock();
 
         $action->redirectConfig('add', ['reader' => 'request.key', 'key' => 'hello']);
 
-        $subject = new \Crud\Event\Subject();
+        $subject = new Subject();
 
         $listener = $this
-            ->getMockBuilder(\Crud\Listener\RedirectListener::class)
+            ->getMockBuilder(RedirectListener::class)
             ->setMethods(['_action', '_getKey', '_getUrl'])
             ->disableoriginalConstructor()
             ->getMock();
@@ -345,7 +350,7 @@ class RedirectListenerTest extends TestCase
             ->expects($this->never())
             ->method('_getUrl');
 
-        $listener->beforeRedirect(new \Cake\Event\Event('Crud.beforeRedirect', $subject));
+        $listener->beforeRedirect(new Event('Crud.beforeRedirect', $subject));
     }
 
     /**
@@ -357,7 +362,7 @@ class RedirectListenerTest extends TestCase
     public function testRedirectWithConfigAndValidKey()
     {
         $action = $this
-            ->getMockBuilder(\Crud\Action\BaseAction::class)
+            ->getMockBuilder(BaseAction::class)
             ->setMethods(null)
             ->disableoriginalConstructor()
             ->getMock();
@@ -368,10 +373,10 @@ class RedirectListenerTest extends TestCase
             'url' => ['action' => 'index'],
         ]);
 
-        $subject = new \Crud\Event\Subject();
+        $subject = new Subject();
 
         $listener = $this
-            ->getMockBuilder(\Crud\Listener\RedirectListener::class)
+            ->getMockBuilder(RedirectListener::class)
             ->setMethods(['_action', '_getKey', '_getUrl'])
             ->disableoriginalConstructor()
             ->getMock();
@@ -390,7 +395,7 @@ class RedirectListenerTest extends TestCase
             ->with($subject, ['action' => 'index'])
             ->will($this->returnValue(['action' => 'index']));
 
-        $listener->beforeRedirect(new \Cake\Event\Event('Crud.beforeRedirect', $subject));
+        $listener->beforeRedirect(new Event('Crud.beforeRedirect', $subject));
 
         $this->assertSame(['action' => 'index'], $subject->url);
     }
@@ -407,39 +412,39 @@ class RedirectListenerTest extends TestCase
             ->withQueryParams(['parent_id' => 10])
             ->withData('epic', 'jippi');
 
-        $Model = new \Cake\ORM\Entity();
+        $Model = new Entity();
         $Model->id = 69;
         $Model->slug = 'jippi-is-awesome';
         $Model->data = ['name' => 'epic', 'slug' => 'epic'];
 
         return [
             [
-                new \Crud\Event\Subject(),
+                new Subject(),
                 ['action' => 'index'],
                 ['action' => 'index'],
             ],
             [
-                new \Crud\Event\Subject(),
+                new Subject(),
                 ['controller' => 'posts', 'action' => 'index'],
                 ['controller' => 'posts', 'action' => 'index'],
             ],
             [
-                new \Crud\Event\Subject(['request' => $Request]),
+                new Subject(['request' => $Request]),
                 ['action' => ['request.key', 'action']],
                 ['action' => 'index'],
             ],
             [
-                new \Crud\Event\Subject(['request' => $Request]),
+                new Subject(['request' => $Request]),
                 ['action' => ['request.data', 'epic']],
                 ['action' => 'jippi'],
             ],
             [
-                new \Crud\Event\Subject(['request' => $Request]),
+                new Subject(['request' => $Request]),
                 ['action' => ['request.query', 'parent_id']],
                 ['action' => 10],
             ],
             [
-                new \Crud\Event\Subject(['id' => 69]),
+                new Subject(['id' => 69]),
                 ['action' => 'edit', ['subject.key', 'id']],
                 ['action' => 'edit', 69],
             ],
@@ -452,10 +457,10 @@ class RedirectListenerTest extends TestCase
      * @dataProvider dataProviderGetUrl
      * @return void
      */
-    public function testGetUrl(\Crud\Event\Subject $subject, $url, $expected)
+    public function testGetUrl(Subject $subject, $url, $expected)
     {
         $listener = $this
-            ->getMockBuilder(\Crud\Listener\RedirectListener::class)
+            ->getMockBuilder(RedirectListener::class)
             ->setMethods(['_request'])
             ->disableoriginalConstructor()
             ->getMock();

--- a/tests/TestCase/Listener/RedirectListenerTest.php
+++ b/tests/TestCase/Listener/RedirectListenerTest.php
@@ -20,7 +20,7 @@ class RedirectListenerTest extends TestCase
     public function testImplementedEvents()
     {
         $listener = $this
-            ->getMockBuilder('\Crud\Listener\RedirectListener')
+            ->getMockBuilder(\Crud\Listener\RedirectListener::class)
             ->setMethods(null)
             ->disableoriginalConstructor()
             ->getMock();
@@ -40,7 +40,7 @@ class RedirectListenerTest extends TestCase
     public function testSetup()
     {
         $listener = $this
-            ->getMockBuilder('\Crud\Listener\RedirectListener')
+            ->getMockBuilder(\Crud\Listener\RedirectListener::class)
             ->setMethods(null)
             ->disableoriginalConstructor()
             ->getMock();
@@ -77,7 +77,7 @@ class RedirectListenerTest extends TestCase
     public function testReaderGetWorks()
     {
         $listener = $this
-            ->getMockBuilder('\Crud\Listener\RedirectListener')
+            ->getMockBuilder(\Crud\Listener\RedirectListener::class)
             ->setMethods(null)
             ->disableoriginalConstructor()
             ->getMock();
@@ -98,7 +98,7 @@ class RedirectListenerTest extends TestCase
     public function testReaderGetFails()
     {
         $listener = $this
-            ->getMockBuilder('\Crud\Listener\RedirectListener')
+            ->getMockBuilder(\Crud\Listener\RedirectListener::class)
             ->setMethods(null)
             ->disableoriginalConstructor()
             ->getMock();
@@ -118,7 +118,7 @@ class RedirectListenerTest extends TestCase
     public function testReaderSetWorks()
     {
         $listener = $this
-            ->getMockBuilder('\Crud\Listener\RedirectListener')
+            ->getMockBuilder(\Crud\Listener\RedirectListener::class)
             ->setMethods(null)
             ->disableoriginalConstructor()
             ->getMock();
@@ -143,7 +143,7 @@ class RedirectListenerTest extends TestCase
     public function testReaderRequestKey()
     {
         $listener = $this
-            ->getMockBuilder('\Crud\Listener\RedirectListener')
+            ->getMockBuilder(\Crud\Listener\RedirectListener::class)
             ->setMethods(['_request'])
             ->disableoriginalConstructor()
             ->getMock();
@@ -171,7 +171,7 @@ class RedirectListenerTest extends TestCase
     public function testReaderRequestData()
     {
         $listener = $this
-            ->getMockBuilder('\Crud\Listener\RedirectListener')
+            ->getMockBuilder(\Crud\Listener\RedirectListener::class)
             ->setMethods(['_request'])
             ->disableoriginalConstructor()
             ->getMock();
@@ -199,7 +199,7 @@ class RedirectListenerTest extends TestCase
     public function testReaderRequestQuery()
     {
         $listener = $this
-            ->getMockBuilder('\Crud\Listener\RedirectListener')
+            ->getMockBuilder(\Crud\Listener\RedirectListener::class)
             ->setMethods(['_request'])
             ->disableoriginalConstructor()
             ->getMock();
@@ -227,7 +227,7 @@ class RedirectListenerTest extends TestCase
     public function testReaderEntityField()
     {
         $listener = $this
-            ->getMockBuilder('\Crud\Listener\RedirectListener')
+            ->getMockBuilder(\Crud\Listener\RedirectListener::class)
             ->setMethods(null)
             ->disableoriginalConstructor()
             ->getMock();
@@ -236,7 +236,7 @@ class RedirectListenerTest extends TestCase
 
         $subject = new \Crud\Event\Subject();
         $subject->entity = $this
-            ->getMockBuilder('\Cake\ORM\Entity')
+            ->getMockBuilder(\Cake\ORM\Entity::class)
             ->setMethods(['get'])
             ->disableoriginalConstructor()
             ->getMock();
@@ -259,7 +259,7 @@ class RedirectListenerTest extends TestCase
     public function testReaderSubjectKey()
     {
         $listener = $this
-            ->getMockBuilder('\Crud\Listener\RedirectListener')
+            ->getMockBuilder(\Crud\Listener\RedirectListener::class)
             ->setMethods(null)
             ->disableoriginalConstructor()
             ->getMock();
@@ -286,13 +286,13 @@ class RedirectListenerTest extends TestCase
     public function testRedirectWithNoConfig()
     {
         $action = $this
-            ->getMockBuilder('\Crud\Action\BaseAction')
+            ->getMockBuilder(\Crud\Action\BaseAction::class)
             ->setMethods(null)
             ->disableoriginalConstructor()
             ->getMock();
 
         $listener = $this
-            ->getMockBuilder('\Crud\Listener\RedirectListener')
+            ->getMockBuilder(\Crud\Listener\RedirectListener::class)
             ->setMethods(['_action', '_getKey'])
             ->disableoriginalConstructor()
             ->getMock();
@@ -318,7 +318,7 @@ class RedirectListenerTest extends TestCase
     public function testRedirectWithConfigButNoValidKey()
     {
         $action = $this
-            ->getMockBuilder('\Crud\Action\BaseAction')
+            ->getMockBuilder(\Crud\Action\BaseAction::class)
             ->setMethods(null)
             ->disableoriginalConstructor()
             ->getMock();
@@ -328,7 +328,7 @@ class RedirectListenerTest extends TestCase
         $subject = new \Crud\Event\Subject();
 
         $listener = $this
-            ->getMockBuilder('\Crud\Listener\RedirectListener')
+            ->getMockBuilder(\Crud\Listener\RedirectListener::class)
             ->setMethods(['_action', '_getKey', '_getUrl'])
             ->disableoriginalConstructor()
             ->getMock();
@@ -357,7 +357,7 @@ class RedirectListenerTest extends TestCase
     public function testRedirectWithConfigAndValidKey()
     {
         $action = $this
-            ->getMockBuilder('\Crud\Action\BaseAction')
+            ->getMockBuilder(\Crud\Action\BaseAction::class)
             ->setMethods(null)
             ->disableoriginalConstructor()
             ->getMock();
@@ -371,7 +371,7 @@ class RedirectListenerTest extends TestCase
         $subject = new \Crud\Event\Subject();
 
         $listener = $this
-            ->getMockBuilder('\Crud\Listener\RedirectListener')
+            ->getMockBuilder(\Crud\Listener\RedirectListener::class)
             ->setMethods(['_action', '_getKey', '_getUrl'])
             ->disableoriginalConstructor()
             ->getMock();
@@ -455,7 +455,7 @@ class RedirectListenerTest extends TestCase
     public function testGetUrl(\Crud\Event\Subject $subject, $url, $expected)
     {
         $listener = $this
-            ->getMockBuilder('\Crud\Listener\RedirectListener')
+            ->getMockBuilder(\Crud\Listener\RedirectListener::class)
             ->setMethods(['_request'])
             ->disableoriginalConstructor()
             ->getMock();

--- a/tests/TestCase/Listener/RelatedModelsListenerTest.php
+++ b/tests/TestCase/Listener/RelatedModelsListenerTest.php
@@ -26,7 +26,7 @@ class RelatedModelsListenerTest extends TestCase
     public function testModels()
     {
         $listener = $this
-            ->getMockBuilder('\Crud\Listener\RelatedModelsListener')
+            ->getMockBuilder(\Crud\Listener\RelatedModelsListener::class)
             ->disableOriginalConstructor()
             ->setMethods(['relatedModels'])
             ->getMock();
@@ -52,7 +52,7 @@ class RelatedModelsListenerTest extends TestCase
     public function testModelsEmpty()
     {
         $listener = $this
-            ->getMockBuilder('\Crud\Listener\RelatedModelsListener')
+            ->getMockBuilder(\Crud\Listener\RelatedModelsListener::class)
             ->disableOriginalConstructor()
             ->setMethods(['relatedModels'])
             ->getMock();
@@ -78,7 +78,7 @@ class RelatedModelsListenerTest extends TestCase
     public function testModelsString()
     {
         $listener = $this
-            ->getMockBuilder('\Crud\Listener\RelatedModelsListener')
+            ->getMockBuilder(\Crud\Listener\RelatedModelsListener::class)
             ->disableOriginalConstructor()
             ->setMethods(['relatedModels', 'getAssociatedByName'])
             ->getMock();
@@ -105,7 +105,7 @@ class RelatedModelsListenerTest extends TestCase
     public function testModelsTrue()
     {
         $listener = $this
-            ->getMockBuilder('\Crud\Listener\RelatedModelsListener')
+            ->getMockBuilder(\Crud\Listener\RelatedModelsListener::class)
             ->disableOriginalConstructor()
             ->setMethods(['relatedModels', 'getAssociatedByType'])
             ->getMock();
@@ -132,22 +132,22 @@ class RelatedModelsListenerTest extends TestCase
     public function testGetAssociatedByTypeReturnValue()
     {
         $listener = $this
-            ->getMockBuilder('\Crud\Listener\RelatedModelsListener')
+            ->getMockBuilder(\Crud\Listener\RelatedModelsListener::class)
             ->disableOriginalConstructor()
             ->setMethods(['relatedModels', '_table'])
             ->getMock();
         $table = $this
-            ->getMockBuilder('\Cake\ORM\Table')
+            ->getMockBuilder(\Cake\ORM\Table::class)
             ->disableOriginalConstructor()
             ->setMethods(['associations'])
             ->getMock();
         $associationCollection = $this
-            ->getMockBuilder('\Cake\ORM\AssociationCollection')
+            ->getMockBuilder(\Cake\ORM\AssociationCollection::class)
             ->disableOriginalConstructor()
             ->setMethods(['get', 'keys'])
             ->getMock();
         $association = $this
-            ->getMockBuilder('\Cake\ORM\Association')
+            ->getMockBuilder(\Cake\ORM\Association::class)
             ->disableOriginalConstructor()
             ->setMethods(['type', 'getName', 'eagerLoader', 'cascadeDelete', 'isOwningSide', 'saveAssociated'])
             ->getMock();
@@ -195,22 +195,22 @@ class RelatedModelsListenerTest extends TestCase
     public function testGetAssociatedByNameReturnValue()
     {
         $listener = $this
-            ->getMockBuilder('\Crud\Listener\RelatedModelsListener')
+            ->getMockBuilder(\Crud\Listener\RelatedModelsListener::class)
             ->disableOriginalConstructor()
             ->setMethods(['relatedModels', '_table'])
             ->getMock();
         $table = $this
-            ->getMockBuilder('\Cake\ORM\Table')
+            ->getMockBuilder(\Cake\ORM\Table::class)
             ->disableOriginalConstructor()
             ->setMethods(['associations'])
             ->getMock();
         $associationCollection = $this
-            ->getMockBuilder('\Cake\ORM\AssociationCollection')
+            ->getMockBuilder(\Cake\ORM\AssociationCollection::class)
             ->disableOriginalConstructor()
             ->setMethods(['get'])
             ->getMock();
         $association = $this
-            ->getMockBuilder('\Cake\ORM\Association')
+            ->getMockBuilder(\Cake\ORM\Association::class)
             ->disableOriginalConstructor()
             ->setMethods(['type', 'getName', 'eagerLoader', 'cascadeDelete', 'isOwningSide', 'saveAssociated'])
             ->getMock();
@@ -251,7 +251,7 @@ class RelatedModelsListenerTest extends TestCase
         $model->addBehavior('Tree');
 
         $association = $this
-            ->getMockBuilder('\Cake\ORM\Association\BelongsTo')
+            ->getMockBuilder(\Cake\ORM\Association\BelongsTo::class)
             ->disableOriginalConstructor()
             ->setMethods(['getTarget'])
             ->getMock();
@@ -262,7 +262,7 @@ class RelatedModelsListenerTest extends TestCase
             ->will($this->returnValue($model));
 
         $listener = $this
-            ->getMockBuilder('\Crud\Listener\RelatedModelsListener')
+            ->getMockBuilder(\Crud\Listener\RelatedModelsListener::class)
             ->disableOriginalConstructor()
             ->setMethods(['publishRelatedModels'])
             ->getMock();
@@ -279,12 +279,12 @@ class RelatedModelsListenerTest extends TestCase
     public function testbeforePaginate()
     {
         $listener = $this
-            ->getMockBuilder('\Crud\Listener\RelatedModelsListener')
+            ->getMockBuilder(\Crud\Listener\RelatedModelsListener::class)
             ->disableOriginalConstructor()
             ->setMethods(['models'])
             ->getMock();
         $table = $this
-            ->getMockBuilder('\Cake\ORM\Table')
+            ->getMockBuilder(\Cake\ORM\Table::class)
             ->disableOriginalConstructor()
             ->setMethods(['associations', 'findAssociation', 'association', 'getSchema'])
             ->getMock();
@@ -299,7 +299,7 @@ class RelatedModelsListenerTest extends TestCase
             ->method('models')
             ->will($this->returnValue(['Users' => 'manyToOne']));
 
-        $db = $this->getMockBuilder('\Cake\Database\Connection')
+        $db = $this->getMockBuilder(\Cake\Database\Connection::class)
             ->disableOriginalConstructor()
             ->getMock();
 

--- a/tests/TestCase/Listener/RelatedModelsListenerTest.php
+++ b/tests/TestCase/Listener/RelatedModelsListenerTest.php
@@ -3,11 +3,17 @@ declare(strict_types=1);
 
 namespace Crud\Test\TestCase\Listener;
 
+use Cake\Database\Connection;
 use Cake\Database\Schema\TableSchema;
 use Cake\Event\Event;
+use Cake\ORM\Association;
+use Cake\ORM\Association\BelongsTo;
+use Cake\ORM\AssociationCollection;
 use Cake\ORM\Query;
+use Cake\ORM\Table;
 use Cake\ORM\TableRegistry;
 use Crud\Event\Subject;
+use Crud\Listener\RelatedModelsListener;
 use Crud\TestSuite\TestCase;
 
 /**
@@ -26,7 +32,7 @@ class RelatedModelsListenerTest extends TestCase
     public function testModels()
     {
         $listener = $this
-            ->getMockBuilder(\Crud\Listener\RelatedModelsListener::class)
+            ->getMockBuilder(RelatedModelsListener::class)
             ->disableOriginalConstructor()
             ->setMethods(['relatedModels'])
             ->getMock();
@@ -52,7 +58,7 @@ class RelatedModelsListenerTest extends TestCase
     public function testModelsEmpty()
     {
         $listener = $this
-            ->getMockBuilder(\Crud\Listener\RelatedModelsListener::class)
+            ->getMockBuilder(RelatedModelsListener::class)
             ->disableOriginalConstructor()
             ->setMethods(['relatedModels'])
             ->getMock();
@@ -78,7 +84,7 @@ class RelatedModelsListenerTest extends TestCase
     public function testModelsString()
     {
         $listener = $this
-            ->getMockBuilder(\Crud\Listener\RelatedModelsListener::class)
+            ->getMockBuilder(RelatedModelsListener::class)
             ->disableOriginalConstructor()
             ->setMethods(['relatedModels', 'getAssociatedByName'])
             ->getMock();
@@ -105,7 +111,7 @@ class RelatedModelsListenerTest extends TestCase
     public function testModelsTrue()
     {
         $listener = $this
-            ->getMockBuilder(\Crud\Listener\RelatedModelsListener::class)
+            ->getMockBuilder(RelatedModelsListener::class)
             ->disableOriginalConstructor()
             ->setMethods(['relatedModels', 'getAssociatedByType'])
             ->getMock();
@@ -132,22 +138,22 @@ class RelatedModelsListenerTest extends TestCase
     public function testGetAssociatedByTypeReturnValue()
     {
         $listener = $this
-            ->getMockBuilder(\Crud\Listener\RelatedModelsListener::class)
+            ->getMockBuilder(RelatedModelsListener::class)
             ->disableOriginalConstructor()
             ->setMethods(['relatedModels', '_table'])
             ->getMock();
         $table = $this
-            ->getMockBuilder(\Cake\ORM\Table::class)
+            ->getMockBuilder(Table::class)
             ->disableOriginalConstructor()
             ->setMethods(['associations'])
             ->getMock();
         $associationCollection = $this
-            ->getMockBuilder(\Cake\ORM\AssociationCollection::class)
+            ->getMockBuilder(AssociationCollection::class)
             ->disableOriginalConstructor()
             ->setMethods(['get', 'keys'])
             ->getMock();
         $association = $this
-            ->getMockBuilder(\Cake\ORM\Association::class)
+            ->getMockBuilder(Association::class)
             ->disableOriginalConstructor()
             ->setMethods(['type', 'getName', 'eagerLoader', 'cascadeDelete', 'isOwningSide', 'saveAssociated'])
             ->getMock();
@@ -195,22 +201,22 @@ class RelatedModelsListenerTest extends TestCase
     public function testGetAssociatedByNameReturnValue()
     {
         $listener = $this
-            ->getMockBuilder(\Crud\Listener\RelatedModelsListener::class)
+            ->getMockBuilder(RelatedModelsListener::class)
             ->disableOriginalConstructor()
             ->setMethods(['relatedModels', '_table'])
             ->getMock();
         $table = $this
-            ->getMockBuilder(\Cake\ORM\Table::class)
+            ->getMockBuilder(Table::class)
             ->disableOriginalConstructor()
             ->setMethods(['associations'])
             ->getMock();
         $associationCollection = $this
-            ->getMockBuilder(\Cake\ORM\AssociationCollection::class)
+            ->getMockBuilder(AssociationCollection::class)
             ->disableOriginalConstructor()
             ->setMethods(['get'])
             ->getMock();
         $association = $this
-            ->getMockBuilder(\Cake\ORM\Association::class)
+            ->getMockBuilder(Association::class)
             ->disableOriginalConstructor()
             ->setMethods(['type', 'getName', 'eagerLoader', 'cascadeDelete', 'isOwningSide', 'saveAssociated'])
             ->getMock();
@@ -251,7 +257,7 @@ class RelatedModelsListenerTest extends TestCase
         $model->addBehavior('Tree');
 
         $association = $this
-            ->getMockBuilder(\Cake\ORM\Association\BelongsTo::class)
+            ->getMockBuilder(BelongsTo::class)
             ->disableOriginalConstructor()
             ->setMethods(['getTarget'])
             ->getMock();
@@ -262,7 +268,7 @@ class RelatedModelsListenerTest extends TestCase
             ->will($this->returnValue($model));
 
         $listener = $this
-            ->getMockBuilder(\Crud\Listener\RelatedModelsListener::class)
+            ->getMockBuilder(RelatedModelsListener::class)
             ->disableOriginalConstructor()
             ->setMethods(['publishRelatedModels'])
             ->getMock();
@@ -279,12 +285,12 @@ class RelatedModelsListenerTest extends TestCase
     public function testbeforePaginate()
     {
         $listener = $this
-            ->getMockBuilder(\Crud\Listener\RelatedModelsListener::class)
+            ->getMockBuilder(RelatedModelsListener::class)
             ->disableOriginalConstructor()
             ->setMethods(['models'])
             ->getMock();
         $table = $this
-            ->getMockBuilder(\Cake\ORM\Table::class)
+            ->getMockBuilder(Table::class)
             ->disableOriginalConstructor()
             ->setMethods(['associations', 'findAssociation', 'association', 'getSchema'])
             ->getMock();
@@ -299,7 +305,7 @@ class RelatedModelsListenerTest extends TestCase
             ->method('models')
             ->will($this->returnValue(['Users' => 'manyToOne']));
 
-        $db = $this->getMockBuilder(\Cake\Database\Connection::class)
+        $db = $this->getMockBuilder(Connection::class)
             ->disableOriginalConstructor()
             ->getMock();
 

--- a/tests/TestCase/Listener/SearchListenerTest.php
+++ b/tests/TestCase/Listener/SearchListenerTest.php
@@ -35,7 +35,7 @@ class SearchListenerTest extends TestCase
     public function testImplementedEvents()
     {
         $listener = $this
-            ->getMockBuilder('\Crud\Listener\SearchListener')
+            ->getMockBuilder(\Crud\Listener\SearchListener::class)
             ->setMethods(null)
             ->disableoriginalConstructor()
             ->getMock();
@@ -62,14 +62,14 @@ class SearchListenerTest extends TestCase
         $eventManager = new EventManager();
         $controller = new Controller($request, $response, 'Search', $eventManager);
 
-        $behaviorRegistryMock = $this->getMockBuilder('\Cake\ORM\BehaviorRegistry')
+        $behaviorRegistryMock = $this->getMockBuilder(\Cake\ORM\BehaviorRegistry::class)
             ->setMockClassName('BehaviorRegistry')
             ->getMock();
         $behaviorRegistryMock->expects($this->once())
             ->method('has')
             ->will($this->returnValue(false));
 
-        $tableMock = $this->getMockBuilder('\Cake\ORM\Table')
+        $tableMock = $this->getMockBuilder(\Cake\ORM\Table::class)
             ->setMockClassName('SearchTables')
             ->setMethods(['behaviors', 'filterParams'])
             ->getMock();
@@ -79,7 +79,7 @@ class SearchListenerTest extends TestCase
 
         TableRegistry::set('Search', $tableMock);
 
-        $queryMock = $this->getMockBuilder('\Cake\ORM\Query')
+        $queryMock = $this->getMockBuilder(\Cake\ORM\Query::class)
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -117,7 +117,7 @@ class SearchListenerTest extends TestCase
         $eventManager = new EventManager();
         $controller = new Controller($request, $response, 'Search', $eventManager);
 
-        $behaviorRegistryMock = $this->getMockBuilder('\Cake\ORM\BehaviorRegistry')
+        $behaviorRegistryMock = $this->getMockBuilder(\Cake\ORM\BehaviorRegistry::class)
             ->setMockClassName('BehaviorRegistry')
             ->setMethods(['has'])
             ->getMock();
@@ -125,7 +125,7 @@ class SearchListenerTest extends TestCase
             ->method('has')
             ->will($this->returnValue(true));
 
-        $tableMock = $this->getMockBuilder('\Cake\ORM\Table')
+        $tableMock = $this->getMockBuilder(\Cake\ORM\Table::class)
             ->setMockClassName('SearchTables')
             ->setMethods(['behaviors'])
             ->getMock();
@@ -135,7 +135,7 @@ class SearchListenerTest extends TestCase
 
         TableRegistry::set('Search', $tableMock);
 
-        $queryMock = $this->getMockBuilder('\Cake\ORM\Query')
+        $queryMock = $this->getMockBuilder(\Cake\ORM\Query::class)
             ->disableOriginalConstructor()
             ->getMock();
         $queryMock->expects($this->once())
@@ -187,7 +187,7 @@ class SearchListenerTest extends TestCase
         $controller->modelFactory('Endpoint', ['Muffin\Webservice\Model\EndpointRegistry', 'get']);
         $controller->setModelType('Endpoint');
 
-        $queryMock = $this->getMockBuilder('\Muffin\Webservice\Query')
+        $queryMock = $this->getMockBuilder(\Muffin\Webservice\Query::class)
             ->disableOriginalConstructor()
             ->getMock();
         $queryMock->expects($this->once())

--- a/tests/TestCase/Listener/SearchListenerTest.php
+++ b/tests/TestCase/Listener/SearchListenerTest.php
@@ -8,11 +8,15 @@ use Cake\Event\Event;
 use Cake\Event\EventManager;
 use Cake\Http\Response;
 use Cake\Http\ServerRequest;
+use Cake\ORM\BehaviorRegistry;
+use Cake\ORM\Table;
 use Cake\ORM\TableRegistry;
 use Crud\Event\Subject;
 use Crud\Listener\SearchListener;
 use Crud\TestSuite\TestCase;
 use Muffin\Webservice\Model\EndpointRegistry;
+use Muffin\Webservice\Query;
+use RuntimeException;
 
 /**
  * Licensed under The MIT License
@@ -35,7 +39,7 @@ class SearchListenerTest extends TestCase
     public function testImplementedEvents()
     {
         $listener = $this
-            ->getMockBuilder(\Crud\Listener\SearchListener::class)
+            ->getMockBuilder(SearchListener::class)
             ->setMethods(null)
             ->disableoriginalConstructor()
             ->getMock();
@@ -55,21 +59,21 @@ class SearchListenerTest extends TestCase
      */
     public function testInjectSearchException()
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
 
         $request = new ServerRequest();
         $response = new Response();
         $eventManager = new EventManager();
         $controller = new Controller($request, $response, 'Search', $eventManager);
 
-        $behaviorRegistryMock = $this->getMockBuilder(\Cake\ORM\BehaviorRegistry::class)
+        $behaviorRegistryMock = $this->getMockBuilder(BehaviorRegistry::class)
             ->setMockClassName('BehaviorRegistry')
             ->getMock();
         $behaviorRegistryMock->expects($this->once())
             ->method('has')
             ->will($this->returnValue(false));
 
-        $tableMock = $this->getMockBuilder(\Cake\ORM\Table::class)
+        $tableMock = $this->getMockBuilder(Table::class)
             ->setMockClassName('SearchTables')
             ->setMethods(['behaviors', 'filterParams'])
             ->getMock();
@@ -117,7 +121,7 @@ class SearchListenerTest extends TestCase
         $eventManager = new EventManager();
         $controller = new Controller($request, $response, 'Search', $eventManager);
 
-        $behaviorRegistryMock = $this->getMockBuilder(\Cake\ORM\BehaviorRegistry::class)
+        $behaviorRegistryMock = $this->getMockBuilder(BehaviorRegistry::class)
             ->setMockClassName('BehaviorRegistry')
             ->setMethods(['has'])
             ->getMock();
@@ -125,7 +129,7 @@ class SearchListenerTest extends TestCase
             ->method('has')
             ->will($this->returnValue(true));
 
-        $tableMock = $this->getMockBuilder(\Cake\ORM\Table::class)
+        $tableMock = $this->getMockBuilder(Table::class)
             ->setMockClassName('SearchTables')
             ->setMethods(['behaviors'])
             ->getMock();
@@ -187,7 +191,7 @@ class SearchListenerTest extends TestCase
         $controller->modelFactory('Endpoint', ['Muffin\Webservice\Model\EndpointRegistry', 'get']);
         $controller->setModelType('Endpoint');
 
-        $queryMock = $this->getMockBuilder(\Muffin\Webservice\Query::class)
+        $queryMock = $this->getMockBuilder(Query::class)
             ->disableOriginalConstructor()
             ->getMock();
         $queryMock->expects($this->once())

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,6 +1,8 @@
 <?php
 
 use Cake\Core\Plugin;
+use Cake\Filesystem\Folder;
+
 // @codingStandardsIgnoreFile
 
 $findRoot = function () {
@@ -47,7 +49,7 @@ Cake\Core\Configure::write('App', [
 ]);
 Cake\Core\Configure::write('debug', true);
 
-$TMP = new \Cake\Filesystem\Folder(TMP);
+$TMP = new Folder(TMP);
 $TMP->create(TMP . 'cache/models', 0777);
 $TMP->create(TMP . 'cache/persistent', 0777);
 $TMP->create(TMP . 'cache/views', 0777);

--- a/tests/test_app/src/Controller/Component/TestCrudComponent.php
+++ b/tests/test_app/src/Controller/Component/TestCrudComponent.php
@@ -3,12 +3,14 @@ declare(strict_types=1);
 
 namespace Crud\Test\App\Controller\Component;
 
+use Crud\Controller\Component\CrudComponent;
+
 /**
  * TestCrudComponent
  *
  * Expose protected methods so we can test them in isolation
  */
-class TestCrudComponent extends \Crud\Controller\Component\CrudComponent
+class TestCrudComponent extends CrudComponent
 {
     /**
      * test visibility wrapper - access protected _modelName property

--- a/tests/test_app/src/Controller/CrudExamplesController.php
+++ b/tests/test_app/src/Controller/CrudExamplesController.php
@@ -3,9 +3,10 @@ declare(strict_types=1);
 
 namespace Crud\Test\App\Controller;
 
+use Cake\Controller\Controller;
 use Crud\Controller\ControllerTrait;
 
-class CrudExamplesController extends \Cake\Controller\Controller
+class CrudExamplesController extends Controller
 {
     use ControllerTrait;
 

--- a/tests/test_app/src/Event/TestCrudEventManager.php
+++ b/tests/test_app/src/Event/TestCrudEventManager.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Crud\Test\App\Event;
 
 use Cake\Event\EventInterface;
+use Cake\Event\EventManager;
 
 /**
  * TestCrudEventManager
@@ -12,7 +13,7 @@ use Cake\Event\EventInterface;
  * As such, it becomes a global listener and is used to keep a log of
  * all events fired during the test
  */
-class TestCrudEventManager extends \Cake\Event\EventManager
+class TestCrudEventManager extends EventManager
 {
     protected $_log = [];
 

--- a/tests/test_app/src/Listener/TestListener.php
+++ b/tests/test_app/src/Listener/TestListener.php
@@ -3,7 +3,9 @@ declare(strict_types=1);
 
 namespace Crud\Test\App\Listener;
 
-class TestListener extends \Crud\Listener\BaseListener
+use Crud\Listener\BaseListener;
+
+class TestListener extends BaseListener
 {
     public $callCount = 0;
 

--- a/tests/test_app/src/Model/Entity/Blog.php
+++ b/tests/test_app/src/Model/Entity/Blog.php
@@ -3,6 +3,8 @@ declare(strict_types=1);
 
 namespace Crud\Test\App\Model\Entity;
 
-class Blog extends \Cake\ORM\Entity
+use Cake\ORM\Entity;
+
+class Blog extends Entity
 {
 }

--- a/tests/test_app/src/Model/Entity/User.php
+++ b/tests/test_app/src/Model/Entity/User.php
@@ -3,6 +3,8 @@ declare(strict_types=1);
 
 namespace Crud\Test\App\Model\Entity;
 
-class User extends \Cake\ORM\Entity
+use Cake\ORM\Entity;
+
+class User extends Entity
 {
 }

--- a/tests/test_app/src/Model/Table/BlogsTable.php
+++ b/tests/test_app/src/Model/Table/BlogsTable.php
@@ -4,8 +4,9 @@ declare(strict_types=1);
 namespace Crud\Test\App\Model\Table;
 
 use Cake\ORM\Query;
+use Cake\ORM\Table;
 
-class BlogsTable extends \Cake\ORM\Table
+class BlogsTable extends Table
 {
     public $customOptions;
 

--- a/tests/test_app/src/Model/Table/CrudExamplesTable.php
+++ b/tests/test_app/src/Model/Table/CrudExamplesTable.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Crud\Test\App\Model\Table;
 
 use Cake\ORM\Query;
+use Cake\ORM\Table;
 
 /**
  * Crud Example Model
@@ -11,7 +12,7 @@ use Cake\ORM\Query;
  * Licensed under The MIT License
  * For full copyright and license information, please see the LICENSE.txt
  */
-class CrudExamplesTable extends \Cake\ORM\Table
+class CrudExamplesTable extends Table
 {
     public $alias = 'CrudExamples';
 

--- a/tests/test_app/src/Model/Table/UsersTable.php
+++ b/tests/test_app/src/Model/Table/UsersTable.php
@@ -3,6 +3,8 @@ declare(strict_types=1);
 
 namespace Crud\Test\App\Model\Table;
 
-class UsersTable extends \Cake\ORM\Table
+use Cake\ORM\Table;
+
+class UsersTable extends Table
 {
 }

--- a/tests/test_app/templates/Blogs/view.php
+++ b/tests/test_app/templates/Blogs/view.php
@@ -1,6 +1,9 @@
 <?php
+
+use Cake\Utility\Inflector;
+
 foreach (${$viewVar}->toArray() as $k => $v) {
-	echo "<dt>" . \Cake\Utility\Inflector::humanize($k) . "</dt>";
+	echo "<dt>" . Inflector::humanize($k) . "</dt>";
 	echo "<dd>";
 	echo $v;
 	echo "</dd>";


### PR DESCRIPTION
Had a similar issue as #632 where I needed to exclude a connection.

It was with the Muffin/webservices plugin, which expects a PSR logger, but got the cake query logger.

Also fix a minor unrelated style error.