### PR TITLE
Use primary key instead of binding key in case of BelongsToMany association

### DIFF
--- a/src/Listener/RelatedModelsListener.php
+++ b/src/Listener/RelatedModelsListener.php
@@ -118,6 +118,12 @@ class RelatedModelsListener extends BaseListener
      */
     protected function _findOptions(Association $association): array
     {
+        if ($association instanceof Association\BelongsToMany) {
+            return [
+                'keyField' => $association->getPrimaryKey(),
+            ];
+        }
+
         return [
             'keyField' => $association->getBindingKey(),
         ];

--- a/src/Listener/RelatedModelsListener.php
+++ b/src/Listener/RelatedModelsListener.php
@@ -6,6 +6,7 @@ namespace Crud\Listener;
 use Cake\Datasource\EntityInterface;
 use Cake\Event\EventInterface;
 use Cake\ORM\Association;
+use Cake\ORM\Association\BelongsToMany;
 use Cake\Utility\Inflector;
 use RuntimeException;
 
@@ -118,7 +119,7 @@ class RelatedModelsListener extends BaseListener
      */
     protected function _findOptions(Association $association): array
     {
-        if ($association instanceof Association\BelongsToMany) {
+        if ($association instanceof BelongsToMany) {
             return [
                 'keyField' => $association->getPrimaryKey(),
             ];

--- a/tests/Fixture/BlogsFixture.php
+++ b/tests/Fixture/BlogsFixture.php
@@ -10,14 +10,15 @@ class BlogsFixture extends TestFixture
         'is_active' => ['type' => 'boolean', 'default' => true, 'null' => false],
         'name' => ['type' => 'string', 'length' => 255, 'null' => false],
         'body' => ['type' => 'text', 'null' => false],
+        'user_id' => ['type' => 'uuid', 'null' => false],
         '_constraints' => ['primary' => ['type' => 'primary', 'columns' => ['id']]],
     ];
 
     public $records = [
-        ['name' => '1st post', 'body' => '1st post body'],
-        ['name' => '2nd post', 'body' => '2nd post body'],
-        ['name' => '3rd post', 'body' => '3rd post body'],
-        ['name' => '4th post', 'body' => '4th post body'],
-        ['name' => '5th post', 'body' => '5th post body'],
+        ['name' => '1st post', 'body' => '1st post body', 'user_id' => '0acad6f2-b47e-4fc1-9086-cbc906dc45fd'],
+        ['name' => '2nd post', 'body' => '2nd post body', 'user_id' => '0acad6f2-b47e-4fc1-9086-cbc906dc45fd'],
+        ['name' => '3rd post', 'body' => '3rd post body', 'user_id' => '0acad6f2-b47e-4fc1-9086-cbc906dc45fd'],
+        ['name' => '4th post', 'body' => '4th post body', 'user_id' => '0acad6f2-b47e-4fc1-9086-cbc906dc45fd'],
+        ['name' => '5th post', 'body' => '5th post body', 'user_id' => '0acad6f2-b47e-4fc1-9086-cbc906dc45fd'],
     ];
 }

--- a/tests/TestCase/Action/AddActionTest.php
+++ b/tests/TestCase/Action/AddActionTest.php
@@ -19,7 +19,7 @@ class AddActionTest extends IntegrationTestCase
      *
      * @var array
      */
-    protected $fixtures = ['plugin.Crud.Blogs'];
+    protected $fixtures = ['plugin.Crud.Blogs', 'plugin.Crud.Users'];
 
     /**
      * Table class to mock on
@@ -111,6 +111,7 @@ class AddActionTest extends IntegrationTestCase
         $this->post('/blogs/add', [
             'name' => 'Hello World',
             'body' => 'Pretty hot body',
+            'user_id' => '0acad6f2-b47e-4fc1-9086-cbc906dc45fd',
         ]);
 
         $this->assertEvents(['beforeSave', 'afterSave', 'setFlash', 'beforeRedirect']);
@@ -157,6 +158,7 @@ class AddActionTest extends IntegrationTestCase
             'name' => 'Hello World',
             'body' => 'Pretty hot body',
             '_add' => 1,
+            'user_id' => '0acad6f2-b47e-4fc1-9086-cbc906dc45fd',
         ]);
 
         $this->assertEvents(['beforeSave', 'afterSave', 'setFlash', 'beforeRedirect']);
@@ -202,6 +204,7 @@ class AddActionTest extends IntegrationTestCase
             'name' => 'Hello World',
             'body' => 'Pretty hot body',
             '_edit' => 1,
+            'user_id' => '0acad6f2-b47e-4fc1-9086-cbc906dc45fd',
         ]);
 
         $this->assertEvents(['beforeSave', 'afterSave', 'setFlash', 'beforeRedirect']);
@@ -404,6 +407,7 @@ class AddActionTest extends IntegrationTestCase
         $this->{$method}('/blogs/add.json', [
             'name' => '6th blog post',
             'body' => 'Amazing blog post',
+            'user_id' => '0acad6f2-b47e-4fc1-9086-cbc906dc45fd',
         ]);
         $this->assertTrue($this->_subject->success);
         $this->assertTrue($this->_subject->created);

--- a/tests/TestCase/Action/DeleteActionTest.php
+++ b/tests/TestCase/Action/DeleteActionTest.php
@@ -17,7 +17,7 @@ class DeleteActionTest extends IntegrationTestCase
      *
      * @var array
      */
-    protected $fixtures = ['plugin.Crud.Blogs'];
+    protected $fixtures = ['plugin.Crud.Blogs', 'plugin.Crud.Users'];
 
     /**
      * Table class to mock on

--- a/tests/TestCase/Action/EditActionTest.php
+++ b/tests/TestCase/Action/EditActionTest.php
@@ -18,7 +18,7 @@ class EditActionTest extends IntegrationTestCase
      *
      * @var array
      */
-    protected $fixtures = ['plugin.Crud.Blogs'];
+    protected $fixtures = ['plugin.Crud.Blogs', 'plugin.Crud.Users'];
 
     /**
      * Table class to mock on

--- a/tests/TestCase/Action/IndexActionTest.php
+++ b/tests/TestCase/Action/IndexActionTest.php
@@ -16,7 +16,7 @@ class IndexActionTest extends IntegrationTestCase
      *
      * @var array
      */
-    protected $fixtures = ['plugin.Crud.Blogs'];
+    protected $fixtures = ['plugin.Crud.Blogs', 'plugin.Crud.Users'];
 
     /**
      * Data provider with all HTTP verbs

--- a/tests/TestCase/Action/LookupActionTest.php
+++ b/tests/TestCase/Action/LookupActionTest.php
@@ -16,7 +16,7 @@ class LookupActionTest extends IntegrationTestCase
      *
      * @var array
      */
-    protected $fixtures = ['plugin.Crud.Blogs'];
+    protected $fixtures = ['plugin.Crud.Blogs', 'plugin.Crud.Users'];
 
     /**
      * Test with no extra options

--- a/tests/TestCase/Action/ViewActionTest.php
+++ b/tests/TestCase/Action/ViewActionTest.php
@@ -16,7 +16,7 @@ class ViewActionTest extends IntegrationTestCase
      *
      * @var array
      */
-    protected $fixtures = ['plugin.Crud.Blogs'];
+    protected $fixtures = ['plugin.Crud.Blogs', 'plugin.Crud.Users'];
 
     /**
      * Data provider with all HTTP verbs

--- a/tests/test_app/src/Model/Table/BlogsTable.php
+++ b/tests/test_app/src/Model/Table/BlogsTable.php
@@ -10,6 +10,13 @@ class BlogsTable extends Table
 {
     public $customOptions;
 
+    public function initialize(array $config): void
+    {
+        parent::initialize($config);
+
+        $this->belongsTo('Users');
+    }
+
     /**
      * findWithCustomOptions
      *


### PR DESCRIPTION
Belongs to many associations have a junction table or through model:

https://book.cakephp.org/4/en/orm/associations.html#belongstomany-associations

A field named like the binding key does not necessarily exist on the target table but only on the junction table.

This change is necessary to prevent the exception introduced by the backport of https://github.com/cakephp/cakephp/pull/17340 to be thrown in such cases.

https://github.com/cakephp/collection/commit/38971692fc079357a93e9b0b26faa5c606073fc2#diff-81970ebd43ab052712b24c8315dfd428fea23a3dcea21316e27d9ce9a2551b83R596-R599

I encountered this after upgrading an application from CakePHP 4.4.x. to 4.5.x.

The reason why this has worked before 4.5 is mentioned at https://github.com/cakephp/cakephp/pull/17340#issuecomment-1898926391.

This change is likely also necessary for the CRUD branch for CakePHP 5.x.