### PR TITLE
Make redirect variable name configureable

### DIFF
--- a/src/Traits/RedirectTrait.php
+++ b/src/Traits/RedirectTrait.php
@@ -66,18 +66,19 @@ trait RedirectTrait
     protected function _redirectUrl($default = null)
     {
         $request = $this->_request();
+        $redirectVar = $this->getConfig('redirectVar', 'redirect_url');
 
-        if (!empty($request->getData('_redirect_url'))) {
-            return $request->getData('_redirect_url');
+        if (!empty($request->getData("_{$redirectVar}"))) {
+            return $request->getData("_{$redirectVar}");
         }
-        if (!empty($request->getQuery('_redirect_url'))) {
-            return $request->getQuery('_redirect_url');
+        if (!empty($request->getQuery("_{$redirectVar}"))) {
+            return $request->getQuery("_{$redirectVar}");
         }
-        if (!empty($request->getData('redirect_url'))) {
-            return $request->getData('redirect_url');
+        if (!empty($request->getData($redirectVar))) {
+            return $request->getData($redirectVar);
         }
-        if (!empty($request->getQuery('redirect_url'))) {
-            return $request->getQuery('redirect_url');
+        if (!empty($request->getQuery($redirectVar))) {
+            return $request->getQuery($redirectVar);
         }
 
         return $default;


### PR DESCRIPTION
This patch makes redirect variable name configurable via:
```php
$action->setConfig('redirectVar', 'new_value');
```
Default value of 'redirect_url' for backward compatibility