### PR TITLE
Simplify Crud action execution.

### DIFF
--- a/src/Controller/Component/CrudComponent.php
+++ b/src/Controller/Component/CrudComponent.php
@@ -430,8 +430,7 @@ class CrudComponent extends Component
         }
 
         $action = Inflector::variable($action);
-        $test = $this->getConfig('actions.' . $action);
-        if (empty($test)) {
+        if (!$this->getConfig('actions.' . $action)) {
             return false;
         }
 

--- a/src/Controller/ControllerTrait.php
+++ b/src/Controller/ControllerTrait.php
@@ -3,7 +3,6 @@ declare(strict_types=1);
 
 namespace Crud\Controller;
 
-use Cake\Controller\Component;
 use Cake\Controller\Exception\MissingActionException;
 use Closure;
 
@@ -13,30 +12,24 @@ use Closure;
  *
  * Licensed under The MIT License
  * For full copyright and license information, please see the LICENSE.txt
+ *
+ * @property \Crud\Controller\Component\CrudComponent $Crud
  */
 trait ControllerTrait
 {
-    /**
-     * List of components that are capable of dispatching an action that is
-     * not already implemented
-     *
-     * @var array
-     */
-    protected array $dispatchComponents = ['Crud' => true];
-
-    /**
-     * Reference to component which should handle the mapped action.
-     *
-     * @var \Controller\Component\Component|null
-     */
-    protected ?Component $mappedComponent;
-
     /**
      * View classes map for content type negotiation.
      *
      * @var array
      */
     protected array $viewClasses = [];
+
+    /**
+     * Whether current action is mapped to a Crud action.
+     *
+     * @var bool
+     */
+    protected bool $mappedAction = false;
 
     /**
      * Get the closure for action to be invoked by ControllerFactory.
@@ -49,9 +42,15 @@ trait ControllerTrait
         try {
             return parent::getAction();
         } catch (MissingActionException $e) {
-            $this->mappedComponent = $this->_isActionMapped();
-            if ($this->mappedComponent) {
-                return $this->mappedComponent->execute(...);
+            $this->mappedAction = $this->Crud->isActionMapped($this->request->getParam('action'));
+
+            if ($this->mappedAction) {
+                return function (): void {
+                    // Dummy closure without arguments.
+                    // This is to prevent the ControllerFactory from trying to type cast the method args.
+                    // invokeAction() below simply ignores the $action argument for Crud mapped actions
+                    // and calls CrudComponent::execute() directly.
+                };
             }
         }
 
@@ -61,17 +60,16 @@ trait ControllerTrait
     /**
      * Dispatches the controller action.
      *
-     * If a controller method with required name does not exist we attempt to execute Crud action.
+     * If the action is mapped to a Crud action we execute it.
      *
      * @param \Closure $action The action closure.
      * @param array $args The arguments to be passed when invoking action.
      * @return void
-     * @throws \UnexpectedValueException If return value of action is not `null` or `ResponseInterface` instance.
      */
     public function invokeAction(Closure $action, array $args): void
     {
-        if ($this->mappedComponent) {
-            $this->response = $this->mappedComponent->execute(
+        if ($this->mappedAction) {
+            $this->response = $this->Crud->execute(
                 $this->request->getParam('action'),
                 array_values($this->getRequest()->getParam('pass'))
             );
@@ -85,7 +83,7 @@ trait ControllerTrait
     /**
      * Set view classes map for content negotiation.
      *
-     * @param array $map
+     * @param array<string, class-string<\Cake\View\View>> $map View class map.
      * @return void
      */
     public function setViewClasses(array $map): void
@@ -102,45 +100,10 @@ trait ControllerTrait
      * This overrides the Controller::viewClasses() of core.
      *
      * @see Cake\Http\ContentTypeNegotiation
-     * @return array<string>
+     * @return array<string, class-string<\Cake\View\View>>
      */
     public function viewClasses(): array
     {
         return $this->viewClasses;
-    }
-
-    /**
-     * Check if an action can be dispatched using CRUD.
-     *
-     * @return \Cake\Controller\Component|null The component instance if action is
-     *  mapped else `null`.
-     */
-    protected function _isActionMapped(): ?Component
-    {
-        foreach ($this->dispatchComponents as $component => $enabled) {
-            if (empty($enabled)) {
-                continue;
-            }
-
-            // Skip if isActionMapped isn't defined in the Component
-            if (!method_exists($this->{$component}, 'isActionMapped')) {
-                continue;
-            }
-
-            // Skip if the action isn't mapped
-            if (!$this->{$component}->isActionMapped()) {
-                continue;
-            }
-
-            // Skip if execute isn't defined in the Component
-            if (!method_exists($this->{$component}, 'execute')) {
-                continue;
-            }
-
-            // Return the component instance.
-            return $this->{$component};
-        }
-
-        return null;
     }
 }

--- a/src/Core/ProxyTrait.php
+++ b/src/Core/ProxyTrait.php
@@ -166,10 +166,6 @@ trait ProxyTrait
     protected function _crud(): CrudComponent
     {
         /** @psalm-suppress UndefinedMagicPropertyFetch */
-        if (!$this->_controller->Crud) {
-            return $this->_controller->components()->load('Crud.Crud');
-        }
-
         return $this->_controller->Crud;
     }
 }


### PR DESCRIPTION
The ControllerTrait::$mappedComponents usage was redundant as ProxyTrait::_crud()
always returned a CrudComponent instance.