### PR TITLE
Fixed passing of passed args to CrudComponent::execute().

### DIFF
--- a/src/Controller/ControllerTrait.php
+++ b/src/Controller/ControllerTrait.php
@@ -66,7 +66,7 @@ trait ControllerTrait
         if ($this->mappedComponent) {
             $this->response = $this->mappedComponent->execute(
                 $this->request->getParam('action'),
-                $args
+                array_values($this->getRequest()->getParam('pass'))
             );
 
             return;


### PR DESCRIPTION
Controller action invocation has changed in CakePHP 4.2.
The ControllerFactory now reflects the action method for arguments injections.
This results in incorrect args to be passed as the factory generates args based on
 CrudComponent::execute() reflection while we need the passed args from request.