### PR TITLE
fix: install older sphinx to support sphinx-rtd-theme

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -12,7 +12,7 @@ pytz==2024.2
 requests==2.32.3
 six==1.16.0
 snowballstemmer==2.2.0
-Sphinx==8.0.2
+Sphinx==7.4.7
 sphinx-rtd-theme==2.0.0
 sphinxcontrib-phpdomain==0.12.0
 urllib3==2.2.3


### PR DESCRIPTION
Sphinx 8 is not yet supported, so we need to downgrade sphinx.