### PR TITLE
Overwrite isAction

### DIFF
--- a/src/Controller/ControllerTrait.php
+++ b/src/Controller/ControllerTrait.php
@@ -52,6 +52,27 @@ trait ControllerTrait
     }
 
     /**
+     * Return true for a mapped action so that AuthComponent doesn't skip
+     * authentication / authorization for that action.
+     *
+     * @param string $action Action name
+     * @return bool True is action is mapped and enabled.
+     */
+    public function isAction(string $action): bool
+    {
+        $isAction = parent::isAction($action);
+        if ($isAction) {
+            return true;
+        }
+
+        if ($this->_isActionMapped()) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
      * Dispatches the controller action.
      *
      * If a controller method with required name does not exist we attempt to execute Crud action.


### PR DESCRIPTION
In https://github.com/FriendsOfCake/crud/pull/645 the isAction overwrite was removed.
If I use the AuthComponent in combination with the CrudComponent the authentication is not triggered because isAction is false.

Is there a different way to make this work or is the AuthComponent not longer supported in combination with CrudComponent?