### PR TITLE
Use CakeException in CrudException

### DIFF
--- a/src/Error/Exception/CrudException.php
+++ b/src/Error/Exception/CrudException.php
@@ -3,10 +3,10 @@ declare(strict_types=1);
 
 namespace Crud\Error\Exception;
 
-use Cake\Core\Exception\Exception;
+use Cake\Core\Exception\CakeException;
 use Psr\Http\Message\ResponseInterface;
 
-class CrudException extends Exception
+class CrudException extends CakeException
 {
     /**
      * @var \Psr\Http\Message\ResponseInterface|null


### PR DESCRIPTION
Hi all,
I got an error with composer autoload:
error: [Error] Class 'Cake\Core\Exception\Exception' not found in /srv/www/vendor/friendsofcake/crud/src/Error/Exception/CrudException.php on line 9

I fixed the problem by changing the class reference like this. I hope it's the right way to fix this.

Thank you