### PR TITLE
Make ControllerTrait::isAction() return a dummy closure for mapped actions.

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -10,3 +10,5 @@ parameters:
 		- */src/TestSuite/*
 	universalObjectCratesClasses:
 		- Crud\Event\Subject
+	bootstrapFiles:
+		- vendor/cakephp/cakephp/src/Core/Exception/CakeException.php

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="3.7.2@d9cae720c1af31db9ba27c2bc1fcf9b0dd092fb0">
+<files psalm-version="4.x-dev@">
+  <file src="src/Error/ExceptionRenderer.php">
+    <DeprecatedClass occurrences="2">
+      <code>\Cake\Error\ExceptionRenderer</code>
+      <code>parent::_outputMessage($template)</code>
+    </DeprecatedClass>
+  </file>
+  <file src="src/Listener/ApiListener.php">
+    <DeprecatedClass occurrences="1">
+      <code>$controller-&gt;RequestHandler-&gt;setConfig('viewClassMap', [$type =&gt; $class])</code>
+    </DeprecatedClass>
+  </file>
   <file src="src/Log/QueryLogger.php">
     <InternalClass occurrences="2">
       <code>\Cake\Database\Log\QueryLogger</code>

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0"?>
 <psalm
-    totallyTyped="false"
     resolveFromConfigFile="true"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"

--- a/src/Controller/ControllerTrait.php
+++ b/src/Controller/ControllerTrait.php
@@ -44,7 +44,12 @@ trait ControllerTrait
         } catch (MissingActionException $e) {
             $this->mappedComponent = $this->_isActionMapped();
             if ($this->mappedComponent) {
-                return Closure::fromCallable([$this->mappedComponent, 'execute']);
+                return function () {
+                    // Dummy closure without arguments.
+                    // This is to prevent the ControllerFactory from trying to type cast the method args.
+                    // invokeAction() below simply ignores the $action argument for Crud mapped actions
+                    // and calls CrudComponent::execute() directly.
+                };
             }
         }
 


### PR DESCRIPTION
This is to prevent the ControllerFactory from trying to type cast the method args.
It was just by dumb luck that this didn't cause problems earlier as we only have
actions with a single argument and 1st argument of CrudComponent::execute() is typed
as nullable string. Any custom action with non array 2nd argument would be broken.