### PR TITLE
Ability to replace primaryKey field via config

### DIFF
--- a/src/Traits/FindMethodTrait.php
+++ b/src/Traits/FindMethodTrait.php
@@ -63,11 +63,12 @@ trait FindMethodTrait
 
         [$finder, $options] = $this->_extractFinder();
         $query = $repository->find($finder, ...$options);
+        $primaryKey = $this->getConfig('primaryKey', $repository->getPrimaryKey());
         /**
          * @psalm-suppress PossiblyInvalidArgument
          * @psalm-suppress InvalidArrayOffset
          */
-        $query->where([current($query->aliasField($repository->getPrimaryKey())) => $id]);
+        $query->where([current($query->aliasField($primaryKey)) => $id]);
 
         $subject->set([
             'repository' => $repository,


### PR DESCRIPTION
Example use case:
```php
$this->Crud->action()->setConfig('primaryKey', 'uuid');
```
this change makes `FriendsOfCake/crud` plugin compatible with `dereuromark/cakephp-expose`