### PR TITLE
Use "keyField" and "valueField" query string vars for Lookup action.

### DIFF
--- a/src/Action/LookupAction.php
+++ b/src/Action/LookupAction.php
@@ -63,12 +63,12 @@ class LookupAction extends BaseAction
         $columns = $this->_table()->getSchema()->columns();
         $config = (array)$this->getConfig('findConfig');
 
-        $idField = $request->getQuery('id');
+        $idField = $request->getQuery('keyField') ?: $request->getQuery('id');
         if (in_array($idField, $columns)) {
             $config['keyField'] = $idField;
         }
 
-        $valueField = $request->getQuery('value');
+        $valueField = $request->getQuery('valueField') ?: $request->getQuery('value');
         if (in_array($valueField, $columns)) {
             $config['valueField'] = $valueField;
         }

--- a/tests/TestCase/Action/LookupActionTest.php
+++ b/tests/TestCase/Action/LookupActionTest.php
@@ -77,6 +77,35 @@ class LookupActionTest extends IntegrationTestCase
     }
 
     /**
+     * Test changing the key field and value field
+     *
+     * @return void
+     */
+    public function testGetWithCustomKeyValueFields()
+    {
+        $this->_eventManager->on(
+            'Controller.initialize',
+            ['priority' => 11],
+            function () {
+                $this->_subscribeToEvents($this->_controller);
+            }
+        );
+
+        $expected = [
+            '1st post' => '1',
+            '2nd post' => '2',
+            '3rd post' => '3',
+        ];
+
+        $this->get('/blogs/lookup.json?keyField=name&valueField=id');
+        $this->assertEvents(['beforeLookup', 'afterLookup', 'beforeRender']);
+        $this->assertNotNull($this->viewVariable('viewVar'));
+        $this->assertNotNull($this->viewVariable('blogs'));
+        $this->assertNotNull($this->viewVariable('success'));
+        $this->assertEquals($expected, $this->viewVariable('blogs')->toArray());
+    }
+
+    /**
      * Tests that the beforeLookup can be used to modify the query
      *
      * @return void


### PR DESCRIPTION
Using the old "id" and "value" names could clash with search field names if using the Search plugin.