### PR TITLE
Added the SerializeTrait to the DeleteAction

### DIFF
--- a/src/Action/DeleteAction.php
+++ b/src/Action/DeleteAction.php
@@ -4,6 +4,7 @@ namespace Crud\Action;
 use Crud\Event\Subject;
 use Crud\Traits\FindMethodTrait;
 use Crud\Traits\RedirectTrait;
+use Crud\Traits\SerializeTrait;
 
 /**
  * Handles 'Delete' Crud actions
@@ -15,6 +16,7 @@ class DeleteAction extends BaseAction
 {
     use FindMethodTrait;
     use RedirectTrait;
+    use SerializeTrait;
 
     /**
      * Default settings for 'add' actions


### PR DESCRIPTION
Hello,

While upgrading my project to CakePHP 4, I discovered the DeleteAction does not implement the SerializeTrait, meaning you can't call `$this->Crud->action()->serialize(['my', 'keys'])` or anything like it. The documentation states you should be able to, so I figured it was just missing by accident and not by design, hence the PR.