### PR TITLE
Fix query logger

### DIFF
--- a/src/Controller/Component/CrudComponent.php
+++ b/src/Controller/Component/CrudComponent.php
@@ -233,7 +233,7 @@ class CrudComponent extends Component
     {
         $this->_loadListeners();
 
-        $this->_action = $controllerAction ?: $this->_action;
+        $this->_action = $controllerAction ?? $this->_action;
 
         $action = $this->_action;
         if (empty($args)) {
@@ -275,7 +275,7 @@ class CrudComponent extends Component
      */
     public function action(?string $name = null): BaseAction
     {
-        if (empty($name)) {
+        if ($name === null) {
             $name = $this->_action;
         }
 
@@ -425,7 +425,7 @@ class CrudComponent extends Component
      */
     public function isActionMapped(?string $action = null): bool
     {
-        if (empty($action)) {
+        if ($action === null) {
             $action = $this->_action;
         }
 
@@ -448,7 +448,7 @@ class CrudComponent extends Component
     public function on(array|string $events, callable $callback, array $options = []): void
     {
         foreach ((array)$events as $event) {
-            if (!strpos($event, '.')) {
+            if (!str_contains($event, '.')) {
                 $event = $this->_config['eventPrefix'] . '.' . $event;
             }
 

--- a/src/Log/QueryLogger.php
+++ b/src/Log/QueryLogger.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Crud\Log;
 
+use Cake\Database\Log\LoggedQuery;
 use Cake\Database\Log\QueryLogger as CakeQueryLogger;
 use Stringable;
 
@@ -30,7 +31,11 @@ class QueryLogger extends CakeQueryLogger
      */
     public function log($level, string|Stringable $message, array $context = []): void
     {
-        $this->_logs[] = (string)$context['query'];
+        if ($context['query'] instanceof LoggedQuery) {
+            $this->_logs[] = $context['query']->jsonSerialize();
+        } else {
+            $this->_logs[] = (string)$context['query'];
+        }
 
         parent::log($level, $message, $context);
     }

--- a/src/Log/QueryLogger.php
+++ b/src/Log/QueryLogger.php
@@ -32,6 +32,7 @@ class QueryLogger extends CakeQueryLogger
     public function log($level, string|Stringable $message, array $context = []): void
     {
         if ($context['query'] instanceof LoggedQuery) {
+            /** @psalm-suppress InternalMethod **/
             $this->_logs[] = $context['query']->jsonSerialize();
         } else {
             $this->_logs[] = (string)$context['query'];

--- a/src/Log/QueryLogger.php
+++ b/src/Log/QueryLogger.php
@@ -31,12 +31,7 @@ class QueryLogger extends CakeQueryLogger
      */
     public function log($level, string|Stringable $message, array $context = []): void
     {
-        if ($context['query'] instanceof LoggedQuery) {
-            /** @psalm-suppress InternalMethod **/
-            $this->_logs[] = $context['query']->jsonSerialize();
-        } else {
-            $this->_logs[] = (string)$context['query'];
-        }
+        $this->_logs[] = $context['query'];
 
         parent::log($level, $message, $context);
     }

--- a/src/Log/QueryLogger.php
+++ b/src/Log/QueryLogger.php
@@ -3,7 +3,6 @@ declare(strict_types=1);
 
 namespace Crud\Log;
 
-use Cake\Database\Log\LoggedQuery;
 use Cake\Database\Log\QueryLogger as CakeQueryLogger;
 use Stringable;
 


### PR DESCRIPTION
Really simple PR, to restore the original workings of the query logger. In previous versions of crud, the query logger would not only store the query, but also the entire context, like the query execution time and rows affected. Right now, a cast to string means only the query is stored in the query log. This PR attempts to restore the original functionality, by using the jsonSerialize method for instances of LoggedQuery.